### PR TITLE
set max-zoom to appropriate value (27 = ~1.5ft)

### DIFF
--- a/app/mapService.js
+++ b/app/mapService.js
@@ -219,6 +219,9 @@ spacialistApp.service('mapService', ['httpGetFactory', 'httpPostFactory', 'httpG
     function initMapVariables() {
         map.map = {};
         map.map.center = {};
+        map.map.defaults = {
+            maxZoom: 27
+        };
         map.map.bounds = map.createBoundsFromArray([
             [-90, 180],
             [90, -180]

--- a/view.html
+++ b/view.html
@@ -83,7 +83,7 @@
         <div ng-if="layerTwo.activeTab == 'map'">
             <div ng-if="currentUser.permissions.view_geodata" ng-controller="mapCtrl">
                 <div id="map-container" ng-if="map">
-                    <leaflet id="mainmap" layers="map.layers" lf-center="map.center" bounds="map.bounds" lf-draw="map.drawOptions" controls="map.controls" geojson="map.geojson" height="{{addonContainerHeight}}px" width="100%">
+                    <leaflet id="mainmap" layers="map.layers" lf-center="map.center" bounds="map.bounds" defaults="map.defaults" lf-draw="map.drawOptions" controls="map.controls" geojson="map.geojson" height="{{addonContainerHeight}}px" width="100%">
                     </leaflet><!-- legend="map.legend" -->
                 </div>
             </div>


### PR DESCRIPTION
Fix #163 
max zoom level is now at 27, which is about 1.5-2ft (less than 1m) on the map.

Please review @eScienceCenter/spacialists 