### PR TITLE
[0.11.1] Make attribute lists striped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.11.1
+### Added
+- Attribute Lists are now striped for better readability
 ### Fixed
 - Login not possible on instances in subfolder
 - Last editor not visible in _Entity Detail_ tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.11.1
+### Fixed
+- Login not possible on instances in subfolder
+
 ## 0.11 - Kilcrea
 ### Added
 - Added websockets for various data synchronization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## 0.11.1
 ### Fixed
 - Login not possible on instances in subfolder
+- Last editor not visible in _Entity Detail_ tab
 
 ## 0.11 - Kilcrea
 ### Added

--- a/app/Entity.php
+++ b/app/Entity.php
@@ -90,6 +90,7 @@ class Entity extends Model implements Searchable {
             'creator' => $this->creator,
             'editors' => $this->editors,
             'metadata' => $this->metadata,
+            'user' => $this->user,
         ];
     }
 

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -16,7 +16,7 @@ export async function logout() {
 }
 
 export async function getCsrfCookie() {
-    await $httpQueue.add(() => web_http.get('/sanctum/csrf-cookie').then(response => {
+    await $httpQueue.add(() => web_http.get('sanctum/csrf-cookie').then(response => {
     }));
 }
 

--- a/resources/js/bootstrap/stores/entity.js
+++ b/resources/js/bootstrap/stores/entity.js
@@ -18,6 +18,7 @@ import {
     can,
     calculateEntityTypeColors,
     fillEntityData,
+    except,
     only,
 } from '@/helpers/helpers.js';
 
@@ -500,7 +501,11 @@ export const useEntityStore = defineStore('entity', {
         },
         async fetchEntityMetadata(id) {
             return fetchEntityMetadata(id).then(data => {
-                return this.updateEntityMetadata(id, data);
+                if(data.user) {
+                    this.entities[id].user = data.user;
+                }
+
+                return this.updateEntityMetadata(id, except(data, 'user'));
             });
         },
         async patchEntityMetadata(entityTypeId, attributeId, etAttrId, metadata) {

--- a/resources/js/components/AttributeList.vue
+++ b/resources/js/components/AttributeList.vue
@@ -14,7 +14,7 @@
             <div
                 v-if="!state.hiddenAttributeList[element.id] || showHidden"
                 class="mt-3 px-2"
-                :class="additionalRowClasses(element)"
+                :class="additionalRowClasses(element, index)"
                 @mouseenter="onEnter(index)"
                 @mouseleave="onLeave(index)"
             >
@@ -316,7 +316,7 @@
                 }
             };
 
-            const additionalRowClasses = elem => {
+            const additionalRowClasses = (elem, idx) => {
                 const classes = [];
                 if(!state.ignoreMetadata && elem.pivot && elem.pivot.metadata && elem.pivot.metadata.width) {
                     const width = elem.pivot.metadata.width;
@@ -330,6 +330,9 @@
                     }
                 } else {
                     classes.push('col-12');
+                }
+                if(idx % 2 == 1) {
+                    classes.push('py-2', 'bg-secondary', 'bg-opacity-10', 'rounded-2');
                 }
                 return classes;
             };

--- a/resources/js/components/attribute/Tabular.vue
+++ b/resources/js/components/attribute/Tabular.vue
@@ -1,6 +1,6 @@
 <template>
-    <div>
-        <table class="table table-striped table-hovered table-sm mb-0 table-sticky">
+    <div class="bg-body rounded-2 p-2">
+        <table class="table table-striped table-hover table-borderless table-sm mb-0 table-sticky">
             <thead class="thead-light">
                 <tr>
                     <th>#</th>
@@ -65,7 +65,7 @@
                 <tr v-if="!disabled && !state.isPreview">
                     <td
                         class="text-center"
-                        style="--bs-table-striped-bg: var(--bs-body-bg);"
+                        style="--bs-table-bg-type: var(--bs-body-bg);"
                         :colspan="state.placeholderWidth"
                     >
                         <button
@@ -82,10 +82,13 @@
                     v-if="!state.isPreview"
                     class="border-0"
                 >
-                    <td>&nbsp;</td>
+                    <td style="--bs-table-bg-type: var(--bs-body-bg);">
+                        &nbsp;
+                    </td>
                     <td
                         v-for="(column, i) in state.columns"
                         :key="i"
+                        style="--bs-table-bg-type: var(--bs-body-bg);"
                     >
                         <form
                             v-if="state.chartShown"

--- a/resources/js/components/search/Simple.vue
+++ b/resources/js/components/search/Simple.vue
@@ -313,7 +313,7 @@
             const state = reactive({
                 id: `multiselect-search-${getTs()}`,
                 loading: false,
-                query: 'base',
+                query: '',
                 isSimpleChain: computed(_ => props.chain && props.chain.length > 0),
                 isFnChain: computed(_ => !!props.chainFn),
                 enableChain: computed(_ => state.isSimpleChain || state.isFnChain || context.slots.chain),

--- a/resources/js/helpers/helpers.js
+++ b/resources/js/helpers/helpers.js
@@ -529,6 +529,10 @@ export function only(object, allows = []) {
 }
 
 export function except(object, excepts = []) {
+    // excepts can either be an array or a single key
+    if(!Array.isArray(excepts)) {
+        excepts = [excepts];
+    }
     return Object.keys(object)
         .filter(key => !excepts.includes(key))
         .reduce((obj, key) => {


### PR DESCRIPTION
This PR makes attribute lists striped to better distinguish them from each other (especially from tables).
Tables now needed a neutral bg, because it uses the same "stripe color". I also removed table borders to save some space (and they are also already striped).

![grafik](https://github.com/user-attachments/assets/ddda1e4d-044e-4250-a43d-2b6b9de14bc4)
