### PR TITLE
Unset sources as well

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -483,6 +483,7 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpPostFactory', 'http
         main.currentElement.element = {};
         main.currentElement.data = {};
         main.currentElement.fields = {};
+        main.currentElement.sources = {};
     };
 
     function addContextSource(source) {


### PR DESCRIPTION
In the bibliography tab the source entries from the previous selected element are still visible if the user deselects an element.

Please review @eScienceCenter/spacialists 