### PR TITLE
added seeder to add a guest user

### DIFF
--- a/lumen/database/seeds/GuestUserSeeder.php
+++ b/lumen/database/seeds/GuestUserSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\User;
+
+class GuestUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $guestName = 'Guest User';
+        $cnt = User::where('name', '=', $guestName)->count();
+        if($cnt === 0) {
+            $guest = new User();
+            $guest->name = $guestName;
+            $guest->email = 'udontneedtoseehisidentification@rebels.tld';
+            $guest->password = Hash::make('thesearentthedroidsuarelookingfor');
+            $guest->save();
+
+            $guestRole = App\Role::where('name', '=', 'guest')->firstOrFail();
+            $guest->attachRole($guestRole);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the possibility to add a guest user account. To add the guest user you have to exec the following two commands from within the lumen folder:
```bash
composer dump-autoload # otherwise the GuestUserSeeder file is not defined
php artisan db:seed --class=GuestUserSeeder
```

Please review @eScienceCenter/spacialists 