### PR TITLE
Add search bar

### DIFF
--- a/app.js
+++ b/app.js
@@ -596,39 +596,6 @@ spacialistApp.filter('urlify', function() {
     };
 });
 
-spacialistApp.filter('dateBcAc', ['$q', '$translate', function($q, $translate) {
-    var bcStr = null;
-    var adStr = null;
-    var translated = false;
-
-    function appendDate(date) {
-        if(date < 0) {
-            return Math.abs(date) + " " + bcStr;
-        } else {
-            return date + " " + adStr;
-        }
-    }
-
-    filterStub.$stateful = true;
-    function filterStub(date) {
-        if(bcStr === null || adStr === null) {
-            if(!translated) {
-                translated = true;
-                $translate('bc').then(function(bc) {
-                    bcStr = bc;
-                });
-                $translate('ad').then(function(ad) {
-                    adStr = ad;
-                });
-            }
-            return date;
-        } else {
-            return appendDate(date);
-        }
-    }
-    return filterStub;
-}]);
-
 spacialistApp.filter('bytes', function() {
 	return function(bytes, precision) {
         var units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
@@ -637,98 +604,6 @@ spacialistApp.filter('bytes', function() {
 		var number = Math.floor(Math.log(bytes) / Math.log(1024));
 		return (bytes / Math.pow(1024, Math.floor(number))).toFixed(precision) +  ' ' + units[number];
 	};
-});
-
-spacialistApp.filter('overallLength', function() {
-    return function(obj) {
-        var count = 0;
-        angular.forEach(obj, function(value, key) {
-            count += value.length;
-        });
-        return count;
-    };
-});
-
-spacialistApp.filter('filterByMarkerName', function() {
-    return function(markers, search) {
-        var searchPattern = new RegExp(search, "i");
-        var tempMarkers = angular.extend({}, markers);
-        angular.forEach(tempMarkers, function(mV, mK) {
-            if(!searchPattern.test(mV.myOptions.name)) {
-                delete tempMarkers[mK];
-            }
-        });
-        return tempMarkers;
-    };
-});
-
-spacialistApp.filter('filterUnlinkedMarker', function() {
-    return function(markers, linkIds) {
-        if(linkIds.length === 0) return {};
-        var tempIds = linkIds.slice();
-        var tempMarkers = angular.extend({}, markers);
-        var linkedMarkers = {};
-        angular.forEach(tempMarkers, function(mV, mK) {
-            for(var i=0; i<tempIds.length; i++) {
-                var lV = tempIds[i];
-                if(lV == mV.id) {
-                    linkedMarkers[mK] = mV;
-                    delete tempMarkers[mK];
-                    tempIds.splice(i, 1);
-                    break;
-                }
-            }
-        });
-        return linkedMarkers;
-    };
-});
-
-spacialistApp.filter('filterLinkedMarker', function() {
-    return function(markers, linkIds) {
-        if(linkIds.length === 0) return markers;
-        var tempIds = linkIds.slice();
-        var tempMarkers = angular.extend({}, markers);
-        angular.forEach(tempMarkers, function(mV, mK) {
-            for(var i=0; i<tempIds.length; i++) {
-                var lV = tempIds[i];
-                if(lV == mV.id) {
-                    delete tempMarkers[mK];
-                    tempIds.splice(i, 1);
-                    break;
-                }
-            }
-        });
-        return tempMarkers;
-    };
-});
-
-spacialistApp.filter('linkedFilter', function() {
-    return function(imgs, linked, unlinked) {
-        var filteredImgs = [];
-        if(typeof linked === 'undefined') linked = false;
-        if(typeof unlinked === 'undefined') unlinked = false;
-        if(linked && unlinked) {
-            return filteredImgs;
-        }
-        if(!linked && !unlinked) {
-            return imgs;
-        }
-        angular.forEach(imgs, function(value, key) {
-            if(linked && typeof value.linked !== 'undefined' && value.linked > 0) {
-                filteredImgs.push(value);
-            } else if(unlinked && (typeof value.linked === 'undefined' || value.linked <= 0)) {
-                filteredImgs.push(value);
-            }
-        });
-        return filteredImgs;
-    };
-});
-
-spacialistApp.filter('contextFilter', function() {
-    return function(imgs, contexts) {
-        //TODO implement contexts (beside libraries)
-        return imgs;
-    };
 });
 
 spacialistApp.filter('truncate', function () {

--- a/app/environmentService.js
+++ b/app/environmentService.js
@@ -20,9 +20,9 @@ spacialistApp.service('environmentService', ['httpGetFactory', function(httpGetF
             env.contexts.roots = response.roots;
             env.contexts.children = response.children;
 
-
             angular.forEach(env.contexts.data, function(context) {
                 context.collapsed = true;
+                context.visible = true;
             });
         });
     }

--- a/app/mainService.js
+++ b/app/mainService.js
@@ -182,6 +182,46 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         });
     };
 
+    main.filterTree = function(elements, term) {
+        angular.forEach(elements.roots, function(r) {
+            isVisible(elements, r, term.toUpperCase());
+        });
+    };
+
+    function isVisible(elems, id, term) {
+        var noSearchTerm = !term || term.length === 0;
+        var data = elems.data;
+        var children = elems.children;
+        if(noSearchTerm) {
+            data[id].visible = true;
+            data[id].collapsed = true;
+        }
+        else if(filters(data[id], term)) {
+            data[id].visible = true;
+            data[id].collapsed = false;
+        } else {
+            data[id].visible = false;
+            data[id].collapsed = true;
+        }
+        if(children[id]) {
+            for(var i=0; i<children[id].length; i++) {
+                if(isVisible(elems, children[id][i], term)) {
+                    data[id].visible = true;
+                    if(noSearchTerm) {
+                        data[id].collapsed = true;
+                    } else {
+                        data[id].collapsed = false;
+                    }
+                }
+            }
+        }
+        return data[id].visible;
+    }
+
+    function filters(elem, term) {
+        return elem.name.toUpperCase().indexOf(term) > -1;
+    }
+
     /**
      * Stores a single element of the context tree in the database
      * @return: returns a promise which returns the ID of the newly inserted context

--- a/controllers/mainCtrl.js
+++ b/controllers/mainCtrl.js
@@ -16,6 +16,7 @@ spacialistApp.controller('mainCtrl', ['$rootScope', '$scope', 'userService', 'an
     $scope.unsetCurrentElement = mainService.unsetCurrentElement;
     $scope.analysisEntries = analysisService.entries;
     $scope.activeAnalysis = analysisService.activeAnalysis;
+    $scope.filterTree = mainService.filterTree;
     var createModalHelper = mainService.createModalHelper;
 
     $scope.storedQueries = analysisService.storedQueries;

--- a/includes/tree-child.html
+++ b/includes/tree-child.html
@@ -1,4 +1,4 @@
-<div ui-tree-handle style="display: table;">
+<div ui-tree-handle style="display: table;" ng-show="contexts.data[id].visible">
     <div style="display: table-cell;">
         <a ng-click="contexts.data[id].collapsed = !contexts.data[id].collapsed" ng-if="contexts.children[id] && contexts.children[id].length > 0" class="expandable-toggle">
             <i class="material-icons" aria-hidden="true">{{ contexts.data[id].collapsed ? 'chevron_right' : 'expand_more' }}
@@ -14,6 +14,6 @@
     </span>
 </div>
 <ul ui-tree-nodes="" ng-model="contexts.children[id]" ng-if="!contexts.data[id].collapsed">
-    <li ng-repeat="id in contexts.children[id]" data-collapsed="contexts.data[id].collapsed" ng-include="'includes/tree-child.html'" ui-tree-node context-menu="setContextMenu">
+    <li ng-repeat="id in contexts.children[id]" ng-show="contexts.data[id].visible" data-collapsed="contexts.data[id].collapsed" ng-include="'includes/tree-child.html'" ui-tree-node context-menu="setContextMenu">
     </li>
 </ul>

--- a/includes/tree.html
+++ b/includes/tree.html
@@ -4,7 +4,7 @@
             <i class="material-icons placeholder"></i><i class="material-icons md-18">add</i>
             <span class="contextPrefix">{{'context-tree.new-toplevel-context'|translate}}</span>
         </li>
-        <li ng-repeat="id in contexts.roots" ui-tree-node data-collapsed="true" ng-include="'includes/tree-child.html'" context-menu="setContextMenu">
+        <li ng-repeat="id in contexts.roots" ng-show="contexts.data[id].visible" ui-tree-node data-collapsed="true" ng-include="'includes/tree-child.html'" context-menu="setContextMenu">
         </li>
         <spinner ng-if="contexts.roots.length == 0"></spinner>
         <li class="clickable" ng-click="createNewContext()">

--- a/view.html
+++ b/view.html
@@ -2,7 +2,19 @@
     <div class="col-md-2" id="tree-container" ng-hide="activeAnalysis.isActive">
         <div ng-if="currentUser.permissions.view_concepts">
             <h3>{{'context-tree.heading'|translate}}</h3>
-            <my-tree on-click-callback="setCurrentElement(target, elem)" contexts="contexts" element="currentElement.element" display-attribute="'name'" type-attribute="'typename'" prefix-attribute="'typelabel'" set-context-menu="newElementContextMenu"></my-tree>
+            <div class="col-md-12">
+                <form class="form-horizontal">
+                    <div class="form-group">
+                        <div class="input-group">
+                            <span class="input-group-addon">
+                                <i class="material-icons">search</i>
+                            </span>
+                            <input class="form-control" type="text" ng-change="filterTree(contexts, treeSearchTerm)" ng-model="treeSearchTerm" placeholder="{{ 'search_val' | translate }}" />
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <my-tree class="col-md-12" on-click-callback="setCurrentElement(target, elem)" contexts="contexts" element="currentElement.element" display-attribute="'name'" type-attribute="'typename'" prefix-attribute="'typelabel'" set-context-menu="newElementContextMenu"></my-tree>
         </div>
         <div ng-if="!currentUser.permissions.view_concepts">
             <div ng-include="'layouts/restricted-access.html'"></div>


### PR DESCRIPTION
Fix #174 

This PR adds a search bar above the context tree. Due to the new context data layout it is only possible to keep the tree structure on search. Thus non-matching elements are still visible if one of their (grand)children is visible (aka matches the search term). Please review @eScienceCenter/spacialists 