### PR TITLE
set (max)height of elements to current viewport height

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,6 +191,9 @@ spacialistApp.directive('spinner', function() {
 
 spacialistApp.directive('resizeWatcher', function($window) {
     return function(scope, element) {
+        var headerPadding = 20;
+        var bottomPadding = 20;
+
         scope.getViewportDim = function() {
             return {
                 'height': $window.innerHeight,
@@ -205,7 +208,7 @@ spacialistApp.directive('resizeWatcher', function($window) {
 
             var headerHeight = document.getElementById('header-nav').offsetHeight;
             var addonNavHeight = document.getElementById('addon-nav').offsetHeight;
-            var containerHeight = scope.containerHeight = height - headerHeight - 20;
+            var containerHeight = scope.containerHeight = height - headerHeight - headerPadding - bottomPadding;
             var addonContainerHeight = scope.addonContainerHeight = containerHeight - addonNavHeight;
 
             $('#tree-container').css('height', containerHeight);

--- a/app.js
+++ b/app.js
@@ -197,23 +197,28 @@ spacialistApp.directive('resizeWatcher', function($window) {
         scope.getViewportDim = function() {
             return {
                 'height': $window.innerHeight,
-                'width': $window.innerWidth
+                'width': $window.innerWidth,
+                'isSm': window.matchMedia("(max-width: 991px)").matches
             };
         };
         scope.$watch(scope.getViewportDim, function(newValue, oldValue) {
-            console.log(newValue);
+            if(newValue.isSm) {
+                $('#tree-container').css('height', '');
+                $('#attribute-container').css('height', '');
+                $('#addon-container').css('height', '');
+            } else {
+                var height = newValue.height;
+                var width = newValue.width;
 
-            var height = newValue.height;
-            var width = newValue.width;
+                var headerHeight = document.getElementById('header-nav').offsetHeight;
+                var addonNavHeight = document.getElementById('addon-nav').offsetHeight;
+                var containerHeight = scope.containerHeight = height - headerHeight - headerPadding - bottomPadding;
+                var addonContainerHeight = scope.addonContainerHeight = containerHeight - addonNavHeight;
 
-            var headerHeight = document.getElementById('header-nav').offsetHeight;
-            var addonNavHeight = document.getElementById('addon-nav').offsetHeight;
-            var containerHeight = scope.containerHeight = height - headerHeight - headerPadding - bottomPadding;
-            var addonContainerHeight = scope.addonContainerHeight = containerHeight - addonNavHeight;
-
-            $('#tree-container').css('height', containerHeight);
-            $('#attribute-container').css('height', containerHeight);
-            $('#addon-container').css('height', containerHeight);
+                $('#tree-container').css('height', containerHeight);
+                $('#attribute-container').css('height', containerHeight);
+                $('#addon-container').css('height', containerHeight);
+            }
         }, true);
     };
 });

--- a/app.js
+++ b/app.js
@@ -189,6 +189,32 @@ spacialistApp.directive('spinner', function() {
     };
 });
 
+spacialistApp.directive('resizeWatcher', function($window) {
+    return function(scope, element) {
+        scope.getViewportDim = function() {
+            return {
+                'height': $window.innerHeight,
+                'width': $window.innerWidth
+            };
+        };
+        scope.$watch(scope.getViewportDim, function(newValue, oldValue) {
+            console.log(newValue);
+
+            var height = newValue.height;
+            var width = newValue.width;
+
+            var headerHeight = document.getElementById('header-nav').offsetHeight;
+            var addonNavHeight = document.getElementById('addon-nav').offsetHeight;
+            var containerHeight = scope.containerHeight = height - headerHeight - 20;
+            var addonContainerHeight = scope.addonContainerHeight = containerHeight - addonNavHeight;
+
+            $('#tree-container').css('height', containerHeight);
+            $('#attribute-container').css('height', containerHeight);
+            $('#addon-container').css('height', containerHeight);
+        }, true);
+    };
+});
+
 spacialistApp.directive('myDirective', function(httpPostFactory, scopeService) {
     return {
         restrict: 'A',

--- a/css/style.css
+++ b/css/style.css
@@ -416,7 +416,7 @@ p, div {
     font-weight: 500;
 }
 
-#tree-container {
+#tree-container, #attribute-container {
     overflow: auto;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -416,6 +416,10 @@ p, div {
     font-weight: 500;
 }
 
+#tree-container {
+    overflow: auto;
+}
+
 .angular-ui-tree-handle {
     cursor: pointer;
     font-weight: 500;

--- a/includes/new-tree.html
+++ b/includes/new-tree.html
@@ -1,4 +1,4 @@
-<div style="max-height: 500px; overflow: auto;" ui-tree data-nodrop-enabled="true" data-drag-enabled="false" ng-init="onInit()">
+<div ui-tree data-nodrop-enabled="true" data-drag-enabled="false" ng-init="onInit()">
     <ul ui-tree-nodes ng-model="itemList" style="margin-bottom: 8px;">
         <li class="clickable" ng-click="createNewContext()">
             <i class="fa fa-fw"></i><i class="fa fa-fw fa-plus fa-light fa-small"></i>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <title>Spacialist</title>
     </head>
     <body>
-        <nav class="navbar navbar-inverse" role="navigation">
+        <nav id="header-nav" class="navbar navbar-inverse" role="navigation">
             <div class="container-fluid" ng-controller="headerCtrl">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle"

--- a/testing.html
+++ b/testing.html
@@ -1,10 +1,10 @@
-<div ng-controller="mainCtrl">
-    <div class="col-md-2" style="max-height: 500px;">
+<div ng-controller="mainCtrl" resize-watcher>
+    <div class="col-md-2" id="tree-container">
         <h3>Elemente</h3>
         <my-tree on-init="getContextList()" on-click-callback="setCurrentElement(target, elem)" item-list="contextList" element="currentElement" display-attribute="'name'" type-attribute="'typename'" prefix-attribute="'typelabel'" set-context-menu="newElementContextMenu"></my-tree>
         <spinner ng-if="getContextListStarted"></spinner>
     </div>
-    <div class="col-md-5" style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;">
+    <div class="col-md-5" style="border-right: 1px solid #ddd; border-left: 1px solid #ddd;" id="attribute-container">
         <div ng-show="currentElement">
             <h3>{{ currentElement.name }}<span ng-if="currentElement.typeLabel" class="type-desc">{{ currentElement.typeLabel }}</span> <small>Element-Eigenschaften</small></h3>
             <form class="form-horizontal" role="form" ng-if="currentElementFields">
@@ -40,8 +40,8 @@
             </div>
         </div>
     </div>
-    <div class="col-md-5">
-        <ul class="nav nav-tabs">
+    <div class="col-md-5" id="addon-container">
+        <ul class="nav nav-tabs" id="addon-nav">
             <li role="presentation" ng-class="{ active: layerTwo.activeTab == 'map'}" ng-if="moduleExists('mapCtrl')">
                 <a href="" ng-click="setActiveTab('map')"><span class="fa fa-fw fa-map-marker"></span><span class="tab-desc"> Karte</span></a>
             </li>
@@ -57,7 +57,7 @@
         </ul>
         <div ng-if="layerTwo.activeTab == 'map'">
             <div id="map-container" ng-if="sideNav.mapTab && map">
-                <leaflet bounds="mapBounds" layers="map.layers" lf-draw="map.drawOptions" controls="map.controls" markers="markers" event-broadcast="map.events" height="768px" width="100%">
+                <leaflet bounds="mapBounds" layers="map.layers" lf-draw="map.drawOptions" controls="map.controls" markers="markers" event-broadcast="map.events" height="{{addonContainerHeight}}px" width="100%">
                     <layercontrol order="normal" icons="map.layercontrol.icons" auto-hide-opacity="true" show-groups="true" title="" base-title="Base Layers" overlays-title="Overlays"></layercontrol>
                 </leaflet>
             </div>


### PR DESCRIPTION
Height of the container elements now matches the current viewport height. Thus there should be no scrolling in the outer div, but for each container (tree, attributes, map).

Please review @eScienceCenter/spacialists 