### PR TITLE
Sets the maxZoom for all layers, including the Geoserver-WMS

### DIFF
--- a/app/mapService.js
+++ b/app/mapService.js
@@ -290,6 +290,7 @@ spacialistApp.service('mapService', ['httpGetFactory', 'httpPostFactory', 'httpG
 
     function setLayerOptions(l) {
         var layerOptions = {};
+        layerOptions.maxZoom = map.map.defaults.maxZoom;
         layerOptions.noWrap = true;
         layerOptions.detectRetina = true;
         if(l.is_overlay) {


### PR DESCRIPTION
Layers like WMS from the Geoserver where only displayed to a rather low zoom level. With this change the default value that is set further above is also set for every (external) layer. Like that all layers can be viewed in high detail.

Please review @eScienceCenter/spacialists 