### PR TITLE
Allow different storage types (e.g. (S)FTP, AWS)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,8 +151,8 @@ JWT_REFRESH_TTL=* #the ttl (in minutes) in which you can generate a new token. D
 JWT_BLACKLIST_GRACE_PERIOD=* #a time span in seconds which allows you to use the same token several times in this time span without blacklisting it (good for async api calls)
 ```
 
-#### Protected Files
-Your uploaded files are stored in a public folder. To increase security it is recommended to define a random path in your `.env` file. The matching key is `SP_FILE_PATH`. You also have to create the path on your system (Do not actually create the last part of the path, you have to create it as a softlink later).
+#### Protected Files (Local driver only)
+If you use the local (public) filesystem driver, your uploaded files are stored in a public folder. To increase security it is recommended to define a random path in your `.env` file. The matching key is `SP_FILE_PATH`. You also have to create the path on your system (Do not actually create the last part of the path, you have to create it as a softlink later).
 
 **Example:**
 ```bash
@@ -182,15 +182,26 @@ Lumen (5.3.2) (Laravel Components 5.3.*)
 #### External storage
 Lumen supports different filesystems. Some of the most popular adapters:
 - AWS S3
-- Dropbox
-- Rackspace
 - SFTP
-- WebDAV
+- Dropbox (Not yet supported by Spacialist)
+- Rackspace (Not yet supported by Spacialist)
+- WebDAV (Not yet supported by Spacialist)
 
