### PR TITLE
Fix date (attribute type)

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -475,6 +475,8 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
                 parsedData[index] = parseInt(val);
             } else if(dType == 'double') {
                 parsedData[index] = parseFloat(val);
+            } else if(dType == 'date') {
+                parsedData[index] = new Date(value.dt_val);
             } else {
                 parsedData[index] = val;
             }

--- a/controllers/mainCtrl.js
+++ b/controllers/mainCtrl.js
@@ -20,6 +20,7 @@ spacialistApp.controller('mainCtrl', ['$rootScope', '$scope', 'userService', 'an
     $scope.filterTree = mainService.filterTree;
     $scope.contextSearch = mainService.contextSearch;
     $scope.treeCallbacks = mainService.treeCallbacks;
+    $scope.datepickerOptions = mainService.datepickerOptions;
     $scope.storedQueries = analysisService.storedQueries;
     var createModalHelper = mainService.createModalHelper;
 

--- a/lumen/app/Http/Controllers/ContextController.php
+++ b/lumen/app/Http/Controllers/ContextController.php
@@ -1169,6 +1169,8 @@ class ContextController extends Controller {
                         if($parsed !== -1) {
                             $attrValue->geography_val = $parsed;
                         }
+                    } else if($datatype == 'date') {
+                        $attrValue->dt_val = $value;
                     } else {
                         $attrValue->str_val = $value;
                     }

--- a/lumen/database/migrations/2017_06_23_122655_set_dt_val_to_date.php
+++ b/lumen/database/migrations/2017_06_23_122655_set_dt_val_to_date.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\AttributeValue;
+use App\Attribute;
+
+class SetDtValToDate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $storedValues = [];
+        $types = Attribute::where('datatype', '=', 'date')->get();
+        foreach($types as $t) {
+            $values = AttributeValue::where('attribute_id', '=', $t->id)->get();
+            foreach($values as $v) {
+                $storedValues[] = ['id' => $v->id, 'value' => $v->str_val];
+            }
+        }
+        Schema::table('attribute_values', function (Blueprint $table) {
+            $table->dropColumn('dt_val');
+        });
+        Schema::table('attribute_values', function (Blueprint $table) {
+            $table->date('dt_val')->nullable();
+        });
+        foreach($storedValues as $sv) {
+            $val = str_replace('"', '', $sv['value']);
+            $date = date_format(new DateTime($val), 'Y-m-d');
+            AttributeValue::where('id', '=', $sv['id'])->update(['dt_val' => $date]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $storedValues = [];
+        $values = AttributeValue::whereNotNull('dt_val')->get();
+        foreach($values as $v) {
+            $storedValues[] = ['id' => $v->id, 'value' => $v->dt_val];
+        }
+        Schema::table('attribute_values', function (Blueprint $table) {
+            $table->dropColumn('dt_val');
+        });
+        Schema::table('attribute_values', function (Blueprint $table) {
+            $table->timestampTz('dt_val')->nullable();
+        });
+        foreach($storedValues as $sv) {
+            $date = new DateTime($sv['value']);
+            AttributeValue::where('id', '=', $sv['id'])->update(['str_val' => $date]);
+        }
+    }
+}


### PR DESCRIPTION
Fix #243 

The old column datatype is `timestamp with time zone`, but we are only interested in the date, not the time. Therefore I "changed" the type from `ts /w tz` to `date`. I also had to adjust the store and load methods, because dates were stored in `str_val`, not in `dt_val` :roll_eyes: 

Please review @eScienceCenter/spacialists (don't forget to run `php artisan migrate`)
fyi @DavidKi