### PR TITLE
Improve loading time

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -504,8 +504,14 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpPostFactory', 'http
             elem.fields = main.artifactReferences[elem.typename].slice();
         }
         var data = {};
-        data = parseData(elem.data);
-        main.currentElement.data = data;
+        httpGetFactory('api/context/get/data/' + elem.id, function(response) {
+            if(response.error) {
+                modalFactory.errorModal(response.error);
+                return;
+            }
+            data = parseData(response.data);
+            main.currentElement.data = data;
+        });
         main.currentElement.fields = elem.fields;
         main.currentElement.element = {
             id: elem.id,

--- a/includes/new-tree-child.html
+++ b/includes/new-tree-child.html
@@ -12,6 +12,6 @@
     </span>
 </div>
 <ul ui-tree-nodes="" ng-model="parent.children" ng-class="{ hidden: collapsed }">
-    <li ng-repeat="parent in parent.children" ui-tree-node data-collapsed="true" ng-include="'includes/new-tree-child.html'" context-menu="setContextMenu">
+    <li ng-repeat="parent in parent.children" ng-if="!collapsed" ui-tree-node data-collapsed="true" ng-include="'includes/new-tree-child.html'" context-menu="setContextMenu">
     </li>
 </ul>

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -27,6 +27,18 @@ class ContextController extends Controller {
         //
     }
 
+    public function getContextData($id) {
+        $user = \Auth::user();
+        if(!$user->can('view_concept_props')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
+        return response()->json([
+            'data' => $this->getData($id)
+        ]);
+    }
+
     private function getData($id) {
         $data = DB::table('attribute_values as av')->select('av.*', 'a.datatype', 'a.thesaurus_root_url')->join('attributes as a', 'av.attribute_id', '=', 'a.id')->where('context_id', $id)->get();
         foreach($data as &$attr) {
@@ -128,9 +140,6 @@ class ContextController extends Controller {
         ");
         $children = [];
         foreach($rootFields as $key => $field) {
-            if($user->can('view_concept_props')) {
-                $rootFields[$key]->data =  $this->getData($field->id);
-            }
             if(array_key_exists($field->id, $children)) $tmpChildren = $children[$field->id];
             else $tmpChildren = array();
             $rootFields[$key]->children = $tmpChildren;

--- a/lumen/app/Http/routes.php
+++ b/lumen/app/Http/routes.php
@@ -24,6 +24,7 @@ $app->group(['middleware' => ['before' => 'jwt.auth', 'after' => 'jwt.refresh']]
     $app->get('context/artifacts/get', 'ContextController@getArtifacts');
     $app->get('context/get/children/{id}', 'ContextController@getChildren');
     $app->get('context/get', 'ContextController@get');
+    $app->get('context/get/data/{id}', 'ContextController@getContextData');
     $app->get('context/get/geodata', 'ContextController@getGeodata');
     $app->get('context/get/byGeodata/{id}', 'ContextController@getContextByGeodata');
     $app->get('context/link/geodata/{cid}/{gid}', 'ContextController@linkGeodata');


### PR DESCRIPTION
Fix #72 
The time for loading the contexts and for creating the tree should be much faster now. Element data is now retrieved after a click on the element/geodata. Thus we only need 500ms instead of 10s (for the currently biggest project) and changes on one machine should now be visible on other machines without reload. Retrieving the data for only one element instead of all (~600) it is almost instantly.
The code for the tree expansion (if the user clickes on a connected geodata) is now more complex and slower. But again, the loading time (which also freezes the app) is down from ~5s to < 1s.
Please review and comment if we should accept the laggy tree expansion but therefore display the tree almost instantly. @eScienceCenter/spacialists 