### PR TITLE
3D Viewer updates

### DIFF
--- a/app/dataEditorService.js
+++ b/app/dataEditorService.js
@@ -67,7 +67,7 @@ spacialistApp.service('dataEditorService', ['httpGetFactory', 'httpGetPromise', 
             if(!response.error) {
                 editor.ct.attributes[i].position--;
                 editor.ct.attributes[i-1].position++;
-                editor.ct.attributes.swap(i, i-1);
+                swap(editor.ct.attributes, i, i-1);
             }
         });
     };
@@ -83,7 +83,7 @@ spacialistApp.service('dataEditorService', ['httpGetFactory', 'httpGetPromise', 
             if(!response.error) {
                 editor.ct.attributes[i].position++;
                 editor.ct.attributes[i+1].position--;
-                editor.ct.attributes.swap(i, i+1);
+                swap(editor.ct.attributes, i, i+1);
             }
         });
     };

--- a/controllers/threeCtrl.js
+++ b/controllers/threeCtrl.js
@@ -64,9 +64,9 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
             },
             function(event) { // onProgress
                 if(event.lengthComputable) {
-                    $scope.status.progress = event.loaded / event.total * 100;
+                    $scope.status.progress = Math.round(event.loaded / event.total * 100);
                     $scope.$apply();
-                    console.log('Downloaded ' + Math.round($scope.status.progress) + '% of model');
+                    console.log('Downloaded ' + $scope.status.progress + '% of model');
                 }
             },
             function(event) { // onError
@@ -91,7 +91,7 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
                 var parent = object;
                 do {
                     children = parent.children;
-                    if(!children) break;
+                    if(!children || !children[0]) break;
                     material = children[0].material;
                     parent = children[0];
                 } while(!material);
@@ -101,7 +101,16 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
     			scene.add(object);
                 sceneObjects.push(object);
                 onWindowResize();
-    		} );
+    		},
+            function(event) { // onProgress
+                if(event.lengthComputable) {
+                    $scope.status.progress = Math.round(event.loaded / event.total * 100);
+                    $scope.$apply();
+                    console.log('Downloaded ' + $scope.status.progress + '% of model');
+                }
+            },
+            function(event) { // onError
+            });
         } else if(extension == 'obj') { // obj
             var sep = fileUrl.lastIndexOf('/')+1;
             var path = fileUrl.substr(0, sep);

--- a/controllers/threeCtrl.js
+++ b/controllers/threeCtrl.js
@@ -11,6 +11,9 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
     var measureLine;
     var ts = Date.now();
 
+    $scope.status = {
+        progress: 0
+    };
     $scope.points = 0;
     $scope.measurementEnabled = false;
     $scope.props = {
@@ -48,16 +51,27 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
     };
 
     function loadObj(path, objFile, materials) {
-        var objLoader = new THREE.OBJLoader();
-        objLoader.setPath(path);
+        var objLoader = new THREE.OBJLoader2();
         if(materials) {
-            objLoader.setMaterials(materials);
+            objLoader.setMaterials(materials.materials);
         }
-        objLoader.load(objFile, function(object) {
-            scene.add(object);
-            sceneObjects.push(object);
-            onWindowResize();
-        }, function() {}, function(xhr) {});
+        objLoader.setPath(path);
+        objLoader.load(objFile,
+            function(object) { // onSuccess
+                scene.add(object);
+                sceneObjects.push(object);
+                onWindowResize();
+            },
+            function(event) { // onProgress
+                if(event.lengthComputable) {
+                    $scope.status.progress = event.loaded / event.total * 100;
+                    $scope.$apply();
+                    console.log('Downloaded ' + Math.round($scope.status.progress) + '% of model');
+                }
+            },
+            function(event) { // onError
+            }
+        );
     }
 
     function init() {

--- a/helpers.js
+++ b/helpers.js
@@ -1,9 +1,8 @@
-Array.prototype.swap = function(a, b) {
-    var t = this[a];
-    this[a] = this[b];
-    this[b] = t;
-    return this;
-};
+function swap(a, i, j) {
+    var t = a[i];
+    a[i] = a[j];
+    a[j] = t;
+}
 
 function getCurrentDeviceClass() {
     return $('#current-device-class').find('div:visible').first().attr('id');

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
             <div ui-view class="col-md-12"></div>
         </div>
         <script src="bower_components/three.js/build/three.min.js"></script>
-        <script src="bower_components/three.js/examples/js/loaders/ColladaLoader.js"></script>
+        <script src="bower_components/three.js/examples/js/loaders/ColladaLoader2.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/OBJLoader2.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/MTLLoader.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/DDSLoader.js"></script>

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
         </div>
         <script src="bower_components/three.js/build/three.min.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/ColladaLoader.js"></script>
-        <script src="bower_components/three.js/examples/js/loaders/OBJLoader.js"></script>
+        <script src="bower_components/three.js/examples/js/loaders/OBJLoader2.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/MTLLoader.js"></script>
         <script src="bower_components/three.js/examples/js/loaders/DDSLoader.js"></script>
         <script src="bower_components/three.js/examples/js/controls/OrbitControls.js"></script>

--- a/layouts/image-properties.html
+++ b/layouts/image-properties.html
@@ -58,6 +58,11 @@
                 <p>
                     Gemessene Länge: {{ props.length }}m
                 </p>
+                <div class="progress animated-item" ng-if="status.progress < 100">
+                    <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" style="width: {{ status.progress }}%">
+                        {{ status.progress }}%
+                    </div>
+                </div>
             </div>
             <div ng-switch-default ng-controller="pdfCtrl">
                 <div ng-if="modalOptions.img.filename.endsWith('.md')">


### PR DESCRIPTION
I updated to newer versions of our used loaders. They are now both capable of listen for an onProgress event (download). The OBJLoader can now also display several objects instead of only one.
I had to remove our custom `swap` method from `Array`, because three.js doesn't check for own properties which lead to `XY is undefined` error messages.

The onProgress event listener is not perfect, because it only tracks the progress of the file download. Parsing the model consumes more time and blocks the browser UI. Thus we can display the download progress, but not the whole loading time. Consider this limitation before merging it.

Please review @eScienceCenter/spacialists 