### PR TITLE
add check if user object exists

### DIFF
--- a/app/userService.js
+++ b/app/userService.js
@@ -15,6 +15,27 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
         return user.currentUser.permissions[to] == 1;
     };
 
+    init();
+
+    function init() {
+        if(!userSet()) {
+            $auth.logout().then(function() {
+                user.currentUser.user = {};
+                user.currentUser.permissions = {};
+                localStorage.removeItem('user');
+                $state.go('auth', {});
+            });
+        }
+    }
+
+    function userSet() {
+        var user = localStorage.getItem('user');
+        if(user === '') return false;
+        var parsedUser = JSON.parse(user);
+        if(!parsedUser) return false;
+        return true;
+    }
+
     user.getUserList = function() {
         user.users.length = 0;
         httpPostFactory('api/user/get/all', new FormData(), function(response) {


### PR DESCRIPTION
This PR checks if the user object exists in localStorage and redirects to the login page if not. Thus it is no longer possible to login, delete the content of the user object (or access the `#/spacialist` state directly without a user object) and then only see the "You are not allowed to access this page...." in all tabs without an option to re-login.
Please review @eScienceCenter/spacialists 