### PR TITLE
Add more last modified

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -542,10 +542,14 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpPostFactory', 'http
                 addContextSource(source);
             });
         });
+        var lastmodified = elem.updated_at || elem.created_at;
+        var d = new Date(lastmodified);
         main.currentElement.fields = elem.fields;
         main.currentElement.element = {
             id: elem.id,
             name: elem.name,
+            lasteditor: elem.lasteditor,
+            lastmodified: d.toLocaleDateString() + ' ' + d.toLocaleTimeString(),
             root_cid: elem.root_cid || -1,
             typeLabel: elem.typelabel,
             typeId: elem.typeid,

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -3,6 +3,7 @@
     "context-tree.new-toplevel-context": "Neuen Top-Kontext anlegen",
     "context-form.heading": "Element-Eigenschaften",
 	"context-form.name": "Name",
+    "context-form.last-modified": "Zuletzt geändert",
 	"context-form.save-button": "Speichern",
 	"context-form.delete-button": "Löschen",
 	"context-form.no-selection": "Kein Element ausgewählt.",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -3,6 +3,7 @@
     "context-tree.new-toplevel-context": "New Top-Level Context",
     "context-form.heading": "Properties",
 	"context-form.name": "Name",
+    "context-form.last-modified": "Last modified",
 	"context-form.save-button": "Save",
 	"context-form.delete-button": "Delete",
 	"context-form.no-selection": "No element selected.",

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -328,6 +328,7 @@ class ContextController extends Controller {
                 $geodata->geom = new Polygon([ $linestring ]);
                 break;
         }
+        $geodata->lasteditor = $user['name'];
         $geodata->save();
         return response()->json([
             'geodata' => [

--- a/lumen/app/Http/Controllers/LiteratureController.php
+++ b/lumen/app/Http/Controllers/LiteratureController.php
@@ -86,6 +86,12 @@ class LiteratureController extends Controller
     }
 
     public function add(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_literature')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->has('type') || !$request->has('title')) {
             return response()->json([
                 'error' => 'Your literature should have at least a title and a type.'
@@ -93,6 +99,7 @@ class LiteratureController extends Controller
         }
 
         $ins = $this->getFields($request);
+        $ins['lasteditor'] = $user['name'];
 
         if($request->has('id')) {
             $id = $request->get('id');
@@ -113,6 +120,12 @@ class LiteratureController extends Controller
     }
 
     public function edit(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('edit_literature')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if(!$request->has('id')) {
             return response()->json([
                 'error' => 'No ID given.'
@@ -122,6 +135,7 @@ class LiteratureController extends Controller
         $id = $request->get('id');
 
         $upd = $this->getFields($request);
+        $upd = $user['name'];
 
         DB::table('literature')
             ->where('id', '=', $id)

--- a/lumen/database/migrations/2017_03_01_101631_add_lasteditor_geodata_literature.php
+++ b/lumen/database/migrations/2017_03_01_101631_add_lasteditor_geodata_literature.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLasteditorGeodataLiterature extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('geodata', function (Blueprint $table) {
+            $table->text('lasteditor');
+        });
+        Schema::table('literature', function (Blueprint $table) {
+            $table->text('lasteditor');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('geodata', function (Blueprint $table) {
+            $table->dropColumn('lasteditor');
+        });
+        Schema::table('literature', function (Blueprint $table) {
+            $table->dropColumn('lasteditor');
+        });
+    }
+}

--- a/view.html
+++ b/view.html
@@ -32,6 +32,14 @@
                     </div>
                     <form-field fields="currentElement.fields" output="currentElement.data" sources="currentElement.sources" label-width="3" input-width="9" offset="0" sp-readonly="{{ !currentUser.permissions.duplicate_edit_concepts }}">
                     </form-field>
+                    <div class="form-group">
+                        <label class="control-label col-md-3" for="lasteditor">{{ 'context-form.last-modified' | translate }}:</label>
+                        <div class="col-md-9">
+                            <p class="form-control-static">
+                                {{ currentElement.element.lastmodified }} (<strong>{{ currentElement.element.lasteditor }}</strong>)
+                            </p>
+                        </div>
+                    </div>
                     <div class="col-md-offset-3" ng-if="currentUser.permissions.duplicate_edit_concepts">
                         <button type="button" class="btn btn-success" ng-click="storeElement(currentElement.element, currentElement.data)">
                             <span class="fa fa-fw fa-floppy-o"></span> {{ 'context-form.save-button' | translate }}


### PR DESCRIPTION
This PR adds a `lasteditor` column to the `geodata` and `literature` table. Furthermore it adds the last editor and the last edit timestamp to the context properties tab. Are there any other places where we should display these informations?
@eScienceCenter/spacialists 