### PR TITLE
remove placeholders from text fields

### DIFF
--- a/includes/inputFields.html
+++ b/includes/inputFields.html
@@ -6,7 +6,7 @@
             </sup>
         </label>
         <div class="col-md-{{inputWidth}}" ng-switch on="attr.datatype">
-            <input class="form-control" ng-switch-when="string" type="text" placeholder="{{ attr.val }}" id="a{{ attr.aid }}_{{ attr.oid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>
+            <input class="form-control" ng-switch-when="string" type="text" id="a{{ attr.aid }}_{{ attr.oid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>
             <input class="form-control" ng-switch-when="double" type="number" step="any" min="0" placeholder="0.0" id="a{{ attr.aid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>
             <input class="form-control" ng-switch-when="integer" type="number" step="1" placeholder="0" id="a{{ attr.aid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>
             <div ng-switch-when="percentage">
@@ -124,7 +124,7 @@
                     </div>
                 </div>
             </div>
-            <input class="form-control" ng-switch-default type="text" id="a{{ attr.aid }}_{{ attr.oid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" placeholder="{{ attr.val }}" ng-readonly="readonlyInput"/>
+            <input class="form-control" ng-switch-default type="text" id="a{{ attr.aid }}_{{ attr.oid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>
         </div>
         <div ng-if="hovered" style="position: absolute;">
             <div ng-if="isEditable" style="float: left;">


### PR DESCRIPTION
The placeholders are not necessary and are only showing the same information as the label of the input element. Hence they can be removed.

@eScienceCenter/spacialists Please review!