### PR TITLE
add reference to another context as datatype

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -244,6 +244,15 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
         });
     };
 
+    main.contextSearch = function(searchString) {
+        var formData = new FormData();
+        formData.append('val', searchString);
+        return httpPostPromise.getData('api/context/search', formData)
+        .then(function(response) {
+            return response;
+        });
+    };
+
     function isVisible(elems, id, term) {
         var noSearchTerm = !term || term.length === 0;
         var data = elems.data;
@@ -459,6 +468,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
             } else if(dType == 'epoch') {
                 if(typeof value.val != 'undefined') parsedData[index] = JSON.parse(value.val);
             } else if(dType == 'geography') {
+                parsedData[index] = value.val;
+            } else if(dType == 'context') {
                 parsedData[index] = value.val;
             } else if(dType == 'integer' || dType == 'percentage') {
                 parsedData[index] = parseInt(val);

--- a/controllers/mainCtrl.js
+++ b/controllers/mainCtrl.js
@@ -18,6 +18,7 @@ spacialistApp.controller('mainCtrl', ['$rootScope', '$scope', 'userService', 'an
     $scope.activeAnalysis = analysisService.activeAnalysis;
     $scope.availableSearchTerms = searchService.availableSearchTerms;
     $scope.filterTree = mainService.filterTree;
+    $scope.contextSearch = mainService.contextSearch;
     $scope.treeCallbacks = mainService.treeCallbacks;
     $scope.storedQueries = analysisService.storedQueries;
     var createModalHelper = mainService.createModalHelper;

--- a/includes/inputFields.html
+++ b/includes/inputFields.html
@@ -20,6 +20,13 @@
                     <span translate="context-form.fields.open-map"/>
                 </button>
             </div>
+            <div ng-switch-when="context">
+                <input class="form-control" type="text" id="a{{ attr.aid }}" placeholder="{{ 'context-form.fields.placeholder-context' | translate }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-model-options="{ debounce: 250 }" ng-readonly="readonlyInput" uib-typeahead="result as result.name for result in contextSearch($viewValue)" typeahead-min-length="3" typeahead-wait-ms="50" typeahead-loading="loadingResultsLabel" typeahead-no-results="noResultsLabel" />
+                <i ng-show="loadingResultsLabel" class="material-icons">refresh</i>
+                <div ng-show="noResultsLabel && result.name.length >= 3">
+                    <i class="material-icons md-18">clear</i> No Results Found
+                </div>
+            </div>
             <textarea class="form-control" ng-switch-when="stringf" id="a{{ attr.aid }}_{{ attr.oid }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"></textarea>
             <p class="input-group" ng-switch-when="date">
                 <input type="text" class="form-control" id="a{{ attr.aid }}_{{ attr.oid }}" uib-datepicker-popup="{{ 'date_format_lg' | translate }}" ng-change="getCurrentDate(attributeOutputs[attr.aid+'_'+attr.oid])" is-open="date.opened" datepicker-options="dateOptions" close-text="{{ 'close' | translate }}" ng-model="attributeOutputs[attr.aid+'_'+attr.oid]" ng-readonly="readonlyInput"/>

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -103,6 +103,7 @@
     "attribute.double.desc": "Eingabefeld für Zahlen (Gleitkomma)",
     "attribute.integer.desc": "Eingabefeld für Zahlen (Ganzzahl)",
     "attribute.percentage.desc": "Prozentangabe",
+    "attribute.context.desc": "Kontext",
     "attribute.string-sc.desc": "Einfachauswahl als Dropdown",
     "attribute.string-mc.desc": "Mehrfachauswahl als Dropdown",
     "attribute.epoch.desc": "Zeitspanne & Epochenauswahl",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -93,6 +93,7 @@
     "attribute.double.desc": "Numeric Input (Floating Point)",
     "attribute.integer.desc": "Numeric Input (Integer)",
     "attribute.percentage.desc": "Percentage Slider",
+    "attribute.context.desc": "Context",
     "attribute.string-sc.desc": "Single Choice as Dropdown",
     "attribute.string-mc.desc": "Multiple Choice as Dropdown",
     "attribute.epoch.desc": "Time Period And Epoch",

--- a/lumen/app/Http/routes.php
+++ b/lumen/app/Http/routes.php
@@ -89,6 +89,7 @@ $app->group(['middleware' => ['before' => 'jwt.auth', 'after' => 'jwt.refresh']]
     $app->post('literature/edit', 'LiteratureController@edit');
     $app->post('literature/import/bib', 'LiteratureController@importBibtex');
     $app->post('editor/search', 'ContextController@search');
+    $app->post('context/search', 'ContextController@searchContext');
     $app->post('editor/contexttype/add', 'ContextController@addContextType');
     $app->post('editor/contexttype/edit', 'ContextController@editContextType');
     $app->post('editor/contexttype/attribute/add', 'ContextController@addAttributeToContextType');


### PR DESCRIPTION
Fix #230 

With this PR it is possible to reference a context in another context's attribute. On our testing machine I already added an attribute with the new `context` datatype and added it to the Library contexttype.
Please review @eScienceCenter/spacialists 