### PR TITLE
close previous popup if unlinked element is selected & was linked

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -523,6 +523,7 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
             if(mapService.getPopupGeoId() == elem.geodata_id) mapService.closePopup();
             return;
         }
+        var isCurrentlyLinked = mapService.getPopupGeoId() == elem.geodata_id;
         elem = target;
         console.log(elem);
         if(elem.typeid === 0) { //context
@@ -565,6 +566,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         if(typeof openAgain == 'undefined') openAgain = true;
         if(elem.geodata_id !== null && openAgain) {
             mapService.openPopup(elem.geodata_id);
+        } else if(elem.geodata_id === null && isCurrentlyLinked) {
+            mapService.closePopup();
         }
         loadLinkedImages(main.currentElement.element.id);
     };

--- a/app/mapService.js
+++ b/app/mapService.js
@@ -36,6 +36,7 @@ spacialistApp.service('mapService', ['httpGetFactory', 'httpPostFactory', 'httpG
     // };
 
     map.getPopupGeoId = function() {
+        if(!map.mapObject._popup) return -1;
         return map.mapObject._popup.options.feature.id;
     };
 

--- a/lumen/database/migrations/2017_03_13_134710_unique_geodata_id.php
+++ b/lumen/database/migrations/2017_03_13_134710_unique_geodata_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UniqueGeodataId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('contexts', function (Blueprint $table) {
+            $table->integer('geodata_id')->unique()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('contexts', function (Blueprint $table) {
+            $table->dropUnique('contexts_geodata_id_unique');
+        });
+    }
+}


### PR DESCRIPTION
Fix #151 

It should now no longer be possible to link a geodata object to multiple contexts (popup should close if it is connected to a context).
Please review @eScienceCenter/spacialists 