### PR TITLE
Extend Travis Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,53 +10,53 @@ services:
 matrix:
     include:
         - addons:
-            dist: xenial
             postgresql: 9.6
             apt:
                 packages:
                     - postgresql-9.6-postgis-2.4
+          dist: xenial
         - addons:
-            dist: xenial
             postgresql: 9.6
             apt:
                 packages:
                     - postgresql-9.6-postgis-2.5
+          dist: xenial
         - addons:
-            dist: bionic
             postgresql: 10
             apt:
                 packages:
                     - postgresql-10-postgis-2.5
+          dist: bionic
         - addons:
-            dist: bionic
             postgresql: 10
             apt:
                 packages:
                     - postgresql-10-postgis-3
+          dist: bionic
         - addons:
-            dist: bionic
             postgresql: 11
             apt:
                 packages:
                     - postgresql-11-postgis-2.5
+          dist: bionic
         - addons:
-            dist: bionic
             postgresql: 11
             apt:
                 packages:
                     - postgresql-11-postgis-3
+          dist: bionic
         - addons:
-            dist: bionic
             postgresql: 12
             apt:
                 packages:
                     - postgresql-12-postgis-2.5
+          dist: bionic
         - addons:
-            dist: bionic
             postgresql: 12
             apt:
                 packages:
                     - postgresql-12-postgis-3
+          dist: bionic
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,66 @@
 language: php
 
-dist: xenial
+php:
+    - '7.2'
+    - '7.3'
 
 services:
     - postgresql
 
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+    - os: linux
+      dist: bionic
+
+matrix:
+    include:
+        - addons:
+            postgresql: 9.6
+            apt:
+                packages:
+                    - postgresql-9.6-postgis-2.4
+        - addons:
+            postgresql: 9.6
+            apt:
+                packages:
+                    - postgresql-9.6-postgis-2.5
+        - addons:
+            postgresql: 10
+            apt:
+                packages:
+                    - postgresql-10-postgis-2.5
+        - addons:
+            postgresql: 10
+            apt:
+                packages:
+                    - postgresql-10-postgis-3
+        - addons:
+            postgresql: 11
+            apt:
+                packages:
+                    - postgresql-11-postgis-2.5
+        - addons:
+            postgresql: 11
+            apt:
+                packages:
+                    - postgresql-11-postgis-3
+        - addons:
+            postgresql: 12
+            apt:
+                packages:
+                    - postgresql-12-postgis-2.5
+        - addons:
+            postgresql: 12
+            apt:
+                packages:
+                    - postgresql-12-postgis-3
+
 addons:
-  postgresql: 9.6
   apt:
     packages:
-    - postgresql-9.6-postgis-2.4
     - gdal-bin
-
-php:
-    - '7.2'
-    - '7.3'
 
 before_script:
     - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,51 +7,52 @@ php:
 services:
     - postgresql
 
-jobs:
-  include:
-    - os: linux
-      dist: xenial
-    - os: linux
-      dist: bionic
-
 matrix:
     include:
         - addons:
+            dist: xenial
             postgresql: 9.6
             apt:
                 packages:
                     - postgresql-9.6-postgis-2.4
         - addons:
+            dist: xenial
             postgresql: 9.6
             apt:
                 packages:
                     - postgresql-9.6-postgis-2.5
         - addons:
+            dist: bionic
             postgresql: 10
             apt:
                 packages:
                     - postgresql-10-postgis-2.5
         - addons:
+            dist: bionic
             postgresql: 10
             apt:
                 packages:
                     - postgresql-10-postgis-3
         - addons:
+            dist: bionic
             postgresql: 11
             apt:
                 packages:
                     - postgresql-11-postgis-2.5
         - addons:
+            dist: bionic
             postgresql: 11
             apt:
                 packages:
                     - postgresql-11-postgis-3
         - addons:
+            dist: bionic
             postgresql: 12
             apt:
                 packages:
                     - postgresql-12-postgis-2.5
         - addons:
+            dist: bionic
             postgresql: 12
             apt:
                 packages:


### PR DESCRIPTION
For now travis-ci only tests very few configurations:
- php 7.2 on ubuntu xenial (16.04) LTS with PSQL 9.6 and postgis 2.4
- php 7.3 on ubuntu xenial (16.04) LTS with PSQL 9.6 and postgis 2.4

The purpose of this PR is to test it on newer psql versions (10, 11, 12) and postgis versions (2.5 and 3) as well as latest ubuntu LTS (bionic).