### PR TITLE
display spinner if tree not retrieved yet, rename new-*

### DIFF
--- a/app.js
+++ b/app.js
@@ -461,7 +461,7 @@ spacialistApp.directive('myDirective', function(httpPostFactory) {
 spacialistApp.directive('myTree', function($parse) {
     return {
         restrict: 'E',
-        templateUrl: 'includes/new-tree.html',
+        templateUrl: 'includes/tree.html',
         scope: {
             onClickCallback: '&',
             contexts: '=',

--- a/includes/tree-child.html
+++ b/includes/tree-child.html
@@ -14,6 +14,6 @@
     </span>
 </div>
 <ul ui-tree-nodes="" ng-model="contexts.children[id]" ng-if="!contexts.data[id].collapsed">
-    <li ng-repeat="id in contexts.children[id]" data-collapsed="contexts.data[id].collapsed" ng-include="'includes/new-tree-child.html'" ui-tree-node context-menu="setContextMenu">
+    <li ng-repeat="id in contexts.children[id]" data-collapsed="contexts.data[id].collapsed" ng-include="'includes/tree-child.html'" ui-tree-node context-menu="setContextMenu">
     </li>
 </ul>

--- a/includes/tree.html
+++ b/includes/tree.html
@@ -4,8 +4,9 @@
             <i class="material-icons placeholder"></i><i class="material-icons md-18">add</i>
             <span class="contextPrefix">{{'context-tree.new-toplevel-context'|translate}}</span>
         </li>
-        <li ng-repeat="id in contexts.roots" ui-tree-node data-collapsed="true" ng-include="'includes/new-tree-child.html'" context-menu="setContextMenu">
+        <li ng-repeat="id in contexts.roots" ui-tree-node data-collapsed="true" ng-include="'includes/tree-child.html'" context-menu="setContextMenu">
         </li>
+        <spinner ng-if="contexts.roots.length == 0"></spinner>
         <li class="clickable" ng-click="createNewContext()">
             <i class="material-icons placeholder"></i><i class="material-icons md-18">add</i>
             <span class="contextPrefix">{{'context-tree.new-toplevel-context'|translate}}</span>

--- a/view.html
+++ b/view.html
@@ -3,7 +3,6 @@
         <div ng-if="currentUser.permissions.view_concepts">
             <h3>{{'context-tree.heading'|translate}}</h3>
             <my-tree on-click-callback="setCurrentElement(target, elem)" contexts="contexts" element="currentElement.element" display-attribute="'name'" type-attribute="'typename'" prefix-attribute="'typelabel'" set-context-menu="newElementContextMenu"></my-tree>
-            <spinner ng-if="getContextListStarted"></spinner>
         </div>
         <div ng-if="!currentUser.permissions.view_concepts">
             <div ng-include="'layouts/restricted-access.html'"></div>


### PR DESCRIPTION
Fix #106 

This re-adds a spinner while the tree is loading. I also renamed `new-tree.html` and `new-tree-child.html`. Please review @eScienceCenter/spacialists 