### PR TITLE
int values are stored in int_val, not str_val anymore

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -477,7 +477,7 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
             } else if(dType == 'context') {
                 parsedData[index] = value.val;
             } else if(dType == 'integer' || dType == 'percentage') {
-                parsedData[index] = parseInt(val);
+                parsedData[index] = parseInt(value.int_val);
             } else if(dType == 'boolean') {
                 parsedData[index] = (parseInt(value.int_val) != 0);
             } else if(dType == 'double') {


### PR DESCRIPTION
On current master int values are stored in the db, but not displayed in the UI. The problem is that on ui-side JS tries to parse `str_val` as int, but in the db we moved int values from `str_val` to `int_val`.
Please review @eScienceCenter/spacialists 