### PR TITLE
remove user from storage if error 400/401 occured

### DIFF
--- a/app.js
+++ b/app.js
@@ -661,6 +661,7 @@ spacialistApp.config(function($stateProvider, $urlRouterProvider, $authProvider,
                     var $state = $injector.get('$state');
                     var userService = $injector.get('userService');
                     userService.loginError.message = 'login.error.400-or-401';
+                    localStorage.removeItem('user');
                     $state.go('auth');
                 } else {
                     updateToken(rejection, $injector);


### PR DESCRIPTION
This should redirect the user to the login page if a request returns http code 400 or 401 (e.g. wrong password, token invalid, <something else is wrong with the token>).
Please review @eScienceCenter/spacialists 