### PR TITLE
evidence.certainty.heading changed

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -191,7 +191,7 @@
     "field-types.dimension.height-placeholder": "H",
     "field-types.dimension.depth-placeholder": "T",
     "evidence.heading": "Weiterführende Information",
-    "evidence.certainty.heading": "Konfidenz in die Wertzuweisung",
+    "evidence.certainty.heading": "Sicherheit der Angabe",
     "evidence.certainty.comment": "Kommentar",
     "evidence.certainty.save": "Speichern",
     "evidence.certainty.save+close": "Speichern und Schließen",


### PR DESCRIPTION
Changed the text for the evidence.certainty.heading from "Konfidenz in die Wertzuweisung" to "Sicherheit der Angabe".