### PR TITLE
changed the logout button further right

### DIFF
--- a/templates/header.html
+++ b/templates/header.html
@@ -35,11 +35,6 @@
                 </li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-                <li ng-if="$ctrl.user.user.name">
-                    <a href="" ng-click="$ctrl.logoutUser()">
-                        <i class="material-icons">power_settings_new</i> {{ $ctrl.user.user.name }}
-                    </a>
-                </li>
                 <li class="dropdown" uib-dropdown>
                     <a href="#" class="dropdown-toggle" uib-dropdown-toggle data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                         <i class="material-icons">build</i>
@@ -139,6 +134,11 @@
                             </a>
                         </li>
                     </ul>
+                </li>
+                <li ng-if="$ctrl.user.user.name">
+                    <a href="" ng-click="$ctrl.logoutUser()">
+                        <i class="material-icons">power_settings_new</i> {{ $ctrl.user.user.name }}
+                    </a>
                 </li>
                 <li>
                     <a target="_blank" href="https://github.com/eScienceCenter/Spacialist/wiki/User-manual">


### PR DESCRIPTION
The tools and settings menus seem to me crammed between the logout button and the language settings. I would suggest to place the logout botton further right, maybe even to the right of the helper icon. Like that the UI features the two important drop-down menus more prominently.