### PR TITLE
fix ugly indent on line break in tree

### DIFF
--- a/includes/new-tree-child.html
+++ b/includes/new-tree-child.html
@@ -1,14 +1,16 @@
-<div ui-tree-handle>
-    <a ng-click="toggle(this)" ng-if="parent.children && parent.children.length > 0" class="expandable-toggle"><span class="fa fa-fw" ng-class="{ 'fa-chevron-right': collapsed, 'fa-chevron-down': !collapsed}" aria-hidden="true"></span></a>
-    <span ng-if="!parent.children || parent.children.length == 0" class="fa fa-fw">
-    </span>
-    <span ng-click="onClickCallback({target:parent, elem: element})" ng-class="{ 'selected-leaf': element.id == parent.id }">
+<div ui-tree-handle style="display: table;">
+    <div style="display: table-cell;">
+        <a ng-click="toggle(this)" ng-if="parent.children && parent.children.length > 0" class="expandable-toggle">
+            <span class="fa fa-fw" ng-class="{ 'fa-chevron-right': collapsed, 'fa-chevron-down': !collapsed}" aria-hidden="true">
+            </span>
+        </a>
+        <span ng-if="!parent.children || parent.children.length == 0" class="fa fa-fw">
+        </span>
+    </div>
+    <span ng-click="onClickCallback({target:parent, elem: element})" ng-class="{ 'selected-leaf': element.id == parent.id }" style="display: table-cell; padding-left: 4px;">
         <i class="fa fa-university fa-fw fa-light fa-small" aria-hidden="true" ng-if="parent.typeid == 0"></i>
         <i class="fa fa-tag fa-fw fa-light fa-small" aria-hidden="true" ng-if="parent.typeid == 1"></i>
         <span ng-style="getColorForId(parent[typeAttribute])" ng-class="{ 'selected-leaf-child': element.id == parent.id }">{{ parent[displayAttribute] }}</span> <span ng-if="parent[prefixAttribute]" class="contextPrefix">{{ parent[prefixAttribute]}}</span>
-    </span>
-    <span ng-if="getRecLength(parent) > 0" class="badge" style="float: right;">
-        {{ getRecLength(parent) }}
     </span>
 </div>
 <ul ui-tree-nodes="" ng-model="parent.children" ng-class="{ hidden: collapsed }">


### PR DESCRIPTION
Fix #155 
Line breaks should now align correct beside the child toggle.
Please review @eScienceCenter/spacialists 