### PR TITLE
Create seeds

### DIFF
--- a/lumen/database/factories/ModelFactory.php
+++ b/lumen/database/factories/ModelFactory.php
@@ -21,11 +21,11 @@ use Phaza\LaravelPostgis\Geometries\Polygon;
 /*
 | Factory for the test user
 */
-$factory->defineAs(App\User::class, 'test', function () {
+$factory->defineAs(App\User::class, 'guest', function () {
     return [
-        'name' => "Test User",
-        'email' => "test@user.com",
-        'password' => Hash::make("testpassword"),
+        'name' => "Guest User",
+        'email' => "udontneedtoseehisidentification@rebels.tld",
+        'password' => Hash::make("thesearentthedroidsuarelookingfor"),
     ];
 });
 

--- a/lumen/database/factories/ModelFactory.php
+++ b/lumen/database/factories/ModelFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Hash;
 /*
 |--------------------------------------------------------------------------
 | Model Factories
@@ -11,9 +12,193 @@
 |
 */
 
+
+
+/*
+| Factory for the test user
+*/
+$factory->defineAs(App\User::class, 'test', function () {
+    return [
+        'name' => "Test User",
+        'email' => "test@user.com",
+        'password' => Hash::make("testpassword"),
+    ];
+});
+
+/*
+| Factories for entries with completely random values
+*/
 $factory->define(App\User::class, function (Faker\Generator $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->email,
+        'password' => $faker->password,
+    ];
+});
+
+// TODO: a concept_label should exist for each (concept x language) pair
+$factory->define(App\ThConcept::class, function(Faker\Generator $faker) {
+    return [
+        'concept_url' => $faker->unique()->url,
+        'concept_scheme' => '',
+        'lasteditor' => $faker->name,
+    ];
+});
+
+$factory->define(App\ThBroader::class, function(Faker\Generator $faker) {
+    $broader = App\ThConcept::inRandomOrder()->first();
+    if(!isset($broader)){
+        factory(App\ThConcept::class, 1)->create();
+        $broader = App\ThConcept::inRandomOrder()->first();
+    }
+    $narrower = App\ThConcept::inRandomOrder()->first();
+    if(!isset($narrower)){
+        factory(App\ThConcept::class, 1)->create();
+        $narrower = App\ThConcept::inRandomOrder()->first();
+    }
+    return [
+        'broader_id' => $broader->id,
+        'narrower_id' => $narrower->id,
+    ];
+});
+
+$factory->define(App\ThConceptLabel::class, function(Faker\Generator $faker) {
+    $language = App\ThLanguage::first();
+    if(!isset($language)){
+        $de = new App\ThLanguage;
+        $de->lasteditor     = 'postgres';
+        $de->display_name   = 'Deutsch';
+        $de->short_name     = 'de';
+        $de->save();
+        $language = $de;
+    }
+
+    $concept = App\ThConcept::inRandomOrder()->first();
+    if(!isset($concept)){
+        factory(App\ThConcept::class, 1)->create();
+        $concept = App\ThConcept::inRandomOrder()->first();
+    }
+
+    return [
+        'concept_id' => $concept->id,
+        'language_id' => $language->id,
+        'label' => $faker->word,
+        'concept_label_type' => 1,
+        'lasteditor' => $faker->name
+    ];
+});
+
+$factory->define(App\ContextType::class, function(Faker\Generator $faker) {
+    $concept = App\ThConcept::inRandomOrder()->first();
+    if(!isset($concept)){
+        factory(App\ThConcept::class, 1)->create();
+        $concept = App\ThConcept::inRandomOrder()->first();
+    }
+    return [
+        'thesaurus_url' => $concept->concept_url,
+        'type' => $faker->randomElement([0,1]),
+    ];
+});
+
+$factory->define(App\Attribute::class, function(Faker\Generator $faker) {
+    $concept = App\ThConcept::inRandomOrder()->first();
+    if(!isset($concept)){
+        factory(App\ThConcept::class, 1)->create();
+        $concept = App\ThConcept::inRandomOrder()->first();
+    }
+    $root_concept = App\ThConcept::inRandomOrder()->first();
+    if(!isset($root_concept)){
+        factory(App\ThConcept::class, 1)->create();
+        $root_concept = App\ThConcept::inRandomOrder()->first();
+    }
+    return [
+        'thesaurus_url' => $concept->concept_url,
+        'thesaurus_root_url' => $faker->optional()->randomElement([$root_concept->concept_url]),
+        'datatype' => $faker->randomElement(['string', 'list', 'date', 'stringf', 'epoch', 'string-sc', 'string-mc']),
+    ];
+});
+
+$factory->define(App\ContextAttribute::class, function(Faker\Generator $faker) {
+    $contextType = App\ContextType::inRandomOrder()->first();
+    if(!isset($contextType)){
+        factory(App\ContextType::class, 1)->create();
+        $contextType = App\ContextType::inRandomOrder()->first();
+    }
+    $attribute = App\Attribute::inRandomOrder()->first();
+    if(!isset($attribute)){
+        factory(App\Attribute::class, 1)->create();
+        $attribute = App\Attribute::inRandomOrder()->first();
+    }
+    return [
+        'context_type_id' => $contextType->id,
+        'attribute_id' => $attribute->id,
+    ];
+});
+
+$factory->define(App\Literature::class, function(Faker\Generator $faker) {
+    return [
+        'author' => $faker->optional($weight=0.9)->name,
+        'editor'=> $faker->optional($weight=0.1)->name,
+        'title' => $faker->sentence($faker->numberBetween(3, 10)),
+        'journal' => $faker->optional($weight=0.9)->word,
+        'year' => $faker->optional($weight=0.9)->year,
+        'pages' => $faker->optional($weight=0.9)->randomDigit(3),
+        'volume' => $faker->optional($weight=0.5)->randomDigit,
+        'number' => $faker->optional($weight=0.5)->randomDigit,
+        'booktitle' => $faker->optional($weight=0.9)->sentence($faker->numberBetween(3, 10)),
+        'publisher' => $faker->optional($weight=0.9)->name,
+        'address' => $faker->optional($weight=0.9)->address,
+        'type' => $faker->randomElement(['book', 'article', 'web']),
+    ];
+});
+
+$factory->define(App\Geodata::class, function(Faker\Generator $faker) {
+    $point = new Phaza\LaravelPostgis\Geometries\Point($faker->latitude($min = -90, $max = 90), $faker->longitude($min = -180, $max = 180));
+    $deltaLat = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $deltaLng = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $point2 = new Phaza\LaravelPostgis\Geometries\Point($point->getLat() + $deltaLat, $point->getLng() + $deltaLng);
+    $deltaLat = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $deltaLng = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $point3 = new Phaza\LaravelPostgis\Geometries\Point($point2->getLat() + $deltaLat, $point2->getLng() + $deltaLng);
+    $deltaLat = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $deltaLng = $faker->randomFloat($min = -0.5, $max = 0.5);
+    $point4 = new Phaza\LaravelPostgis\Geometries\Point($point3->getLat() + $deltaLat, $point3->getLng() + $deltaLng);
+    $linestring = new Phaza\LaravelPostgis\Geometries\LineString([$point, $point2, $point3, $point4, $point]);
+    $polygon = new Phaza\LaravelPostgis\Geometries\Polygon([$linestring]);
+    return [
+        'geom' => $faker->randomElement([$point, $polygon, $linestring]),
+    ];
+});
+
+$factory->define(App\Context::class, function(Faker\Generator $faker) {
+    $contextType = App\ContextType::inRandomOrder()->first();
+    if(!isset($contextType)){
+        factory(App\ContextType::class, 1)->create();
+        $contextType = App\ContextType::inRandomOrder()->first();
+    }
+    $geodata = App\Geodata::inRandomOrder()->first();
+    if(!isset($geodata)){
+        $geodata = new App\Geodata();
+    }
+    $rootContext = App\Context::inRandomOrder()->first();
+    if(!isset($rootContext)){
+        $rootContext = new App\Context();
+    }
+    return [
+        'context_type_id' => $contextType->id,
+        'root_context_id' => $faker->optional()->randomElement([$rootContext->id]),
+        'name' => $faker->word,
+        // 'icon' => $faker->optional($weight=0.9)->randomElement([]), //TODO
+        // 'color' => $faker->optional()->randomElement([$faker->hexcolor]), //TODO
+        'geodata_id' => $faker->optional($weight=0.7)->randomElement([$geodata->id]),
+        'lasteditor' => $faker->name,
+    ];
+});
+
+$factory->define(App\Source::class, function(Faker\Generator $faker) {
+    $point = new Phaza\LaravelPostgis\Geometries\Point();
+    $polygon = new Phaza\LaravelPostgis\Geometries\Polygon();
+    return [
+        'geom' => $faker->randomElement([$point, $polygon]),
     ];
 });

--- a/lumen/database/seeds/DatabaseSeeder.php
+++ b/lumen/database/seeds/DatabaseSeeder.php
@@ -11,8 +11,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call('LanguageTableSeeder');
-        $this->call('TestSeeder');
+        $this->call('LanguageTableSeeder');
+        $this->call('RandomSeeder');
 
         // $this->call('ContextTableSeeder');
         // // $this->call('ThesaurusSeeder');

--- a/lumen/database/seeds/DatabaseSeeder.php
+++ b/lumen/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,15 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call('UsersTableSeeder');
+        // $this->call('LanguageTableSeeder');
+        $this->call('TestSeeder');
+
+        // $this->call('ContextTableSeeder');
+        // // $this->call('ThesaurusSeeder');
+        // //
+        App\User::select()->delete();
+        $user = factory(App\User::class, 'test')->create();
+        $user->attachRole(App\Role::where('name', 'employee')->first());
     }
