### PR TITLE
Role editor permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,17 +95,17 @@
                                 <span class="fa fa-fw fa-sign-out"></span> {{ currentUser.user.name }}
                             </a>
                         </li>
-                        <li ng-if="currentUser.permissions.view_users" class="dropdown" uib-dropdown>
+                        <li ng-if="currentUser.permissions.view_users || currentUser.permissions.add_edit_role" class="dropdown" uib-dropdown>
                             <a href="#" class="dropdown-toggle" uib-dropdown-toggle data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                                 {{'main.menu.user-management'|translate}} <span class="caret"></span>
                             </a>
                             <ul class="dropdown-menu" uib-dropdown-menu>
-                                <li>
+                                <li ng-if="currentUser.permissions.view_users">
                                     <a href="" ng-click="openUserManagement()">
                                         <i class="fa fa-fw fa-users"></i> {{'main.menu.user-list'|translate}}
                                     </a>
                                 </li>
-                                <li>
+                                <li ng-if="currentUser.permissions.add_edit_role">
                                     <a href="" ng-click="openRoleManagement()">
                                         <i class="fa fa-fw fa-cog"></i> {{'main.menu.role-list'|translate}}
                                     </a>

--- a/lumen/app/Http/Controllers/UserController.php
+++ b/lumen/app/Http/Controllers/UserController.php
@@ -106,7 +106,7 @@ class UserController extends Controller
 
     public function getRoles() {
         $user = \Auth::user();
-        if(!$user->can('add_remove_role')) {
+        if(!$user->can('add_remove_role') && !$user->can('add_edit_role')) {
             return response([
                 'error' => 'You do not have the permission to call this method'
             ], 403);
@@ -118,6 +118,12 @@ class UserController extends Controller
     }
 
     public function getPermissionsByRole($id) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         return response()->json([
             'permissions' => DB::table('permissions as p')
                                 ->select('p.*')
@@ -196,6 +202,12 @@ class UserController extends Controller
     }
 
     public function editRole(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_edit_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         if($request->has('role_id')) {
             $role_id = $request->get('role_id');
             $editedRole = Role::find($role_id);
@@ -218,11 +230,23 @@ class UserController extends Controller
     }
 
     public function deleteRole($id) {
+        $user = \Auth::user();
+        if(!$user->can('delete_role')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         Role::find($id)->delete();
         return response()->json();
     }
 
     public function addRolePermission(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $roleId = $request->get('role_id');
         $permId = $request->get('permission_id');
         DB::table('permission_role')
@@ -234,6 +258,12 @@ class UserController extends Controller
     }
 
     public function removeRolePermission(Request $request) {
+        $user = \Auth::user();
+        if(!$user->can('add_remove_permission')) {
+            return response([
+                'error' => 'You do not have the permission to call this method'
+            ], 403);
+        }
         $roleId = $request->get('role_id');
         $permId = $request->get('permission_id');
         DB::table('permission_role')

--- a/lumen/database/migrations/2017_01_22_162056_define_roles_and_permissions.php
+++ b/lumen/database/migrations/2017_01_22_162056_define_roles_and_permissions.php
@@ -174,66 +174,12 @@ class DefineRolesAndPermissions extends Migration
         $guest = new App\Role();
         $guest->name = 'guest';
         $guest->display_name = 'Guest';
-        $guest->description = 'Project Administrator';
+        $guest->description = 'Guest User';
         $guest->save();
         $guest->attachPermission($view_concepts);
         $guest->attachPermission($view_concept_props);
         $guest->attachPermission($view_photos);
         $guest->attachPermission($view_geodata);
-        // Map user
-        $map_user = new App\Role();
-        $map_user->name = 'map_user';
-        $map_user->display_name = 'Map user';
-        $map_user->description = 'User is allowed to see concepts and can manage geodata (upload, edit, delete, link)';
-        $map_user->save();
-        $map_user->attachPermission($view_concepts);
-        $map_user->attachPermission($view_geodata);
-        $map_user->attachPermission($create_edit_geodata);
-        $map_user->attachPermission($upload_remove_geodata);
-        $map_user->attachPermission($link_geodata);
-        // Photo user
-        $photo_user = new App\Role();
-        $photo_user->name = 'photo_user';
-        $photo_user->display_name = 'Photo user';
-        $photo_user->description = 'User is allowed to see concepts and can manage photos (upload, edit, delete, link)';
-        $photo_user->save();
-        $photo_user->attachPermission($view_concepts);
-        $photo_user->attachPermission($manage_photos);
-        $photo_user->attachPermission($link_photos);
-        $photo_user->attachPermission($edit_photo_props);
-        $photo_user->attachPermission($view_photos);
-        // Photo assistent
-        $photo_assistent = new App\Role();
-        $photo_assistent->name = 'photo_assistent';
-        $photo_assistent->display_name = 'Photo assistent';
-        $photo_assistent->description = 'User is allowed to see concepts and can edit photo properties';
-        $photo_assistent->save();
-        $photo_assistent->attachPermission($view_concepts);
-        $photo_assistent->attachPermission($edit_photo_props);
-        $photo_assistent->attachPermission($view_photos);
-        // Employee
-        $employee = new App\Role();
-        $employee->name = 'employee';
-        $employee->display_name = 'Employee';
-        $employee->description = 'User can do anything except user management';
-        $employee->save();
-        $employee->attachPermission($create_concepts);
-        $employee->attachPermission($delete_move_concepts);
-        $employee->attachPermission($duplicate_edit_concepts);
-        $employee->attachPermission($view_concepts);
-        $employee->attachPermission($view_concept_props);
-        $employee->attachPermission($edit_literature);
-        $employee->attachPermission($add_remove_literature);
-        $employee->attachPermission($manage_photos);
-        $employee->attachPermission($link_photos);
-        $employee->attachPermission($edit_photo_props);
-        $employee->attachPermission($view_photos);
-        $employee->attachPermission($export_photos);
-        $employee->attachPermission($view_geodata);
-        $employee->attachPermission($create_edit_geodata);
-        $employee->attachPermission($upload_remove_geodata);
-        $employee->attachPermission($link_geodata);
-        $employee->attachPermission($view_users);
     }
 
     /**

--- a/lumen/database/migrations/2017_03_10_153046_add_role_management_permissions.php
+++ b/lumen/database/migrations/2017_03_10_153046_add_role_management_permissions.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\Role;
+use App\Permission;
+
+class AddRoleManagementPermissions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Add and edit roles
+        $add_edit_role = new Permission();
+        $add_edit_role->name = 'add_edit_role';
+        $add_edit_role->display_name = 'Add and edit roles';
+        $add_edit_role->description = 'add and edit existing roles';
+        $add_edit_role->save();
+        // Delete roles
+        $delete_role = new Permission();
+        $delete_role->name = 'delete_role';
+        $delete_role->display_name = 'Delete roles';
+        $delete_role->description = 'delete existing roles';
+        $delete_role->save();
+        // Add and remove permissions
+        $add_remove_permission = new Permission();
+        $add_remove_permission->name = 'add_remove_permission';
+        $add_remove_permission->display_name = 'Add and remove permissions';
+        $add_remove_permission->description = 'add and remove permissions to/from roles';
+        $add_remove_permission->save();
+
+        $admin = Role::where('name', '=', 'admin')->firstOrFail();
+        $admin->attachPermission($view_roles);
+        $admin->attachPermission($add_edit_role);
+        $admin->attachPermission($delete_role);
+        $admin->attachPermission($add_remove_permission);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $permissions = [
+            'view_roles', 'add_edit_role',
+            'delete_role', 'add_remove_permission'
+        ];
+        foreach($permissions as $p) {
+            $entry = Permission::where('name', '=', $p)->firstOrFail();
+            $entry->delete();
+        }
+    }
+}

--- a/roles.html
+++ b/roles.html
@@ -1,5 +1,5 @@
 <div ng-controller="userCtrl" resize-watcher>
-    <table class="table table-striped table-hover" ng-init="getRoles()">
+    <table class="table table-striped table-hover" ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role" ng-init="getRoles()">
         <tr>
             <th>
                 {{ 'role.name' | translate }}
@@ -10,10 +10,10 @@
             <th>
                 {{ 'role.description' | translate }}
             </th>
-            <th>
+            <th ng-if="currentUser.permissions.add_remove_permission">
                 {{ 'role.permissions' | translate }}
             </th>
-            <th>
+            <th ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role">
                 {{ 'role.options' | translate }}
             </th>
             <th>
@@ -33,7 +33,7 @@
             <td>
                 {{ role.description }}
             </td>
-            <td ng-init="getRolePermissions(role)">
+            <td ng-if="currentUser.permissions.add_remove_permission" ng-init="getRolePermissions(role)">
                 <ui-select multiple ng-model="role.permissions" close-on-select="false" name="role_permissions_{{ role.id }}" id="role_permissions_{{ role.id }}" on-select="addRolePermission($item, role)" on-remove="removeRolePermission($item, role)">
                     <ui-select-match><span uib-tooltip="{{ $item.description }}">{{ $item.display_name }}</span></ui-select-match>
                     <ui-select-choices repeat="permission in permissions | filter:$select.search">
@@ -41,10 +41,10 @@
                     </ui-select-choices>
                 </ui-select>
             </td>
-            <th>
-                <button type="button" class="btn btn-info" ng-click="openEditRoleDialog(role)">
+            <th ng-if="currentUser.permissions.add_edit_role || currentUser.permissions.delete_role">
+                <button type="button" class="btn btn-info" ng-click="openEditRoleDialog(role)" ng-if="currentUser.permissions.add_edit_role">
                     <i class="fa fa-fw fa-pencil"></i>
-                </button> <button type="button" class="btn btn-danger" ng-click="deleteRole(role)">
+                </button> <button type="button" class="btn btn-danger" ng-click="deleteRole(role)" ng-if="currentUser.permissions.delete_role">
                     <i class="fa fa-fw fa-trash-o"></i>
                 </button>
             </th>
@@ -56,7 +56,7 @@
             </td>
         </tr>
     </table>
-    <button type="button" class="btn btn-success" ng-click="openAddRoleDialog()">
+    <button type="button" class="btn btn-success" ng-click="openAddRoleDialog()" ng-if="currentUser.permissions.add_edit_role">
         <i class="fa fa-fw fa-plus"></i> {{ 'role.add' | translate }}
     </button>
 </div>


### PR DESCRIPTION
This PR adds the missing permissions from #157.
Now, columns in the role view should only be visible if the user has the appropriate permissions. On the server-side it should no longer be possible to add/edit/delete roles without the permission.

Please review @eScienceCenter/spacialists 