### PR TITLE
Visual input feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,50 @@ var spacialistApp = angular.module('tutorialApp', ['ngAnimate', 'satellizer', 'u
 
 $.material.init();
 
+spacialistApp.service('snackbarService', [function() {
+    var defaults = {
+        autoclose: {
+            timeout: 2000,
+            htmlAllowed: true
+        },
+        persistent: {
+            timeout: 0,
+            htmlAllowed: true
+        }
+    };
+
+    function getAutocloseSnack() {
+        return angular.merge({}, defaults.autoclose);
+    }
+    function getPersistentSnack() {
+        return angular.merge({}, defaults.persistent);
+    }
+
+    var snack = {};
+    snack.snacks = {};
+
+    snack.addAutocloseSnack = function(content) {
+        var options = getAutocloseSnack();
+        options.content = content;
+        $.snackbar(options);
+    };
+    snack.addPersistentSnack = function(id, content) {
+        if(snack.snacks[id]) return;
+        var options = getPersistentSnack();
+        options.content = content;
+        snack.snacks[id] = $.snackbar(options);
+    };
+    snack.closeSnack = function(id, keepAsKey) {
+        if(!snack.snacks[id]) return;
+        snack.snacks[id].snackbar('hide');
+        if(keepAsKey !== false) {
+            delete snack.snacks[id];
+        }
+    };
+
+    return snack;
+}]);
+
 spacialistApp.service('modalService', ['$uibModal', 'httpGetFactory', function($uibModal, httpGetFactory) {
     var defaults = {
         backdrop: true,

--- a/app.js
+++ b/app.js
@@ -20,18 +20,34 @@ spacialistApp.service('snackbarService', [function() {
     function getPersistentSnack() {
         return angular.merge({}, defaults.persistent);
     }
+    function getPrefix(snackType) {
+        switch(snackType) {
+            case 'success':
+                return '<i class="material-icons text-success">check</i> ';
+            case 'info':
+                return '<i class="material-icons text-info">info_outline</i> ';
+            case 'warning':
+                return '<i class="material-icons text-warning">warning</i> ';
+            case 'error':
+                return '<i class="material-icons text-danger">error_outline</i> ';
+            default:
+                return '';
+        }
+    }
 
     var snack = {};
     snack.snacks = {};
 
-    snack.addAutocloseSnack = function(content) {
+    snack.addAutocloseSnack = function(content, snackType) {
         var options = getAutocloseSnack();
+        content = getPrefix(snackType) + content;
         options.content = content;
         $.snackbar(options);
     };
-    snack.addPersistentSnack = function(id, content) {
+    snack.addPersistentSnack = function(id, content, snackType) {
         if(snack.snacks[id]) return;
         var options = getPersistentSnack();
+        content = getPrefix(snackType) + content;
         options.content = content;
         snack.snacks[id] = $.snackbar(options);
     };

--- a/app/imageService.js
+++ b/app/imageService.js
@@ -1,4 +1,4 @@
-spacialistApp.service('imageService', ['$rootScope', 'httpPostFactory', 'httpGetFactory', 'modalService', 'Upload', '$timeout', function($rootScope, httpPostFactory, httpGetFactory, modalService, Upload, $timeout) {
+spacialistApp.service('imageService', ['$rootScope', 'httpPostFactory', 'httpGetFactory', 'modalService', 'snackbarService', 'Upload', '$timeout', function($rootScope, httpPostFactory, httpGetFactory, modalService, snackbarService, Upload, $timeout) {
     var images = {
         all: [],
         linked: [],
@@ -86,6 +86,10 @@ spacialistApp.service('imageService', ['$rootScope', 'httpPostFactory', 'httpGet
                         $timeout(function() {
                             images.upload.files.length = 0;
                         }, 1000);
+                        var content = $translate.instant('snackbar.image-upload.success', {
+                            cnt: images.upload.finished
+                        });
+                        snackbarService.addAutocloseSnack(content, 'success');
                     }
                 });
             }, function(response) {
@@ -106,7 +110,8 @@ spacialistApp.service('imageService', ['$rootScope', 'httpPostFactory', 'httpGet
         formData.append('imgId', imgId);
         formData.append('ctxId', contextId);
         httpPostFactory('api/image/link', formData, function(response) {
-            console.log("image " + imgId + " is now linked to " + contextId);
+            var content = $translate.instant('snackbar.image-linked.success');
+            snackbarService.addAutocloseSnack(content, 'success');
             images.getImagesForContext(contextId);
         });
     };
@@ -116,7 +121,8 @@ spacialistApp.service('imageService', ['$rootScope', 'httpPostFactory', 'httpGet
         formData.append('imgId', imgId);
         formData.append('ctxId', contextId);
         httpPostFactory('api/image/unlink', formData, function(response) {
-            console.log("unlinked image " + imgId + " from " + contextId);
+            var content = $translate.instant('snackbar.image-unlinked.success');
+            snackbarService.addAutocloseSnack(content, 'success');
             images.getImagesForContext(contextId);
         });
     };

--- a/app/mainService.js
+++ b/app/mainService.js
@@ -552,17 +552,12 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         } else if(elem.typeid == 1) { //find
             elem.fields = main.artifactReferences[elem.typename].slice();
         }
-        var content = 'Loading data of ' + elem.name;
-        snackbarService.addPersistentSnack('getElemData', content);
         var data = {};
         httpGetFactory('api/context/get/data/' + elem.id, function(response) {
             if(response.error) {
                 modalFactory.errorModal(response.error);
                 return;
             }
-            snackbarService.closeSnack('getElemData');
-            var content = 'Successfully loaded data of ' + elem.name;
-            snackbarService.addAutocloseSnack(content, 'warning');
             data = parseData(response.data);
             main.currentElement.data = data;
         });

--- a/app/mainService.js
+++ b/app/mainService.js
@@ -232,6 +232,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         elem.data = parsedData;
         var promise = storeElement(elem);
         promise.then(function(response){
+            var content = $translate.instant('snackbar.data-stored.success');
+            snackbarService.addAutocloseSnack(content, 'success');
             if(response.error){
                 modalFactory.errorModal(response.error);
                 return;
@@ -278,6 +280,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
                     modalFactory.errorModal(response.error);
                     return;
                 }
+                var content = $translate.instant('snackbar.element-deleted.success', { name: elem.title  });
+                snackbarService.addAutocloseSnack(content, 'success');
                 var path = response.path;
                 modalFactory.deleteModal(elem.name, function() {
                     deleteElement(elem, function() {
@@ -340,6 +344,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
                     formData.append('possibility', modalFields.value);
                     if(modalFields.description) formData.append('possibility_description', modalFields.description);
                     httpPostFactory('api/context/set/possibility', formData, function(callback) {
+                        var content = $translate.instant('snackbar.data-stored.success');
+                        snackbarService.addAutocloseSnack(content, 'success');
                         main.currentElement.data[aid+'_pos'] = modalFields.value;
                         main.currentElement.data[aid+'_desc'] = modalFields.description;
                     });

--- a/app/mainService.js
+++ b/app/mainService.js
@@ -561,8 +561,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
                 return;
             }
             snackbarService.closeSnack('getElemData');
-            var content = '<i class="material-icons fa-green">check</i> Successfully loaded data of ' + elem.name;
-            snackbarService.addAutocloseSnack(content);
+            var content = 'Successfully loaded data of ' + elem.name;
+            snackbarService.addAutocloseSnack(content, 'warning');
             data = parseData(response.data);
             main.currentElement.data = data;
         });

--- a/app/mainService.js
+++ b/app/mainService.js
@@ -1,4 +1,4 @@
-spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpPostFactory', 'httpPostPromise', 'modalFactory', '$uibModal', 'moduleHelper', 'imageService', 'literatureService', 'mapService', '$timeout', '$translate', function(httpGetFactory, httpGetPromise, httpPostFactory, httpPostPromise, modalFactory, $uibModal, moduleHelper, imageService, literatureService, mapService, $timeout, $translate) {
+spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpPostFactory', 'httpPostPromise', 'modalFactory', '$uibModal', 'moduleHelper', 'imageService', 'literatureService', 'mapService', 'snackbarService', '$timeout', '$translate', function(httpGetFactory, httpGetPromise, httpPostFactory, httpPostPromise, modalFactory, $uibModal, moduleHelper, imageService, literatureService, mapService, snackbarService, $timeout, $translate) {
     var main = {};
     var modalFields;
 
@@ -552,12 +552,17 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         } else if(elem.typeid == 1) { //find
             elem.fields = main.artifactReferences[elem.typename].slice();
         }
+        var content = 'Loading data of ' + elem.name;
+        snackbarService.addPersistentSnack('getElemData', content);
         var data = {};
         httpGetFactory('api/context/get/data/' + elem.id, function(response) {
             if(response.error) {
                 modalFactory.errorModal(response.error);
                 return;
             }
+            snackbarService.closeSnack('getElemData');
+            var content = '<i class="material-icons fa-green">check</i> Successfully loaded data of ' + elem.name;
+            snackbarService.addAutocloseSnack(content);
             data = parseData(response.data);
             main.currentElement.data = data;
         });

--- a/app/userService.js
+++ b/app/userService.js
@@ -1,4 +1,4 @@
-spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'modalFactory', '$auth', '$state', '$http', function(httpPostFactory, httpGetFactory, modalFactory, $auth, $state, $http) {
+spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'modalFactory', 'snackbarService', '$auth', '$state', '$http', function(httpPostFactory, httpGetFactory, modalFactory, snackbarService, $auth, $state, $http) {
     var user = {};
     user.currentUser = {
         permissions: {},
@@ -73,6 +73,8 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
         }
         httpPostFactory('api/user/edit', formData, function(response) {
             user.users[$index] = response.user;
+            var content = $translate.instant(snackbar.data-updated.success);
+            snackbarService.addAutocloseSnack(content, 'success');
         });
     };
 
@@ -122,7 +124,14 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
                     role[k] = response.role[k];
                 }
             }
-            if(isNew) user.roles.push(role);
+            if(isNew) {
+                user.roles.push(role);
+                var content = $translate.instant(snackbar.data-stored.success);
+                snackbarService.addAutocloseSnack(content, 'success');
+            } else {
+                var content = $translate.instant(snackbar.data-updated.success);
+                snackbarService.addAutocloseSnack(content, 'success');
+            }
         });
     }
 
@@ -156,8 +165,12 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
             // if an error occurs, readd removed permission
             if(response.error) {
                 role.permissions.push(item);
+                var content = $translate.instant(snackbar.data-updated.error);
+                snackbarService.addAutocloseSnack(content, 'error');
                 return;
             }
+            var content = $translate.instant(snackbar.data-updated.success);
+            snackbarService.addAutocloseSnack(content, 'success');
         });
     };
 
@@ -173,6 +186,8 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
         formData.append('user_id', user_id);
         httpPostFactory('api/user/add/role', formData, function(response) {
             // TODO only remove/add role if function returns no error
+            var content = $translate.instant(snackbar.data-updated.success);
+            snackbarService.addAutocloseSnack(content, 'success');
         });
     };
 
@@ -182,6 +197,8 @@ spacialistApp.service('userService', ['httpPostFactory', 'httpGetFactory', 'moda
         formData.append('user_id', user_id);
         httpPostFactory('api/user/remove/role', formData, function(response) {
             // TODO only remove/add role if function returns no error
+            var content = $translate.instant(snackbar.data-updated.success);
+            snackbarService.addAutocloseSnack(content, 'success');
         });
     };
 

--- a/css/style.css
+++ b/css/style.css
@@ -563,7 +563,7 @@ g.compound > rect {
 }
 
 /* Material Icons (should be part of the bower component) */
-ul.nav .material-icons, button .material-icons, ul.dropdown-menu .material-icons {
+ul.nav .material-icons, button .material-icons, ul.dropdown-menu .material-icons, span.snackbar-content .material-icons {
     vertical-align: bottom;
 }
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
         <link rel="stylesheet" href="bower_components/material-design-icons/iconfont/material-icons.css">
         <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/bootstrap-material-design.min.css"/>
         <link rel="stylesheet" href="bower_components/bootstrap-material-design/dist/css/ripples.min.css"/>
+        <link rel="stylesheet" href="bower_components/snackbarjs/dist/snackbar.min.css"/>
+        <link rel="stylesheet" href="bower_components/snackbarjs/themes-css/material.css"/>
         <!--<link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,300italic,300,400italic,500,500italic,700,700italic' rel='stylesheet' type='text/css'>-->
         <link rel="stylesheet" href="css/style.css" />
         <title>{{'spacialist'|translate}}</title>
@@ -159,6 +161,7 @@
         <script src="bower_components/klayjs/klay.js"></script>
         <script src="bower_components/bootstrap-material-design/dist/js/material.min.js"></script>
         <script src="bower_components/bootstrap-material-design/dist/js/ripples.min.js"></script>
+        <script src="bower_components/snackbarjs/dist/snackbar.min.js"></script>
         <script src="helpers.js"></script>
         <script src="app.js"></script>
         <script src="app/langService.js"></script>

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -183,6 +183,14 @@
     "context-menu.duplicate-element": "Element duplizieren",
     "context-menu.delete": "Löschen",
 
+    "snackbar.data-stored.success": "Daten erfolgreich gespeichert.",
+    "snackbar.data-updated.success": "Daten erfolgreich aktualisiert.",
+    "snackbar.data-updated.error": "Fehler beim Aktualisieren der Daten.",
+    "snackbar.element-deleted.success": "{{ name }} gelöscht.",
+    "snackbar.image-linked.success": "Bild mit Kontext verknüpft.",
+    "snackbar.image-unlinked.success": "Bild von Kontext gelöst.",
+    "snackbar.image-upload.success": "{{ cnt }} Bilder hochgeladen.",
+
     "dates_list": "Zeitangaben",
     "map": "Karte",
     "doc_info": "Dokument-Informationen",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -172,6 +172,14 @@
     "context-menu.duplicate-element": "Duplicate element",
     "context-menu.delete": "Delete",
 
+    "snackbar.data-stored.success": "Successfully stored data.",
+    "snackbar.data-updated.success": "Successfully updated data.",
+    "snackbar.data-updated.error": "Error while updating data.",
+    "snackbar.element-deleted.success": "{{ name }} deleted.",
+    "snackbar.image-linked.success": "Linked photo to context.",
+    "snackbar.image-unlinked.success": "Unlinked photo from context.",
+    "snackbar.image-upload.success": "{{ cnt }} photos uploaded.",
+
     "dates_list": "Dates list",
     "map": "Map",
     "doc_info": "Document",


### PR DESCRIPTION
Fix #65 
This adds a snackbar-like popup to "silent" actions to the bottom left corner of the screen. The snackbar supports several types (success, info, warning and error). We could replace the current warning popup (which does not allow any interaction (e.g. try again, ignore, ...)) with snackbars.
If you find any "silent" action which does not open a snackbar, please add a comment. Otherwise please merge @eScienceCenter/spacialists 

Hint: Snackbars should appear for store context, delete context, edit user, add/remove roles, add/remove permissions and maybe others I already forgot.