+
 }

--- a/lumen/database/seeds/DatabaseSeeder.php
+++ b/lumen/database/seeds/DatabaseSeeder.php
@@ -17,9 +17,8 @@ class DatabaseSeeder extends Seeder
         // $this->call('ContextTableSeeder');
         // // $this->call('ThesaurusSeeder');
         // //
-        App\User::select()->delete();
-        $user = factory(App\User::class, 'test')->create();
-        $user->attachRole(App\Role::where('name', 'employee')->first());
+        $user = factory(App\User::class, 'guest')->create();
+        $user->attachRole(App\Role::where('name', 'guest')->first());
     }
 
 }

--- a/lumen/database/seeds/DatabaseSeeder.php
+++ b/lumen/database/seeds/DatabaseSeeder.php
@@ -13,10 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call('LanguageTableSeeder');
         $this->call('RandomSeeder');
-
-        // $this->call('ContextTableSeeder');
-        // // $this->call('ThesaurusSeeder');
-        // //
         $user = factory(App\User::class, 'guest')->create();
         $user->attachRole(App\Role::where('name', 'guest')->first());
     }

--- a/lumen/database/seeds/LanguageTableSeeder.php
+++ b/lumen/database/seeds/LanguageTableSeeder.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Hash;
 class LanguageTableSeeder extends Seeder
 {
     public function run() {
-        App\ThLanguage::select()->delete();
         $de = new App\ThLanguage;
         $de->lasteditor     = 'postgres';
         $de->display_name   = 'Deutsch';
@@ -37,7 +36,5 @@ class LanguageTableSeeder extends Seeder
         $it->display_name  = 'Italiano';
         $it->short_name    = 'it';
         $it->save();
-
-
     }
 }

