### PR TITLE
Updated style to increase height of progress bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -282,6 +282,10 @@ ol li.list-group-item {
     padding-top: 10px;
 }
 
+.progress {
+    height: 20px !important;}
+}
+
 .external-container {
     position: relative;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -283,7 +283,7 @@ ol li.list-group-item {
 }
 
 .progress {
-    height: 20px !important;}
+    height: 20px !important;
 }
 
 .external-container {


### PR DESCRIPTION
Currently, the progress, which we are using to register confidence within the sources popup is very slim. This gives it a sufficient height to work with.

@eScienceCenter/spacialists please review and merge