### PR TITLE
add missing dimension reference

### DIFF
--- a/controllers/mainCtrl.js
+++ b/controllers/mainCtrl.js
@@ -23,6 +23,7 @@ spacialistApp.controller('mainCtrl', ['$rootScope', '$scope', 'userService', 'an
     $scope.datepickerOptions = mainService.datepickerOptions;
     $scope.storedQueries = analysisService.storedQueries;
     $scope.editMode = mainService.editMode;
+    $scope.dimensionUnits = mainService.dimensionUnits;
     var createModalHelper = mainService.createModalHelper;
 
     $scope.newElementContextMenu = [


### PR DESCRIPTION
The unit of the `dimension` attribute type was missing in the context properties tab. Please review @eScienceCenter/spacialists 