### PR TITLE
changed color to background for elemnts in the tree

### DIFF
--- a/app/mainService.js
+++ b/app/mainService.js
@@ -513,7 +513,7 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
      */
     main.getColorForId = function(id) {
         var sat = '90%';
-        var lgt = '65%';
+        var lgt = '70%';
         var hue = 0;
         if(typeof id !== 'undefined') {
             var newId = '';
@@ -528,7 +528,7 @@ spacialistApp.service('mainService', ['httpGetFactory', 'httpGetPromise', 'httpP
             lgt
         ];
         return {
-            'color': 'hsl(' + hsl.join(',') + ')'
+            'background-color': 'hsl(' + hsl.join(',') + ')'
         };
     };
 

--- a/includes/tree-child.html
+++ b/includes/tree-child.html
@@ -10,7 +10,7 @@
     <span ui-sref="root.spacialist.context.data({id: r.id })" ui-sref-active="selected-leaf-child" style="display: table-cell; padding-left: 4px;">
         <i class="material-icons md-18" aria-hidden="true" ng-if="contexts.data[r.id].type == 0">account_balance</i>
         <i class="material-icons md-18" aria-hidden="true" ng-if="contexts.data[r.id].type == 1">spa</i>
-        <span ng-style="options.getColorForId(contexts.data[r.id].uri)" ng-bind-html="contexts.data[r.id].name | sphighlight:highlight"></span> <span ng-if="contexts.data[r.id].uri" class="contextPrefix">{{ concepts[contexts.data[r.id].uri].label}}</span>
+        <span ng-style="options.getColorForId(contexts.data[r.id].uri)" style="padding: 0 5px; border-radius: 3px" ng-bind-html="contexts.data[r.id].name | sphighlight:highlight"></span> <span ng-if="contexts.data[r.id].uri" class="contextPrefix">{{ concepts[contexts.data[r.id].uri].label}}</span>
     </span>
 </div>
 <ul ui-tree-nodes="" ng-model="contexts.children[r.id]" ng-if="!contexts.data[r.id].collapsed">


### PR DESCRIPTION
As elements in the tree are sometimes unreadable due to bright colors and we use background colors in ThesauRex I tried to change the tree in Spacialist to use background colors as well.

![screenshot 2018-02-21 12 19 04](https://user-images.githubusercontent.com/6630811/36477635-374441c2-1702-11e8-9157-3422920bd970.png)

Possible ToDo's:
- [ ] switch text color to white if the`main.getColorForId` return a darker value. I've changed `var lgt` to compensate, but that value might be changed back to `'65%'`.

@eScienceCenter/spacialists please review & discuss