### PR TITLE
Use updated entrust version

### DIFF
--- a/lumen/composer.json
+++ b/lumen/composer.json
@@ -11,7 +11,7 @@
         "tymon/jwt-auth": "^1.0@dev",
         "league/flysystem": " ~1.0",
         "doctrine/dbal": "^2.5",
-        "zizaco/entrust": "5.2.x-dev",
+        "zizaco/entrust": "1.8.0-alpha1",
         "phaza/laravel-postgis": "^3.1"
     },
     "require-dev": {


### PR DESCRIPTION
The entrust plugin has a release tag where we no longer need the fixes to use entrust.
`composer update` is required.

Please merge @eScienceCenter/spacialists 