### PR TITLE
remove unnecessary styling

### DIFF
--- a/includes/inputFields.html
+++ b/includes/inputFields.html
@@ -84,7 +84,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="col-md-12 input-group" style="padding-top: 10px;">
+                <div style="padding-top: 10px;">
                     <ui-select ng-model="attributeOutputs[attr.aid+'_'+attr.oid].epoch"
                     name="{{ attr.aid+'_'+attr.oid }}" id="{{ attr.aid+'_'+attr.oid }}"
                     ng-disabled="readonlyInput">


### PR DESCRIPTION
This PR removes the classes from the epoch select2 dropdown. With this classes it had non-bootstrap styling. Now it should look as all other input fields.

Please review @eScienceCenter/spacialists 