### PR TITLE
Fix views

### DIFF
--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -24,7 +24,7 @@ class ContextController extends Controller {
             } else if($attr->datatype == 'string-sc' || $attr->datatype == 'string-mc') {
                 $attr->val = DB::table('th_concept')
                     ->select('id as narrower_id',
-                        DB::table('getConceptLabelsFromUrl')
+                        DB::table('getconceptlabelsfromurl')
                         ->where('concept_url', $attr->thesaurus_val)
                         ->where('short_name', 'de')
                         ->value('label')
@@ -62,7 +62,7 @@ class ContextController extends Controller {
                     'end' => $end,
                     'epoch' => DB::table('th_concept')
                                 ->select('id as narrower_id',
-                                    DB::table('getConceptLabelsFromUrl')
+                                    DB::table('getconceptlabelsfromurl')
                                     ->where('concept_url', $thUri)
                                     ->where('short_name', 'de')
                                     ->value('label')
@@ -79,8 +79,8 @@ class ContextController extends Controller {
         return response()->json(
             DB::table('context_types as c')
                 ->select('c.thesaurus_url as index', 'ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'c.type',
-                    DB::raw("(select label from getConceptLabelsFromUrl where concept_url = c.thesaurus_url and short_name = 'de') as title"),
-                    DB::raw("(select label from getConceptLabelsFromUrl where concept_url = a.thesaurus_url and short_name = 'de') as val")
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = c.thesaurus_url and short_name = 'de') as title"),
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = a.thesaurus_url and short_name = 'de') as val")
                 )
                 ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
                 ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -103,7 +103,7 @@ class ContextController extends Controller {
 	        JOIN    contexts cc
 	        ON      cc.root_context_id = q.id
         )
-        SELECT  q.*, ct.type as typeid, ct.thesaurus_url AS typename, (select label from getConceptLabelsFromUrl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
+        SELECT  q.*, ct.type as typeid, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
         FROM    q
         JOIN context_types AS ct
         ON q.context_type_id = ct.id
@@ -135,8 +135,8 @@ class ContextController extends Controller {
     public function getChoices() {
         $rows = DB::table('context_types as c')
         ->select('ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'a.thesaurus_root_url as root',
-            DB::raw("(select label from getConceptLabelsFromUrl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-            DB::raw("(select label from getConceptLabelsFromUrl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
         )
         ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
         ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -156,13 +156,13 @@ class ContextController extends Controller {
             $row->choices = DB::select("
                 WITH RECURSIVE
                 top AS (
-                    SELECT br.broader_id, br.narrower_id, (select label from getConceptLabelsFromID where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
-                            (select label from getConceptLabelsFromID where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
+                    SELECT br.broader_id, br.narrower_id, (select label from getconceptlabelsfromid where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
+                            (select label from getconceptlabelsfromid where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
                     FROM th_broaders br
                     WHERE broader_id = $rootId
                     UNION
-                    SELECT br.broader_id, br.narrower_id, (select label from getConceptLabelsFromID where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
-                            (select label from getConceptLabelsFromID where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
+                    SELECT br.broader_id, br.narrower_id, (select label from getconceptlabelsfromid where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
+                            (select label from getconceptlabelsfromid where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
                     FROM top t, th_broaders br
                     WHERE t.narrower_id = br.broader_id
                 )
@@ -177,8 +177,8 @@ class ContextController extends Controller {
     public function getAttributes($id) {
         $rows = DB::table('context_types as c')
         ->select('ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'a.thesaurus_root_url as root',
-            DB::raw("(select label from getConceptLabelsFromUrl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-            DB::raw("(select label from getConceptLabelsFromUrl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
         )
         ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
         ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -196,13 +196,13 @@ class ContextController extends Controller {
             $row->choices = DB::select("
                 WITH RECURSIVE
                 top AS (
-                    SELECT br.broader_id, br.narrower_id, (select label from getConceptLabelsFromID where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
-                        (select label from getConceptLabelsFromID where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
+                    SELECT br.broader_id, br.narrower_id, (select label from getconceptlabelsfromid where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
+                        (select label from getconceptlabelsfromid where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
                     FROM th_broaders br
                     WHERE broader_id = $rootId
                     UNION
-                    SELECT br.broader_id, br.narrower_id, (select label from getConceptLabelsFromID where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
-                        (select label from getConceptLabelsFromID where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
+                    SELECT br.broader_id, br.narrower_id, (select label from getconceptlabelsfromid where concept_id = br.broader_id and short_name = 'de' limit 1) as broad,
+                        (select label from getconceptlabelsfromid where concept_id = br.narrower_id and short_name = 'de' limit 1) as narr
                     FROM top t, th_broaders br
                     WHERE t.narrower_id = br.broader_id
                 )
@@ -263,10 +263,10 @@ class ContextController extends Controller {
                 } else if($attr->datatype == 'string-sc' || $attr->datatype == 'string-mc') {
                     $attr->val = DB::table('th_concept')
                         ->select('id as narrower_id',
-                            DB::table('getConceptLabelsFromUrl')
+                            DB::raw("'".DB::table('getconceptlabelsfromurl')
                             ->where('concept_url', $attr->thesaurus_val)
                             ->where('short_name', 'de')
-                            ->value('label')
+                            ->value('label')."' as narr")
                         )
                         ->where('concept_url', '=', $attr->thesaurus_val)
                         ->first();
@@ -281,8 +281,8 @@ class ContextController extends Controller {
         return response()->json(
             DB::table('context_types as c')
                 ->select('c.thesaurus_url as index', 'ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'c.type',
-                    DB::raw("(select label from getConceptLabelsFromUrl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-                    DB::raw("(select label from getConceptLabelsFromUrl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
                 )
                 ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
                 ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -307,7 +307,7 @@ class ContextController extends Controller {
                 JOIN    contexts cc
                 ON      cc.root_context_id = q.id
             )
-            SELECT  q.*, ct.type, ct.thesaurus_url AS typename, (select label from getConceptLabelsFromUrl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
+            SELECT  q.*, ct.type, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
             FROM    q
             JOIN context_types AS ct
             ON q.context_type_id = ct.id

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -24,10 +24,10 @@ class ContextController extends Controller {
             } else if($attr->datatype == 'string-sc' || $attr->datatype == 'string-mc') {
                 $attr->val = DB::table('th_concept')
                     ->select('id as narrower_id',
-                        DB::table('getconceptlabelsfromurl')
+                        DB::raw("'".DB::table('getconceptlabelsfromurl')
                         ->where('concept_url', $attr->thesaurus_val)
                         ->where('short_name', 'de')
-                        ->value('label')
+                        ->value('label')."' as narr")
                     )
                     ->where('concept_url', '=', $attr->thesaurus_val)
                     ->first();
@@ -62,10 +62,10 @@ class ContextController extends Controller {
                     'end' => $end,
                     'epoch' => DB::table('th_concept')
                                 ->select('id as narrower_id',
-                                    DB::table('getconceptlabelsfromurl')
+                                    DB::raw("'".DB::table('getconceptlabelsfromurl')
                                     ->where('concept_url', $thUri)
                                     ->where('short_name', 'de')
-                                    ->value('label')
+                                    ->value('label')."' as narr")
                                 )
                                 ->where('concept_url', '=', $thUri)
                                 ->first()

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -79,8 +79,8 @@ class ContextController extends Controller {
         return response()->json(
             DB::table('context_types as c')
                 ->select('c.thesaurus_url as index', 'ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'c.type',
-                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = c.thesaurus_url and short_name = 'de') as title"),
-                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = a.thesaurus_url and short_name = 'de') as val")
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = c.thesaurus_url and short_name = 'de' limit 1) as title"),
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = a.thesaurus_url and short_name = 'de' limit 1) as val")
                 )
                 ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
                 ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -103,7 +103,7 @@ class ContextController extends Controller {
 	        JOIN    contexts cc
 	        ON      cc.root_context_id = q.id
         )
-        SELECT  q.*, ct.type as typeid, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
+        SELECT  q.*, ct.type as typeid, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de' limit 1) as typelabel
         FROM    q
         JOIN context_types AS ct
         ON q.context_type_id = ct.id
@@ -135,8 +135,8 @@ class ContextController extends Controller {
     public function getChoices() {
         $rows = DB::table('context_types as c')
         ->select('ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'a.thesaurus_root_url as root',
-            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de' limit 1) AS title"),
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de' limit 1) AS val")
         )
         ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
         ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -177,8 +177,8 @@ class ContextController extends Controller {
     public function getAttributes($id) {
         $rows = DB::table('context_types as c')
         ->select('ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'a.thesaurus_root_url as root',
-            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de' limit 1) AS title"),
+            DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de' limit 1) AS val")
         )
         ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
         ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -281,8 +281,8 @@ class ContextController extends Controller {
         return response()->json(
             DB::table('context_types as c')
                 ->select('c.thesaurus_url as index', 'ca.context_type_id as ctid', 'ca.attribute_id as aid', 'a.datatype', 'c.type',
-                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de') AS title"),
-                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de') AS val")
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = C.thesaurus_url and short_name = 'de' limit 1) AS title"),
+                    DB::raw("(select label from getconceptlabelsfromurl where concept_url = A.thesaurus_url and short_name = 'de' limit 1) AS val")
                 )
                 ->leftJoin('context_attributes as ca', 'c.id', '=', 'ca.context_type_id')
                 ->leftJoin('attributes as a', 'ca.attribute_id', '=', 'a.id')
@@ -307,7 +307,7 @@ class ContextController extends Controller {
                 JOIN    contexts cc
                 ON      cc.root_context_id = q.id
             )
-            SELECT  q.*, ct.type, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de') as typelabel
+            SELECT  q.*, ct.type, ct.thesaurus_url AS typename, (select label from getconceptlabelsfromurl where concept_url = ct.thesaurus_url and short_name = 'de' limit 1) as typelabel
             FROM    q
             JOIN context_types AS ct
             ON q.context_type_id = ct.id

--- a/lumen/app/Http/Controllers/SourceController.php
+++ b/lumen/app/Http/Controllers/SourceController.php
@@ -30,7 +30,7 @@ class SourceController extends Controller {
 
     public function getByContext($id) {
         $src = DB::table('sources')
-                ->select('sources.*', DB::raw("(select label from getConceptLabelsFromUrl where concept_url = attributes.thesaurus_url and short_name = 'de') AS attribute_name"))
+                ->select('sources.*', DB::raw("(select label from getconceptlabelsfromurl where concept_url = attributes.thesaurus_url and short_name = 'de') AS attribute_name"))
                 ->where('context_id', '=', $id)
                 ->join('attributes', 'sources.attribute_id', '=', 'attributes.id')
                 ->orderBy('attribute_name', 'asc')

--- a/lumen/app/Http/Controllers/SourceController.php
+++ b/lumen/app/Http/Controllers/SourceController.php
@@ -30,7 +30,7 @@ class SourceController extends Controller {
 
     public function getByContext($id) {
         $src = DB::table('sources')
-                ->select('sources.*', DB::raw("(select label from getconceptlabelsfromurl where concept_url = attributes.thesaurus_url and short_name = 'de') AS attribute_name"))
+                ->select('sources.*', DB::raw("(select label from getconceptlabelsfromurl where concept_url = attributes.thesaurus_url and short_name = 'de' limit 1) AS attribute_name"))
                 ->where('context_id', '=', $id)
                 ->join('attributes', 'sources.attribute_id', '=', 'attributes.id')
                 ->orderBy('attribute_name', 'asc')

--- a/lumen/database/migrations/2017_01_11_141536_create-db-functions.php
+++ b/lumen/database/migrations/2017_01_11_141536_create-db-functions.php
@@ -40,7 +40,7 @@ class CreateDbFunctions extends Migration
      */
     public function down()
     {
-        Schema::getConnection()->statement('DROP VIEW getLabelForTmpId');
-        Schema::getConnection()->statement('DROP VIEW getLabelForId');
+        Schema::getConnection()->statement('DROP VIEW getConceptLabelsFromID');
+        Schema::getConnection()->statement('DROP VIEW getConceptLabelsFromUrl');
     }
 }


### PR DESCRIPTION
Lumen's query Builder seems to be case sensitive, therefore the references to the views got changed to lowercase.
The former used functions resulted in a single entry, while the view queries could result a column of values. Adding `limit 1` to the view queries should resolve this.
Furthermore, the recent name changes made in the migrations were missing in the `down()`-method.
Fixes #54