-To enable one of these adapters you need to add the driver to your `composer.json`. For a list of available adapters, see [here](https://github.com/thephpleague/flysystem). To use one of the drivers add it to the `config => filesystems => disks` array in `bootstrap/app.php`. The `local` driver is already configured and set as default. To switch to another default adapter simply add the configuration to the `disks` array and set the `default` to the key of your added driver.
+To enable one of these adapters (AWS, (S)FTP are enabled by default) you need to add the driver to your `composer.json`. For a list of available adapters, see [here](https://github.com/thephpleague/flysystem). To use one of the drivers add it to the `config => filesystems => disks` array in `bootstrap/app.php`. The `local` and `public` drivers are already configured and `public` is set as default. To switch to another default adapter simply add the configuration to the `disks` array and set the `default` to the key of your added driver.
+Instead of manipulating the `default` key in `bootstrap/app.php` one can set the `SP_FILE_DRIVER` key in the `.env` file. If not provided, it defaults to the `default` setting.
+
+##### Limitations
+Some drivers do not support to create accessible URLs. Thus, there is a new method which creates an URL. Unfortunately, this method does not respect the `ProxyPass` setting (`ProxyPass "/Spacialist/api" "http://spacialist-lumen.tld"`) in the apache config file. To ensure that the correct URL is returned, an additional `env` key (`SP_API_PREFIX`) is added to the `.env` file. It must contain the path to the API defined in the `ProxyPass` setting, but without the name of the cloned folder. E.g. if your ProxyPass is the one above, the API path would be `/api`. However, the `SP_API_PREFIX` must not start with a / and must end with a /. In this example the result would be:
+```bash
+SP_API_PREFIX=api/
+```
+If not provided, it defaults to `api/`.
+
+The following drivers do not support URLs:
+- (S)FTP
 
 For further informations regarding the cotent of `config => filesystems => disks` see these documentations:
-- [Laravel Filesystem](https://laravel.com/docs/5.4/filesystem)
+- [Laravel Filesystem](https://laravel.com/docs/5.3/filesystem)
 - [Laravel Sample Config](https://github.com/laravel/laravel/blob/master/config/filesystems.php)
 - [Flysystem Github Page](https://github.com/thephpleague/flysystem)
 - [Flysystem Laravel Integration](https://github.com/GrahamCampbell/Laravel-Flysystem)

--- a/controllers/pdfCtrl.js
+++ b/controllers/pdfCtrl.js
@@ -1,28 +1,7 @@
 spacialistApp.controller('pdfCtrl', ['$scope', 'httpGetFactory', function($scope, httpGetFactory) {
-    $scope.fileLoaded = false;
-    $scope.isPreview = false;
-    $scope.isMd = false;
-    $scope.isCsv = false;
     $scope.status = {
         progress: 0
     };
-
-    $scope.togglePreview = function() {
-        $scope.isPreview = !$scope.isPreview;
-        $scope.isMd = !$scope.isMd;
-    };
-
-    $scope.toggleCsv = function(url) {
-        $scope.isPreview = !$scope.isPreview;
-        $scope.isCsv = !$scope.isCsv;
-        if($scope.isCsv) {
-            httpGetFactory(url, function(response) {
-                $scope.csvData = response;
-            });
-        } else {
-            delete $scope.csvData;
-        }
-    }
 
     $scope.onProgress = function(event) {
         $scope.status.progress = Math.round(event.loaded / event.total * 100);

--- a/controllers/threeCtrl.js
+++ b/controllers/threeCtrl.js
@@ -42,9 +42,9 @@ spacialistApp.controller('threeCtrl', ['$scope', function($scope) {
         length: 0.0
     };
 
-    $scope.initThree = function(url) {
+    $scope.initThree = function(url, filename) {
         fileUrl = url;
-        extension = url.substr(url.lastIndexOf('.')+1);
+        extension = filename.substr(filename.lastIndexOf('.')+1);
         init();
         animate();
     };

--- a/layouts/pdf.html
+++ b/layouts/pdf.html
@@ -19,4 +19,3 @@
     </button>
     <input type="text" min="1" ng-model="pageNum"><span>/{{pageCount}}</span>
 </nav>
-<canvas id="pdf-canvas" class="rotate0"></canvas>

--- a/lumen/app/Helpers.php
+++ b/lumen/app/Helpers.php
@@ -32,7 +32,14 @@ class Helpers {
     }
 
     public static function getFullFilePath($filename) {
-        return Storage::disk(Helpers::getDisk())->url($filename);
+        try {
+            return Storage::disk(Helpers::getDisk())->url($filename);
+        } catch(\RuntimeException $e) {
+            // If ->url() is not supported by the storage driver/disk,
+            // a RuntimeException is thrown. Return url for file link route
+            $route = route('fileLink', ['filename' => $filename]);
+            return $route;
+        }
     }
 
     public static function getStorageFilePath($filename) {

--- a/lumen/app/Helpers.php
+++ b/lumen/app/Helpers.php
@@ -52,7 +52,7 @@ class Helpers {
     }
 
     public static function getStorageFilePath($filename) {
-        return Storage::url(env('SP_FILE_PATH') .'/'. $filename);
+        return Storage::url($filename);
     }
 
     public static function computeCitationKey($l) {

--- a/lumen/app/Helpers.php
+++ b/lumen/app/Helpers.php
@@ -27,8 +27,12 @@ class Helpers {
         }
     }
 
+    public static function getDisk() {
+        return env('SP_FILE_DRIVER', config('filesystems.default'));
+    }
+
     public static function getFullFilePath($filename) {
-        return Storage::disk('public')->url(env('SP_FILE_PATH') .'/'. $filename);
+        return Storage::disk(Helpers::getDisk())->url($filename);
     }
 
     public static function getStorageFilePath($filename) {

--- a/lumen/app/Helpers.php
+++ b/lumen/app/Helpers.php
@@ -38,6 +38,15 @@ class Helpers {
             // If ->url() is not supported by the storage driver/disk,
             // a RuntimeException is thrown. Return url for file link route
             $route = route('fileLink', ['filename' => $filename]);
+            $base = url("");
+            // We want to remove trailing / as well
+            if(!Helpers::endsWith($base, '/')) {
+                $base .= '/';
+            }
+            // remove base url
+            $route = substr($route, strlen($base));
+            // add api prefix to route url
+            $route = env('SP_API_PREFIX', 'api/') . $route;
             return $route;
         }
     }

--- a/lumen/app/Http/Controllers/FileController.php
+++ b/lumen/app/Http/Controllers/FileController.php
@@ -342,7 +342,8 @@ class FileController extends Controller
 
         $file = $request->file('file');
         $filename = $file->getClientOriginalName();
-        $filehandle = fopen($file->getRealPath(), 'r');
+        $realPath = $file->getRealPath();
+        $filehandle = fopen($realPath, 'r');
         Storage::disk(Helpers::getDisk())->put(
             $filename,
             $filehandle
@@ -362,25 +363,25 @@ class FileController extends Controller
             $cleanName = substr($filename, 0, strlen($filename)-strlen($ext)-1);
             $thumbName = $cleanName . $THUMB_SUFFIX . $EXP_SUFFIX;
 
-            $imageInfo = getimagesize($fileUrl);
+            $imageInfo = getimagesize($realPath);
             $width = $imageInfo[0];
             $height = $imageInfo[1];
             $mime = $imageInfo[2];//$imageInfo['mime'];
             if($width > $THUMB_WIDTH) {
                 switch($mime) {
                     case IMAGETYPE_JPEG:
-                        $image = imagecreatefromjpeg($fileUrl);
+                        $image = imagecreatefromjpeg($realPath);
                         break;
                     case IMAGETYPE_PNG:
-                        $image = imagecreatefrompng($fileUrl);
+                        $image = imagecreatefrompng($realPath);
                         break;
                     case IMAGETYPE_GIF:
-                        $image = imagecreatefromgif($fileUrl);
+                        $image = imagecreatefromgif($realPath);
                         break;
                     default:
                         //echo "is of UNSUPPORTED type " . $imageInfo['mime'];
                         // use imagemagick to convert from unsupported file format to jpg, which is supported by native php
-                        $im = new Imagick($fileUrl);
+                        $im = new Imagick($realPath);
                         $fileUrl = $url . '/' . $cleanName . $EXP_SUFFIX;
                         $im->setImageFormat($EXP_FORMAT);
                         $im->writeImage($fileUrl);

--- a/lumen/app/Http/Controllers/FileController.php
+++ b/lumen/app/Http/Controllers/FileController.php
@@ -68,14 +68,11 @@ class FileController extends Controller
         $mimeType = $file->mime_type;
         $isImage = substr($mimeType, 0, strlen($this->imageMime)) === $this->imageMime;
         if(!$isImage) return null;
-        $url = Helpers::getStorageFilePath($file->filename);
-        if(Helpers::startsWith($url, '/')) {
-            $url = substr($url, 1);
-        }
-        if(!\Illuminate\Support\Facades\File::exists($url)) {
+        $disk = Helpers::getDisk();
+        if(!Storage::disk($disk)->exists($file->filename)) {
             return null;
         }
-        $data = new PelDataWindow(file_get_contents($url));
+        $data = new PelDataWindow(Storage::disk($disk)->get($file->filename));
         if(PelJpeg::isValid($data)) {
             $jpg = new PelJpeg();
             $jpg->load($data);

--- a/lumen/app/Http/Controllers/FileController.php
+++ b/lumen/app/Http/Controllers/FileController.php
@@ -232,6 +232,7 @@ class FileController extends Controller
     }
 
     public function getFileFromLink($filename) {
+        $filename = urldecode($filename);
         $file = File::where('name', $filename)->orWhere('thumb', $filename)->first();
         if(isset($file)) {
             return response(Storage::disk(Helpers::getDisk())->get($file->name))

--- a/lumen/app/Http/Controllers/FileController.php
+++ b/lumen/app/Http/Controllers/FileController.php
@@ -231,6 +231,15 @@ class FileController extends Controller
         return response()->json($this->getFileById($id));
     }
 
+    public function getFileFromLink($filename) {
+        $file = File::where('name', $filename)->orWhere('thumb', $filename)->first();
+        if(isset($file)) {
+            return response(Storage::disk(Helpers::getDisk())->get($file->name))
+                ->header('Content-Type', $file->mime_type);
+        }
+        return '';
+    }
+
     public function getAvailableTags() {
         $tagObj = Preference::where('label', 'prefs.tag-root')->value('default_value');
         $tagUri = json_decode($tagObj)->uri;

--- a/lumen/app/Http/Controllers/FileController.php
+++ b/lumen/app/Http/Controllers/FileController.php
@@ -343,6 +343,23 @@ class FileController extends Controller
 
         $file = $request->file('file');
         $filename = $file->getClientOriginalName();
+        $fileext = $file->getClientOriginalExtension();
+        // Compute length of extension + separator ('.')
+        // Only actual set length > 0 and add separator if an extension is found
+        $extlen = 0;
+        if(strlen($fileext) > 0) {
+            $extlen = strlen($fileext) + 1;
+        }
+        // Cut off extension + separator '.'
+        $withoutExt = substr($filename, 0, strlen($filename)-$extlen);
+        $nameCtr = 1;
+        $disk = Helpers::getDisk();
+        // Check if file with name already exists, if so append counter
+        // until name is unique
+        while(Storage::disk($disk)->exists($filename)) {
+            $filename = $withoutExt . "-$nameCtr" . ".$fileext";
+            $nameCtr++;
+        }
         $realPath = $file->getRealPath();
         $filehandle = fopen($realPath, 'r');
         Storage::disk(Helpers::getDisk())->put(

--- a/lumen/app/Http/routes.php
+++ b/lumen/app/Http/routes.php
@@ -17,6 +17,13 @@ use Illuminate\Http\Request;
 $app->get('/', function () use ($app) {
     return $app->version();
 });
+// needed to display files from servers, that do not
+// support Storage::url (e.g. (s)ftp), without middleware,
+// because ng-src can not set auth token
+$app->get('file/{filename}/link', [
+    'uses' => 'FileController@getFileFromLink',
+    'as' => 'fileLink'
+]);
 
 $app->post('user/login', 'UserController@login');
 

--- a/lumen/bootstrap/app.php
+++ b/lumen/bootstrap/app.php
@@ -25,7 +25,7 @@ $app = new Laravel\Lumen\Application(
 
 config([
     "filesystems" => [
-        'default' => 'local',
+        'default' => 'public',
         'disks' => [
             'local' => [
                 'driver' => 'local',

--- a/lumen/bootstrap/app.php
+++ b/lumen/bootstrap/app.php
@@ -33,8 +33,8 @@ config([
             ],
             'public' => [
                 'driver' => 'local',
-                'root' => app()->basePath('/public/storage'),
-                'url' => './lumen/public/storage',
+                'root' => app()->basePath('/public/storage') . '/' . env('SP_FILE_PATH'),
+                'url' => './lumen/public/storage' . '/' . env('SP_FILE_PATH'),
                 'visibility' => 'public',
             ],
         ],

--- a/lumen/bootstrap/app.php
+++ b/lumen/bootstrap/app.php
@@ -108,6 +108,7 @@ $app->register(App\Providers\AppServiceProvider::class);
 $app->register(Tymon\JWTAuth\Providers\LumenServiceProvider::class);
 $app->register(Zizaco\Entrust\EntrustServiceProvider::class);
 $app->register(Phaza\LaravelPostgis\DatabaseServiceProvider::class);
+$app->register(Neoxia\Filesystem\SftpServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------

--- a/lumen/composer.json
+++ b/lumen/composer.json
@@ -15,7 +15,8 @@
         "phaza/laravel-postgis": "^3.1",
         "renanbr/bibtex-parser": "^0.3",
         "lsolesen/pel": "^0.9.6",
-        "wapmorgan/unified-archive": "^0.0.10"
+        "wapmorgan/unified-archive": "^0.0.10",
+        "neoxia/laravel-sftp": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/modals/file.html
+++ b/modals/file.html
@@ -33,7 +33,7 @@
                 </video>
             </div>
             <div class="hg-100" ng-switch-when="3d" ng-controller="threeCtrl">
-                <div class="hg-100" id="threejs-container" ng-init="initThree($ctrl.file.url)">
+                <div class="hg-100" id="threejs-container" ng-init="initThree($ctrl.file.url, $ctrl.file.filename)">
                     <div style="position: absolute; top: 10px; left: 10px;">
                         <button class="btn btn-primary" style="display: block;" ng-click="zoomOut()"><i class="material-icons">zoom_out</i></button>
                         <button class="btn btn-primary" style="display: block;" ng-click="zoomIn()"><i class="material-icons">zoom_in</i></button>

--- a/modals/file.html
+++ b/modals/file.html
@@ -299,14 +299,16 @@
                     </td>
                 </tr>
             </table>
-            <button type="button" class="btn btn-default" ng-click="showAllExif=!showAllExif">
-                <span ng-show="!showAllExif">
-                    <span translate="files.exif.show-all"></span> <i class="material-icons">arrow_drop_down</i>
-                </span>
-                <span ng-show="showAllExif">
-                    <span translate="files.exif.hide-all"></span> <i class="material-icons">arrow_drop_up</i>
-                </span>
-            </button>
+            <div ng-if="$ctrl.file.exif">
+                <button type="button" class="btn btn-default" ng-click="showAllExif=!showAllExif">
+                    <span ng-show="!showAllExif">
+                        <span translate="files.exif.show-all"></span> <i class="material-icons">arrow_drop_down</i>
+                    </span>
+                    <span ng-show="showAllExif">
+                        <span translate="files.exif.hide-all"></span> <i class="material-icons">arrow_drop_up</i>
+                    </span>
+                </button>
+            </div>
             <table class="table-striped" ng-if="showAllExif">
                 <tr ng-repeat="(key, e) in $ctrl.file.exif">
                     <td>


### PR DESCRIPTION
This PR replaces the (mostly used) static storage driver with a dynamic one. Some of the required steps are already described in the [INSTALL.md](https://github.com/eScienceCenter/Spacialist/blob/master/INSTALL.md#external-storage). Additionally, a new `env` setting `SP_FILE_DRIVER` is required. It has to be set to one of the keys/names in the `config>filesystems>disks` array in `bootstrap/app.php`.
Supported (useful) drivers are
- AWS
- (S)FTP
- WebDAV

Please feel free to setup a (s)ftp or aws driver an test it. If there are no major issues, this could be merged in 0.5. :) @eScienceCenter/spacialists 