### PR TITLE
Restrict leaflet to 1.0.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "lodash": "^4.16.0",
     "ng-file-upload": "^12.2.9",
     "angular-ui-tree": "^2.22.0",
-    "leaflet": "^1.0.0",
+    "leaflet": "~1.0.0",
     "leaflet-draw": "^0.4.9",
     "angular-simple-logger": "^0.1.7",
     "ui-leaflet": "^2.0.0",


### PR DESCRIPTION
Leaflet 1.1 is released and has some breaking API changes. With this PR max leaflet version is 1.0.x. Please merge @eScienceCenter/spacialists 