### PR TITLE
Show colors for geodata

### DIFF
--- a/controllers/mapCtrl.js
+++ b/controllers/mapCtrl.js
@@ -1,8 +1,7 @@
 spacialistApp.controller('mapCtrl', ['$scope', 'mapService', 'mainService', 'modalFactory', 'httpGetFactory', '$compile', function($scope, mapService, mainService, modalFactory, httpGetFactory, $compile) {
     $scope.map = mapService.map;
     $scope.mapObject = mapService.mapObject;
-    $scope.markerIcons = mapService.markerIcons;
-    $scope.markers = mapService.markers;
+    $scope.geodataList = mapService.geodataList;
     $scope.currentElement = mainService.currentElement;
     $scope.currentGeodata = mapService.currentGeodata;
     ////
@@ -29,22 +28,8 @@ spacialistApp.controller('mapCtrl', ['$scope', 'mapService', 'mainService', 'mod
         mapService.addContextToMarkers(elem);
     };
 
-    $scope.updateMarkerOptions = function(markerId, markerKey, color, icon) {
-        if(typeof markerId == 'undefined') return;
-        if(markerId <= 0) return;
-        var formData = new FormData();
-        formData.append('id', markerId);
-        if(typeof color != 'undefined') formData.append('color', color);
-        if(typeof icon != 'undefined') formData.append('icon', icon.icon);
-        httpPostPromise.getData('api/context/set/icon', formData).then(
-            function(icon) {
-                console.log(icon);
-                angular.extend($scope.markers[markerKey].icon, {
-                    className: 'fa fa-fw fa-lg fa-' + icon.icon,
-                    color: icon.color
-                });
-            }
-        );
+    $scope.updateMarkerOptions = function(geodata_id, color) {
+        mapService.updateMarker(geodata_id, color);
     };
 
     /**

--- a/controllers/mapCtrl.js
+++ b/controllers/mapCtrl.js
@@ -45,9 +45,9 @@ spacialistApp.controller('mapCtrl', ['$scope', 'mapService', 'mainService', 'mod
         $compile(popup._contentNode)(newScope);
         var center = popup._source.getBounds().getCenter();
         popup.setLatLng(center);
-        var featureId = args.leafletEvent.popup._source.feature.id;
-        mapService.setCurrentGeodata(featureId);
-        var promise = mapService.getMatchingContext(featureId);
+        var geodataId = args.leafletEvent.popup._source.feature.id;
+        mapService.setCurrentGeodata(geodataId);
+        var promise = mapService.getMatchingContext(geodataId);
         promise.then(function(response) {
             if(response.error) {
                 modalFactory.errorModal(response.error);
@@ -61,6 +61,8 @@ spacialistApp.controller('mapCtrl', ['$scope', 'mapService', 'mainService', 'mod
                 }
             }
         });
+
+        $scope.markerOptions.color = $scope.geodataList['#' + geodataId].color;
     });
 
     $scope.$on('leafletDirectiveDraw.mainmap.draw:edited', function(event, args) {

--- a/layouts/marker.html
+++ b/layouts/marker.html
@@ -31,34 +31,21 @@
     </button>
 </p>
 
-<!--<div ng-init="collapsed=true">
+<div ng-init="collapsed=true">
     <h5 ng-click="collapsed=!collapsed" class="clickable">{{'map-marker.options.label'|translate}} <small><i class="fa fa-fw" ng-class="collapsed ? 'fa-caret-right' : 'fa-caret-down'"></i></small></h5>
     <div ng-if="!collapsed">
         <form class="form-horizontal" role="form">
             <div class="form-group">
-                <label class="control-label col-md-3" for="color_{{ markerKey }}">
+                <label class="control-label col-md-3" for="color_{{ currentGeodata.id }}">
                     {{'map-marker.options.color'|translate}}:
                 </label>
                 <div class="col-md-9">
-                    <input class="form-control" type="color" name="color_{{ markerKey }}" ng-model="markerOptions.color" id="color_{{ markerKey }}" ng-disabled="!currentUser.permissions.duplicate_edit_concepts"/>
-                </div>
-            </div>
-            <div class="form-group row">
-                <label class="control-label col-md-3" for="icon_{{ markerKey }}">
-                    {{'map-marker.options.icon'|translate}}:
-                </label>
-                <div class="col-md-9">
-                    <ui-select ng-model="markerOptions.icon" name="icon_{{ markerKey }}" ng-disabled="!currentUser.permissions.duplicate_edit_concepts">
-                        <ui-select-match placeholder="{{'map-marker.options.icon'|translate}}"><i class="fa fa-fw fa-{{ $select.selected.icon }}"></i> {{ $select.selected.name }}</ui-select-match>
-                        <ui-select-choices repeat="icon in icons | filter: $select.search">
-                            <span><i class="fa fa-fw fa-{{ icon.icon }}"></i> {{ icon.name | highlight: $select.search }}</span>
-                        </ui-select-choices>
-                    </ui-select>
+                    <input class="form-control" type="color" name="color_{{ currentGeodata.id }}" ng-model="markerOptions.color" id="color_{{ currentGeodata.id }}" ng-disabled="!currentUser.permissions.duplicate_edit_concepts"/>
                 </div>
             </div>
 
-            <button type="button" class="btn btn-xs btn-success" ng-click="updateMarkerOptions(activeMarker, markerKey, markerOptions.color, markerOptions.icon)" ng-if="currentUser.permissions.duplicate_edit_concepts"><i class="fa fa-fw fa-floppy-o"></i> {{'map-marker.save'|translate}}</button>-->
+            <button type="button" class="btn btn-xs btn-success" ng-click="updateMarkerOptions(currentGeodata.id, markerOptions.color)" ng-if="currentUser.permissions.duplicate_edit_concepts"><i class="fa fa-fw fa-floppy-o"></i> {{'map-marker.save'|translate}}</button>
 
-        <!--</form>
+        </form>
     </div>
-</div>-->
+</div>

--- a/lumen/app/Context.php
+++ b/lumen/app/Context.php
@@ -16,8 +16,6 @@ class Context extends Model
         'root_context_id',
         'name',
         'lasteditor',
-        'icon',
-        'color',
         'geodata_id',
     ];
 }

--- a/lumen/app/Geodata.php
+++ b/lumen/app/Geodata.php
@@ -16,8 +16,9 @@ class Geodata extends Model
      * @var array
      */
     protected $fillable = [
+        'color',
     ];
-    
+
     protected $postgisFields = [
         'geom',
     ];

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -608,7 +608,8 @@ class ContextController extends Controller {
         foreach($geoms as $geom) {
             $geodataList[] = [
                 'geodata' => $geom->geom->jsonSerialize(),
-                'id' => $geom->id
+                'id' => $geom->id,
+                'color' => $geom->color,
             ];
         }
         return response()->json([
@@ -782,7 +783,7 @@ class ContextController extends Controller {
         return response()->json(['context' => $context]);
     }
 
-    public function setIcon(Request $request) {
+    public function setColor(Request $request) {
         $user = \Auth::user();
         if(!$user->can('duplicate_edit_concepts')) {
             return response([
@@ -792,18 +793,12 @@ class ContextController extends Controller {
         $id = $request->get('id');
         $upd = [];
 
-        if($request->has('icon')) $upd['icon'] = $request->get('icon');
-        if($request->has('color')) $upd['color'] = $request->get('color');
 
-        DB::table('contexts')
-            ->where('id', $id)
-            ->update($upd);
-        $icon = DB::table('contexts')
-                ->where('id', $id)
-                ->first();
+        $geodata = Geodata::find($id);
+        $geodata->color = $request->get('color');
+        $geodata->save();
         return response()->json([
-            'icon' => $icon->icon,
-            'color' => $icon->color
+            'color' => $geodata->color
         ]);
     }
 

--- a/lumen/app/Http/routes.php
+++ b/lumen/app/Http/routes.php
@@ -61,7 +61,7 @@ $app->group(['middleware' => ['before' => 'jwt.auth', 'after' => 'jwt.refresh']]
     $app->post('image/unlink', 'ImageController@unlink');
     $app->post('context/add/geodata', 'ContextController@addGeodata');
     $app->post('context/set', 'ContextController@set');
-    $app->post('context/set/icon', 'ContextController@setIcon');
+    $app->post('context/set/color', 'ContextController@setColor');
     $app->post('sources/add', 'SourceController@add');
     $app->post('context/set/possibility', 'ContextController@setPossibility');
     $app->post('context/wktToGeojson', 'ContextController@wktToGeojson');

--- a/lumen/database/factories/ModelFactory.php
+++ b/lumen/database/factories/ModelFactory.php
@@ -111,7 +111,7 @@ $factory->define(App\Attribute::class, function(Faker\Generator $faker) {
     return [
         'thesaurus_url' => $concept->concept_url,
         'thesaurus_root_url' => $faker->optional()->randomElement([$root_concept->concept_url]),
-        'datatype' => $faker->randomElement(['string', 'list', 'date', 'stringf', 'epoch', 'string-sc', 'string-mc']),
+        'datatype' => $faker->randomElement(['string', 'list', 'date', 'stringf', 'epoch', 'string-sc', 'string-mc', 'dimension']),
     ];
 });
 
@@ -176,6 +176,7 @@ $factory->define(App\Geodata::class, function(Faker\Generator $faker) {
 
     return [
         'geom' => $geom,
+        'color' => $faker->randomElement([$faker->hexcolor]),
     ];
 });
 
@@ -184,10 +185,8 @@ $factory->define(App\Context::class, function(Faker\Generator $faker) {
     if(!isset($contextType)){
         $contextType = factory(App\ContextType::class)->create();
     }
-    $geodata = App\Geodata::inRandomOrder()->first();
-    if(!isset($geodata)){
-        $geodata = factory(App\Geodata::class)->create();
-    }
+    $geodata = factory(App\Geodata::class)->create();
+
     $rootContext = App\Context::inRandomOrder()->first();
     if(!isset($rootContext)){
         // if there is no entry in the Contexts table, do not recursively call this factory
@@ -197,9 +196,7 @@ $factory->define(App\Context::class, function(Faker\Generator $faker) {
         'context_type_id' => $contextType->id,
         'root_context_id' => $faker->optional()->randomElement([$rootContext->id]),
         'name' => $faker->word,
-        'icon' => $faker->optional($weight=0.9)->randomElement(['plus','close','circle','circle-o','dot-circle-o','square','square-o','star','asterisk','flag','flag-o','map-marker','map-pin','university']),
-        'color' => $faker->optional()->randomElement([$faker->hexcolor]),
-        'geodata_id' => $faker->optional($weight=0.7)->randomElement([$geodata->id]),
+        'geodata_id' => $geodata->id,
         'lasteditor' => $faker->name,
     ];
 });

--- a/lumen/database/migrations/2017_01_22_162056_define_roles_and_permissions.php
+++ b/lumen/database/migrations/2017_01_22_162056_define_roles_and_permissions.php
@@ -204,8 +204,7 @@ class DefineRolesAndPermissions extends Migration
             $entry->delete();
         }
         $roles = [
-            'admin', 'guest', 'map_user', 'photo_user',
-            'photo_assistent', 'employee'
+            'admin', 'guest',
         ];
         foreach($roles as $r) {
             $entry = App\Role::where('name', '=', $r)->firstOrFail();

--- a/lumen/database/migrations/2017_03_10_153046_add_role_management_permissions.php
+++ b/lumen/database/migrations/2017_03_10_153046_add_role_management_permissions.php
@@ -48,7 +48,7 @@ class AddRoleManagementPermissions extends Migration
     public function down()
     {
         $permissions = [
-            'view_roles', 'add_edit_role',
+            'add_edit_role',
             'delete_role', 'add_remove_permission'
         ];
         foreach($permissions as $p) {

--- a/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
+++ b/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
@@ -76,7 +76,9 @@ class MoveColorToGeodata extends Migration
                     '#99FF33'   =>  'flag-o',
                     '#FFFF33'   =>  'map-marker',
             ];
-            App\Context::where('geodata_id', $geodata->id)->update(['icon' => $translate[$geodata->color]]);
+            if(array_key_exists($geodata->color, $translate)) {
+                App\Context::where('geodata_id', $geodata->id)->update(['icon' => $translate[$geodata->color]]);
+            }
         });
 
         Schema::table('geodata', function(Blueprint $table) {

--- a/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
+++ b/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
@@ -36,7 +36,7 @@ class MoveColorToGeodata extends Migration
                     'flag-o'        =>  '#99FF33',
                     'map-marker'    =>  '#FFFF33',
             ];
-            App\Geodata::where('id', $context->geodata_id)->update(['color' => $translate[$context->icon]]);
+            if(isset($context->geodata_id) && isset($context->icon) && $context->icon != '') App\Geodata::where('id', $context->geodata_id)->update(['color' => $translate[$context->icon]]);
         });
 
         Schema::table('contexts', function(Blueprint $table) {

--- a/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
+++ b/lumen/database/migrations/2017_03_28_115827_move_color_to_geodata.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MoveColorToGeodata extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('geodata', function (Blueprint $table) {
+            $table->text('color')->nullable();
+        });
+
+
+        // former icon specifications will now be translated into different colors
+        App\Context::get()->each(function ($context) {
+            $translate = [
+                    'plus'          =>  '#3333FF',
+                    'close'         =>  '#9933FF',
+                    'circle'        =>  '#FF33FF',
+                    'university'    =>  '#3399FF',
+                    'circle-o'      =>  '#0000B8',
+                    'dot-circle-o'  =>  '#FF3333',
+                    'square'        =>  '#33FFFF',
+                    'map-pin'       =>  '#FF3399',
+                    'flag'          =>  '#B8B800',
+                    'square-o'      =>  '#FF9933',
+                    'star'          =>  '#33FF99',
+                    'asterisk'      =>  '#33FF33',
+                    'flag-o'        =>  '#99FF33',
+                    'map-marker'    =>  '#FFFF33',
+            ];
+            App\Geodata::where('id', $context->geodata_id)->update(['color' => $translate[$context->icon]]);
+        });
+
+        Schema::table('contexts', function(Blueprint $table) {
+            $table->dropColumn('color');
+            $table->dropColumn('icon');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+        Schema::table('contexts', function(Blueprint $table) {
+            $table->text('icon')->nullable();
+            $table->text('color')->nullable();
+        });
+
+        App\Geodata::get()->each(function ($geodata) {
+            // former icon specifications will now be translated into different colors
+            $translate = [
+                    '#3333FF'   =>  'plus',
+                    '#9933FF'   =>  'close',
+                    '#FF33FF'   =>  'circle',
+                    '#3399FF'   =>  'university',
+                    '#0000B8'   =>  'circle-o',
+                    '#FF3333'   =>  'dot-circle-o',
+                    '#33FFFF'   =>  'square',
+                    '#FF3399'   =>  'map-pin',
+                    '#B8B800'   =>  'flag',
+                    '#FF9933'   =>  'square-o',
+                    '#33FF99'   =>  'star',
+                    '#33FF33'   =>  'asterisk',
+                    '#99FF33'   =>  'flag-o',
+                    '#FFFF33'   =>  'map-marker',
+            ];
+            App\Context::where('geodata_id', $geodata->id)->update(['icon' => $translate[$geodata->color]]);
+        });
+
+        Schema::table('geodata', function(Blueprint $table) {
+            $table->dropColumn('color');
+        });
+    }
+}

--- a/lumen/database/seeds/RandomSeeder.php
+++ b/lumen/database/seeds/RandomSeeder.php
@@ -28,7 +28,6 @@ class RandomSeeder extends Seeder
         factory(App\Attribute::class, $numberSeedEntries)->create();
         factory(App\ContextAttribute::class, $numberSeedEntries)->create();
         factory(App\Literature::class, $numberSeedEntries)->create();
-        factory(App\Geodata::class, $numberSeedEntries)->create();
         for($i = 0; $i < $numberSeedEntries; $i++){
             // creation needs to be done in a loop in order to have root-context relationships
             factory(App\Context::class)->create();


### PR DESCRIPTION
Colors can now be assigned to polygons and markers. Former used icons are no longer available as discussed in #176. When migrating existing projects, these icons will be translated into different colors.

Resolves #176 