### PR TITLE
Added helper icon

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -80,7 +80,7 @@
                     <a target="_blank" href="https://github.com/eScienceCenter/Spacialist/wiki/User-manual">
                         <i class="material-icons">help</i>
                     </a>
-                </li>            
+                </li>
 	    </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li ng-if="$ctrl.user.user.name">

--- a/templates/header.html
+++ b/templates/header.html
@@ -76,7 +76,12 @@
                         </li>
                     </ul>
                 </li>
-            </ul>
+                <li>
+                    <a target="_blank" href="https://github.com/eScienceCenter/Spacialist/wiki/User-manual">
+                        <i class="material-icons">help</i>
+                    </a>
+                </li>            
+	    </ul>
             <ul class="nav navbar-nav navbar-right">
                 <li ng-if="$ctrl.user.user.name">
                     <a href="" ng-click="$ctrl.logoutUser()">


### PR DESCRIPTION
So that the users can easily find the manual, which is provided through the GitHub-Wiki, I've added a helper-icon at the farthest right of the menu bar.

![bildschirmfoto von 2017-12-14 10-30-37](https://user-images.githubusercontent.com/6630811/33985275-6cc80212-e0ba-11e7-942a-34e5a9490bc9.png)

@eScienceCenter/spacialists please review and merge once ok