--- a/lumen/database/seeds/LanguageTableSeeder.php
+++ b/lumen/database/seeds/LanguageTableSeeder.php
@@ -6,31 +6,38 @@ use Illuminate\Support\Facades\Hash;
 class LanguageTableSeeder extends Seeder
 {
     public function run() {
-        DB::table('th_language')->delete();
-        DB::table('th_language')->create(array(
-            'lasteditor'    => 'postgres',
-            'display_name'  => 'Deutsch',
-            'short_name'    => 'de'
-        ));
-        DB::table('th_language')->create(array(
-            'lasteditor'    => 'postgres',
-            'display_name'  => 'English',
-            'short_name'    => 'en'
-        ));
-        DB::table('th_language')->create(array(
-           'lasteditor'    => 'postgres',
-           'display_name'  => 'Español',
-           'short_name'    => 'es'
-        ));
-        DB::table('th_language')->create(array(
-            'lasteditor'    => 'postgres',
-            'display_name'  => 'Français',
-            'short_name'    => 'fr'
-        ));
-        DB::table('th_language')->create(array(
-            'lasteditor'    => 'postgres',
-            'display_name'  => 'Italiano',
-            'short_name'    => 'it'
-        ));
+        App\ThLanguage::select()->delete();
+        $de = new App\ThLanguage;
+        $de->lasteditor     = 'postgres';
+        $de->display_name   = 'Deutsch';
+        $de->short_name     = 'de';
+        $de->save();
+
+        $en = new App\ThLanguage;
+        $en->lasteditor    = 'postgres';
+        $en->display_name  = 'English';
+        $en->short_name    = 'en';
+        $en->save();
+
+        $es = new App\ThLanguage;
+        $es->lasteditor    = 'postgres';
+        $es->display_name  = 'Español';
+        $es->short_name    = 'es';
+        $es->save();
+
+        $fr = new App\ThLanguage;
+        $fr->lasteditor    = 'postgres';
+        $fr->display_name  = 'Français';
+        $fr->short_name    = 'fr';
+        $fr->save();
+
+
+        $it = new App\ThLanguage;
+        $it->lasteditor    = 'postgres';
+        $it->display_name  = 'Italiano';
+        $it->short_name    = 'it';
+        $it->save();
+
+
     }
 }

--- a/lumen/database/seeds/RandomSeeder.php
+++ b/lumen/database/seeds/RandomSeeder.php
@@ -11,12 +11,19 @@ class RandomSeeder extends Seeder
      */
     public function run()
     {
-        $numberSeedEntries = 10;
+        $numberSeedEntries = 20;
 
 
-        factory(App\ThConcept::class, $numberSeedEntries)->create();
+        $concepts = factory(App\ThConcept::class, $numberSeedEntries)->create()->each(function ($concept) {
+            foreach(App\ThLanguage::get() as $language){
+                factory(App\ThConceptLabel::class)->create([
+                    'concept_id' => $concept->id,
+                    'language_id' => $language->id,
+                ]);
+            }
+        });
+
         factory(App\ThBroader::class, $numberSeedEntries)->create();
-        factory(App\ThConceptLabel::class, $numberSeedEntries)->create();
         factory(App\ContextType::class, $numberSeedEntries)->create();
         factory(App\Attribute::class, $numberSeedEntries)->create();
         factory(App\ContextAttribute::class, $numberSeedEntries)->create();
@@ -26,5 +33,7 @@ class RandomSeeder extends Seeder
             // creation needs to be done in a loop in order to have root-context relationships
             factory(App\Context::class)->create();
         }
+        factory(App\Source::class, $numberSeedEntries)->create();
+        factory(App\AttributeValue::class, $numberSeedEntries)->create();
     }
 }

--- a/lumen/database/seeds/RandomSeeder.php
+++ b/lumen/database/seeds/RandomSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class RandomSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $numberSeedEntries = 10;
+
+
+        factory(App\ThConcept::class, $numberSeedEntries)->create();
+        factory(App\ThBroader::class, $numberSeedEntries)->create();
+        factory(App\ThConceptLabel::class, $numberSeedEntries)->create();
+        factory(App\ContextType::class, $numberSeedEntries)->create();
+        factory(App\Attribute::class, $numberSeedEntries)->create();
+        factory(App\ContextAttribute::class, $numberSeedEntries)->create();
+        factory(App\Literature::class, $numberSeedEntries)->create();
+        factory(App\Geodata::class, $numberSeedEntries)->create();
+        for($i = 0; $i < $numberSeedEntries; $i++){
+            // creation needs to be done in a loop in order to have root-context relationships
+            factory(App\Context::class)->create();
+        }
+    }
+}


### PR DESCRIPTION
Creating random database entries for testing purpose is now possible. Run `php artisan db:seed` to create random objects on an empty database or `php artisan migrate:refresh --seed` in order to refresh the seeds (Warning: this will delete all entries in the database).
Resolves #51 