### PR TITLE
[0.12] Allow plugins to register attribute types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.12 - (Luxor)
+### Added
+- Plugin-System now supports custom components, e.g. attribute types
 ### Changed
 - Alerts can now be dismissed
 

--- a/app/AttributeTypes/AttributeBase.php
+++ b/app/AttributeTypes/AttributeBase.php
@@ -7,45 +7,17 @@ use App\AttributeValue;
 use App\Entity;
 use App\EntityType;
 use App\Exceptions\InvalidDataException;
+use App\Registries\AttributeRegistry;
 use App\User;
 use App\Utils\StringUtils;
-use Illuminate\Support\Arr;
 
 abstract class AttributeBase
 {
     protected static string $type;
     protected static ?string $field;
+    protected static ?string $label;
     protected static bool $inTable;
     protected static bool $hasSelection;
-
-    private static array $types = [
-        "boolean" => BooleanAttribute::class,
-        "date" => DateAttribute::class,
-        "daterange" => DaterangeAttribute::class,
-        "dimension" => DimensionAttribute::class,
-        "double" => DoubleAttribute::class,
-        "string-mc" => DropdownMultipleAttribute::class,
-        "string-sc" => DropdownSingleAttribute::class,
-        "entity" => EntityAttribute::class,
-        "entity-mc" => EntityMultipleAttribute::class,
-        "epoch" => EpochAttribute::class,
-        "geography" => GeographyAttribute::class,
-        "iconclass" => IconclassAttribute::class,
-        "integer" => IntegerAttribute::class,
-        "list" => ListAttribute::class,
-        "percentage" => PercentageAttribute::class,
-        "richtext" => RichtextAttribute::class,
-        "rism" => RismAttribute::class,
-        "serial" => SerialAttribute::class,
-        "sql" => SqlAttribute::class,
-        "string" => StringAttribute::class,
-        "stringf" => StringfieldAttribute::class,
-        "table" => TableAttribute::class,
-        "timeperiod" => TimeperiodAttribute::class,
-        "userlist" => UserlistAttribute::class,
-        "url" => UrlAttribute::class,
-        "si-unit" => SiUnitAttribute::class,
-    ];
 
     public static function serialized() : array {
         return [
@@ -54,38 +26,10 @@ abstract class AttributeBase
         ];
     }
 
-    public static function getTypes(bool $serialized = false, array $filters = []) : array {
-        if(count($filters) > 0) {
-            $types = Arr::where(self::$types, function(string $attr, string $key) use($filters) {
-                foreach($filters as $on => $value) {
-                    if($on == "datatype") {
-                        if($attr::getType() != $value) return false;
-                    } else if($on == "in_table") {
-                        if($attr::getInTable() != $value) return false;
-                    } else if($on == "field") {
-                        if($attr::getField() != $value) return false;
-                    } else if($on == "has_selection") {
-                        if($attr::getHasSelection() != $value) return false;
-                    }
-                }
-                return true;
-            });
-        } else {
-            $types = self::$types;
-        }
-
-        if($serialized) {
-            return array_values(array_map(function(string $class) {
-                return $class::serialized();
-            }, $types));
-        } else {
-            return $types;
-        }
-    }
-
     public static function getMatchingClass(string $datatype) : bool|AttributeBase {
-        if(array_key_exists($datatype, self::$types)) {
-            return new self::$types[$datatype]();
+        $types = AttributeRegistry::getTypes();
+        if(array_key_exists($datatype, $types)) {
+            return new $types[$datatype]['class']();
         }
 
         return false;
@@ -98,6 +42,10 @@ abstract class AttributeBase
 
     public static function getType() : string {
         return static::$type;
+    }
+
+    public static function getLabel() : ?string {
+        return static::$label;
     }
 
     public static function getInTable() : bool {

--- a/app/AttributeTypes/TableAttribute.php
+++ b/app/AttributeTypes/TableAttribute.php
@@ -3,6 +3,7 @@
 namespace App\AttributeTypes;
 
 use App\Attribute;
+use App\Registries\AttributeRegistry;
 
 class TableAttribute extends AttributeBase
 {
@@ -14,7 +15,7 @@ class TableAttribute extends AttributeBase
     public static function getSelection(Attribute $a) {
         $types = array_map(function(array $entry) {
             return $entry["datatype"];
-        }, AttributeBase::getTypes(true, ['in_table' => true, 'has_selection' => true]));
+        }, AttributeRegistry::getTypes(true, ['in_table' => true, 'has_selection' => true]));
 
         $columns = Attribute::where('parent_id', $a->id)
             ->whereIn('datatype', $types)

--- a/app/File/Directory.php
+++ b/app/File/Directory.php
@@ -3,6 +3,7 @@
 namespace App\File;
 
 use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -56,11 +57,16 @@ class Directory {
      * Stores a file inside the directory.
      *
      * @param string $filename The filename
-     * @param $file The file
+     * @param UploadedFile|string $file The file
      * @return string The path to the file
      */
-    public function store(string $filename, $file): string {
-        return $file->storeAs($this->directory, $filename, $this->disk);
+    public function store(string $filename, UploadedFile|string $file): string {
+        if($file instanceof UploadedFile) {
+            return $file->storeAs($this->directory, $filename, $this->disk);
+        } else {
+            $filename = Str::finish($this->directory, '/') . $filename;
+            return Storage::disk($this->disk)->put($filename, $file);
+        }
     }
 
     /**

--- a/app/File/Directory.php
+++ b/app/File/Directory.php
@@ -70,7 +70,7 @@ class Directory {
      * @return Response|BinaryFileResponse The file as BinaryFileResponse or Response if the file is not inside the directory.
      */
     function download(string $filepath): Response | BinaryFileResponse {
-        if($this->contains($filepath)){
+        if($this->contains($filepath)) {
             return DownloadHandler::makeFileResponse($filepath);
         }
         return response()->noContent();

--- a/app/Http/Controllers/EditorController.php
+++ b/app/Http/Controllers/EditorController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-// use App\AvailableLayer;
 use App\Attribute;
 use App\AttributeValue;
 use App\AvailableLayer;
@@ -14,6 +13,7 @@ use \App\Plugins\Map\App\Geodata;
 use App\Plugin;
 use App\ThConcept;
 use App\AttributeTypes\AttributeBase;
+use App\Registries\AttributeRegistry;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -117,7 +117,7 @@ class EditorController extends Controller {
             ], 403);
         }
 
-        return response()->json(AttributeBase::getTypes(true));
+        return response()->json(AttributeRegistry::getTypes(true));
     }
 
     public function getAvailableGeometryTypes() {

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\AttributeTypes\AttributeBase;
+use App\Registries\AttributeRegistry;
 use App\EntityType;
 use App\Plugin;
 use App\Preference;
@@ -39,9 +39,10 @@ class HomeController extends Controller
 
         $concepts = ThConcept::getMap($locale);
 
-        $datatypes = AttributeBase::getTypes();
+        $datatypes = AttributeRegistry::getTypes();
         $datatypeData = [];
-        foreach($datatypes as $key => $datatype) {
+        foreach($datatypes as $key => $typeDef) {
+            $datatype = $typeDef['class'];
             if(method_exists($datatype, "getGlobalData")) {
                 $datatypeData[$key] = $datatype::getGlobalData();
             }

--- a/app/Http/Controllers/PluginController.php
+++ b/app/Http/Controllers/PluginController.php
@@ -40,6 +40,7 @@ class PluginController extends Controller
         foreach($plugins as $plugin) {
             $plugin->metadata = $plugin->getMetadata();
             $plugin->changelog = $plugin->getChangelog();
+            $plugin->registeredAttributes = $plugin->getRegisteredAttributes();
         }
 
         return response()->json($plugins);
@@ -186,5 +187,10 @@ class PluginController extends Controller
         return response()->json([
             'uninstall_location' => $plugin->publicName(),
         ]);
+    }
+
+    public function downloadScript(Request $request) {
+        $file = "plugins/" . $request->query('src');
+        return Plugin::getDirectory()->download($file);
     }
 }

--- a/app/Http/Controllers/PluginController.php
+++ b/app/Http/Controllers/PluginController.php
@@ -140,7 +140,7 @@ class PluginController extends Controller
 
             return response()->json([
                 'plugin' => $plugin,
-                'install_location' => $plugin->publicName(),
+                'install_location' => $plugin->publicName(false),
             ]);
         }
     }
@@ -165,7 +165,7 @@ class PluginController extends Controller
             $plugin->handleUninstall();
             return response()->json([
                 'plugin' => $plugin,
-                'uninstall_location' => $plugin->publicName(),
+                'uninstall_location' => $plugin->publicName(false),
             ]);
         } catch(ModelNotFoundException $e) {
             // Already uninstalled
@@ -185,7 +185,7 @@ class PluginController extends Controller
         $plugin->handleRemove();
         $plugin->delete();
         return response()->json([
-            'uninstall_location' => $plugin->publicName(),
+            'uninstall_location' => $plugin->publicName(false),
         ]);
     }
 

--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -315,20 +315,14 @@ class Plugin extends Model
         $name = $this->name;
         $scriptPath = base_path("app/Plugins/$name/js/script.js");
         if(file_exists($scriptPath)) {
-            $filehandle = fopen($scriptPath, 'r');
-            Storage::put(
-                $this->publicName(),
-                $filehandle,
-            );
-            fclose($filehandle);
+            $scriptDirectory = self::getDirectory();
+            $scriptDirectory->store($this->publicName(false), $scriptPath);
         }
     }
 
     private function removeScript(): void {
         $path = $this->publicName();
-        if(Storage::exists($path)) {
-            Storage::delete($path);
-        }
+        self::getDirectory()->delete($this->publicName());
     }
 
     private function addPermissions(): void {

--- a/app/Plugin.php
+++ b/app/Plugin.php
@@ -2,10 +2,11 @@
 
 namespace App;
 
+use App\File\Directory;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
@@ -26,19 +27,19 @@ class Plugin extends Model
         'title',
     ];
 
-    public static function isInstalled($name) {
+    public static function isInstalled($name): bool {
         return self::whereNotNull('installed_at')->where('name', $name)->exists();
     }
 
-    public static function getInstalled() {
+    public static function getInstalled(): Collection {
         return self::whereNotNull('installed_at')->get();
     }
 
-    public function slugName() {
+    public function slugName(): string {
         return Str::slug($this->name);
     }
 
-    public function publicName($withPath = true) {
+    public function publicName($withPath = true): string {
         $slug = $this->slugName();
         $uuid = $this->uuid;
         $name = "{$slug}-{$uuid}.js";
@@ -48,7 +49,7 @@ class Plugin extends Model
         return $name;
     }
 
-    public static function getInfo($path, $isString = false) {
+    public static function getInfo($path, $isString = false): mixed {
         if(!$isString) {
             $infoPath = Str::finish($path, '/') . 'App/info.xml';
             if(!File::isFile($infoPath)) return false;
@@ -58,11 +59,11 @@ class Plugin extends Model
         }
 
         $xmlObject = simplexml_load_string($xmlString);
-        
+
         return json_decode(json_encode($xmlObject), true);
     }
 
-    public function getMetadata() {
+    public function getMetadata(): array {
         $info = self::getInfo(base_path("app/Plugins/$this->name"));
         if($info !== false) {
             $metadata = [];
@@ -80,7 +81,7 @@ class Plugin extends Model
         }
     }
 
-    public function getChangelog($since = null) {
+    public function getChangelog(?string $since = null): string {
         $changelog = Str::finish(base_path("app/Plugins/$this->name"), '/') . 'CHANGELOG.md';
         if(!File::isFile($changelog)) return '';
         $changes = file_get_contents($changelog);
@@ -92,7 +93,23 @@ class Plugin extends Model
         return $changes;
     }
 
-    public static function updateOrCreateFromInfo(array $info) : Plugin {
+    public function getRegisteredAttributes(): array {
+        $info = self::getInfo(base_path("app/Plugins/$this->name"));
+        $attributes = [];
+        if($info !== false) {
+            if(array_key_exists('attributes', $info)) {
+                $attributes = $info['attributes']['attribute'];
+                // If only one <attribute> exists, this <attribute> is returned
+                // instead of an array, but we always want an array
+                if(array_key_exists('@attributes', $attributes)) {
+                    $attributes = [$attributes];
+                }
+            }
+        }
+        return $attributes;
+    }
+
+    public static function updateOrCreateFromInfo(array $info): Plugin {
         $id = $info['name'];
         $plugin = self::where('name', $id)->first();
         // discovered new Plugin, add it to DB
@@ -109,7 +126,7 @@ class Plugin extends Model
         return $plugin;
     }
 
-    public static function updateState() : void {
+    public static function updateState(): void {
         $pluginPath = base_path('app/Plugins');
         $availablePlugins = File::directories($pluginPath);
 
@@ -117,7 +134,7 @@ class Plugin extends Model
         self::cleanupPlugins($availablePlugins);
     }
 
-    public static function cleanupPlugins(array $list) : void {
+    public static function cleanupPlugins(array $list): void {
         $pluginNames = [];
 
         foreach($list as $p) {
@@ -131,7 +148,7 @@ class Plugin extends Model
         }
     }
 
-    public static function discoverPlugins(array $list) : void {
+    public static function discoverPlugins(array $list): void {
         foreach($list as $ap) {
             $info = self::getInfo($ap);
             if($info !== false) {
@@ -140,7 +157,7 @@ class Plugin extends Model
         }
     }
 
-    public static function discoverPluginByName($name) : Plugin|null {
+    public static function discoverPluginByName($name): ?Plugin {
         $pluginPath = base_path("app/Plugins/$name");
         $info = self::getInfo($pluginPath);
         if($info === false) {
@@ -152,13 +169,17 @@ class Plugin extends Model
         return $plugin;
     }
 
-    public function updateUpdateState($fromInfoVersion) {
+    public static function getDirectory(): Directory {
+        return new Directory('plugins');
+    }
+
+    public function updateUpdateState($fromInfoVersion): void {
         if($this->version != $fromInfoVersion) {
             // installed version splitted
             preg_match('/(\d+)\.(\d+).(\d+)(-.+)?/', $this->version, $iv);
             // available/latest version splitted
             preg_match('/(\d+)\.(\d+).(\d+)(-.+)?/', $fromInfoVersion, $lv);
-    
+
             if(
                 ($lv[1] > $iv[1] || $lv[2] > $iv[2] || $lv[3] > $iv[3]) ||
                 (!isset($lv[4]) && isset($iv[4])) ||
@@ -172,7 +193,7 @@ class Plugin extends Model
         }
     }
 
-    public function handleInstallation() {
+    public function handleInstallation(): void {
         $this->runMigrations();
         $this->publishScript();
         $this->addPermissions();
@@ -182,7 +203,7 @@ class Plugin extends Model
         $this->save();
     }
 
-    public function handleUpdate() {
+    public function handleUpdate(): string {
         $oldVersion = $this->version;
         // TODO is it really the same as install?
         $this->handleInstallation();
@@ -195,14 +216,14 @@ class Plugin extends Model
         return $oldVersion;
     }
 
-    public function handleUninstall() {
+    public function handleUninstall(): void {
         $this->removeScript();
 
         $this->installed_at = null;
         $this->save();
     }
 
-    public function handleRemove() {
+    public function handleRemove(): void {
         // if installed, first rollback migrations and delete all files and presets
         if(isset($this->installed_at)) {
             $this->handleUninstall();
@@ -217,7 +238,7 @@ class Plugin extends Model
         $this->delete();
     }
 
-    public function getPermissions() {
+    public function getPermissions(): mixed {
         $pluginPermissionPath = base_path("app/Plugins/$this->name/App/permissions.json");
         if(!File::isFile($pluginPermissionPath)) {
             return [];
@@ -226,11 +247,11 @@ class Plugin extends Model
         return json_decode(file_get_contents($pluginPermissionPath), true);
     }
 
-    public function getPermissionGroups() {
+    public function getPermissionGroups(): array {
         return array_keys($this->getPermissions());
     }
 
-    public function getRolePresets() {
+    public function getRolePresets(): mixed {
         $rolePresets = base_path("app/Plugins/$this->name/App/role-presets.json");
         if(!File::isFile($rolePresets)) {
             return [];
@@ -239,14 +260,14 @@ class Plugin extends Model
         return json_decode(file_get_contents($rolePresets), true);
     }
 
-    private function getClassWithPrefix($path, $classname) {
+    private function getClassWithPrefix($path, $classname): string {
         return "App\\Plugins\\$this->name\\$path\\$classname";
     }
 
-    private function getMigrationPath() {
+    private function getMigrationPath(): string {
         return base_path("app/Plugins/$this->name/Migration");
     }
-    private function getSortedMigrations(bool $desc = false) : array {
+    private function getSortedMigrations(bool $desc = false): array {
         $migrationPath = $this->getMigrationPath();
         if(file_exists($migrationPath) && is_dir($migrationPath)) {
             $migrations = collect(File::files($migrationPath))->map(function($f) {
@@ -264,7 +285,7 @@ class Plugin extends Model
         return [];
     }
 
-    private function runMigrations() {
+    private function runMigrations(): void {
         foreach($this->getSortedMigrations() as $migration) {
             preg_match("/^[1-9]\d{3}_\d{2}_\d{2}_\d{6}_(.*)\.php$/", $migration, $matches);
             if(count($matches) != 2) continue;
@@ -277,7 +298,7 @@ class Plugin extends Model
         }
     }
 
-    private function rollbackMigrations() {
+    private function rollbackMigrations(): void {
         foreach($this->getSortedMigrations(true) as $migration) {
             preg_match("/^[1-9]\d{3}_\d{2}_\d{2}_\d{6}_(.*)\.php$/", $migration, $matches);
             if(count($matches) != 2) continue;
@@ -290,7 +311,7 @@ class Plugin extends Model
         }
     }
 
-    private function publishScript() {
+    private function publishScript(): void {
         $name = $this->name;
         $scriptPath = base_path("app/Plugins/$name/js/script.js");
         if(file_exists($scriptPath)) {
@@ -303,14 +324,14 @@ class Plugin extends Model
         }
     }
 
-    private function removeScript() {
+    private function removeScript(): void {
         $path = $this->publicName();
         if(Storage::exists($path)) {
             Storage::delete($path);
         }
     }
 
-    private function addPermissions() {
+    private function addPermissions(): void {
         $permGroups = $this->getPermissions();
         foreach($permGroups as $group => $permSet) {
             foreach($permSet as $perm) {
@@ -324,7 +345,7 @@ class Plugin extends Model
         }
     }
 
-    private function removePermissions() {
+    private function removePermissions(): void {
         $permGroups = $this->getPermissions();
         foreach($permGroups as $group => $permSet) {
             foreach($permSet as $perm) {
@@ -333,7 +354,7 @@ class Plugin extends Model
         }
     }
 
-    private function installPresetsFromFile() {
+    private function installPresetsFromFile(): void {
         $rolePresets = $this->getRolePresets();
         foreach($rolePresets as $preset) {
             $baseRolePreset = RolePreset::where('name', $preset['extends'])->firstOrFail();
@@ -345,11 +366,11 @@ class Plugin extends Model
         }
     }
 
-    private function uninstallPresets() {
+    private function uninstallPresets(): void {
         RolePresetPlugin::where('from', $this->id)->delete();
     }
 
-    private function removePreferences() {
+    private function removePreferences(): void {
         $id = Str::kebab($this->name);
         Preference::where('label', 'ilike', "plugin.$id.%")->delete();
     }

--- a/app/Registries/AttributeRegistry.php
+++ b/app/Registries/AttributeRegistry.php
@@ -27,7 +27,7 @@ class AttributeRegistry {
     }
 
     private static function registerCoreTypes(): void {
-        $files = glob('../app/AttributeTypes/*.php');
+        $files = glob(base_path('/app/AttributeTypes') . '/*.php');
         foreach($files as $file) {
             $className = basename($file, '.php');
             $class = "App\\AttributeTypes\\{$className}";

--- a/app/Registries/AttributeRegistry.php
+++ b/app/Registries/AttributeRegistry.php
@@ -45,7 +45,8 @@ class AttributeRegistry {
         foreach($installedPlugins as $plugin) {
             $attributeTypes = $plugin->getRegisteredAttributes();
             foreach($attributeTypes as $attributeType) {
-                $class = basename($attributeType['@attributes']['src'], '.php');
+                $path = "App\\Plugins\\Address\\" . $attributeType['@attributes']['src'];
+                $class = basename($path, '.php');
                 self::register(new $class(), $plugin->name);
             }
         }

--- a/app/Registries/AttributeRegistry.php
+++ b/app/Registries/AttributeRegistry.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Registries;
+
+use App\AttributeTypes\AttributeBase;
+use App\Plugin;
+use Illuminate\Support\Arr;
+
+class AttributeRegistry {
+    private static array $types = [];
+
+    private static function reset(): void {
+        self::$types = [];
+    }
+
+    private static function register(AttributeBase $type, ?string $pluginName = null): void {
+        $key = $type::getType();
+        if(array_key_exists($key, self::$types)) {
+            throw new \Exception("Attribute type '{$key}' is already registered.");
+        }
+        self::$types[$key] = [
+            'class' => $type::class,
+        ];
+        if(isset($pluginName)) {
+            self::$types[$key]['plugin'] = $pluginName;
+        }
+    }
+
+    private static function registerCoreTypes(): void {
+        $files = glob('../app/AttributeTypes/*.php');
+        foreach($files as $file) {
+            $className = basename($file, '.php');
+            $class = "App\\AttributeTypes\\{$className}";
+
+            // Skip all abstract classes
+            if((new \ReflectionClass($class))->isAbstract()) continue;
+
+            self::register(new $class());
+        }
+    }
+
+    private static function registerPluginTypes(): void {
+        $installedPlugins = Plugin::getInstalled();
+
+        foreach($installedPlugins as $plugin) {
+            $attributeTypes = $plugin->getRegisteredAttributes();
+            foreach($attributeTypes as $attributeType) {
+                $class = basename($attributeType['@attributes']['src'], '.php');
+                self::register(new $class(), $plugin->name);
+            }
+        }
+    }
+
+    public static function getTypes(bool $serialized = false, array $filters = []): array {
+        self::reset();
+        self::registerCoreTypes();
+        self::registerPluginTypes();
+
+        if(count($filters) > 0) {
+            $types = Arr::where(self::$types, function(array $typeDef, string $key) use($filters) {
+                $attr = $typeDef['class'];
+                foreach($filters as $on => $value) {
+                    if($on == "datatype") {
+                        if($attr::getType() != $value) return false;
+                    } else if($on == "in_table") {
+                        if($attr::getInTable() != $value) return false;
+                    } else if($on == "field") {
+                        if($attr::getField() != $value) return false;
+                    } else if($on == "has_selection") {
+                        if($attr::getHasSelection() != $value) return false;
+                    }
+                }
+                return true;
+            });
+        } else {
+            $types = self::$types;
+        }
+
+        if($serialized) {
+            return array_values(array_map(function(array $typeDef) {
+                $data = $typeDef['class']::serialized();
+                if(array_key_exists('plugin', $typeDef) && isset($typeDef['plugin'])) {
+                    $data['plugin'] = $typeDef['plugin'];
+                    $data['label'] = $typeDef['class']::getLabel();
+                }
+                return $data;
+            }, $types));
+        } else {
+            return $types;
+        }
+    }
+}

--- a/resources/js/bootstrap/plugins.js
+++ b/resources/js/bootstrap/plugins.js
@@ -49,6 +49,14 @@ const defaultPluginOptions = {
     store: null,
     api: null,
 };
+const defaultComponentOptions = {
+    of: null, // id of registered plugin
+    key: null,
+    type: null, // e.g. attribute
+    datatype: null, // required if type=attribute
+    component: null,
+    componentTag: null,
+};
 const defaultSlotOptions = {
     of: null, // id of registered plugin
     slot: 'tab', // one of 'tab', 'tools' or 'settings'
@@ -224,6 +232,35 @@ export const SpPS = {
             }
         }
         SpPS.api.store.systemStore.registerPluginInSlot(mergedOptions);
+    },
+    registerComponent: (options) => {
+        if(!options.of || !SpPS.data.plugins[options.of]) {
+            throw new Error('This plugin part has no associated plugin or that plugin is not installed!');
+        }
+        if(!options.component) {
+            throw new Error('To register a component you must provide a component!');
+        }
+        const mergedOptions = {
+            ...defaultComponentOptions,
+            ...only(options, Object.keys(defaultComponentOptions)),
+        };
+        if(mergedOptions.type != 'attribute') {
+            if(!mergedOptions.componentTag) {
+                mergedOptions.componentTag = mergedOptions.key;
+            }
+            mergedOptions.componentTag = `sp-plugin-${mergedOptions.componentTag}`;
+            if(!!mergedOptions.component) {
+                if(typeof mergedOptions.component == 'string') {
+                    SpPS.data.app.component(mergedOptions.componentTag, {
+                        template: mergedOptions.component,
+                    });
+                } else {
+                    SpPS.data.app.component(mergedOptions.componentTag, mergedOptions.component);
+                }
+            }
+        } else {
+            SpPS.api.store.systemStore.registerPluginAttribute(mergedOptions);
+        }
     },
     registerPreference: (options) => {
         if(!options.of || !SpPS.data.plugins[options.of]) {

--- a/resources/js/bootstrap/stores/attribute.js
+++ b/resources/js/bootstrap/stores/attribute.js
@@ -51,6 +51,16 @@ export const useAttributeStore = defineStore('attribute', {
             return filteredSelection;
         },
         getTableAttributeTypes: state => state.attributeTypes.filter(type => type.in_table),
+        isFromPlugin: state => datatype => {
+            return !!useSystemStore().registeredPluginAttributes[datatype];
+        },
+        getPluginAttributeLabel: state => datatype => {
+            const attributeType = state.attributeTypes.find(attributeType => {
+                return attributeType.datatype == datatype && !!attributeType.plugin;
+            });
+
+            return attributeType?.label;
+        },
     },
     actions: {
         setAttributes(attributes) {

--- a/resources/js/bootstrap/stores/system.js
+++ b/resources/js/bootstrap/stores/system.js
@@ -72,6 +72,7 @@ export const useSystemStore = defineStore('system', {
             tools: [],
             settings: [],
         },
+        registeredPluginAttributes: {},
         registeredPluginPreferences: {
             user: {},
             system: {},
@@ -117,7 +118,7 @@ export const useSystemStore = defineStore('system', {
     },
     actions: {
         getConceptById(id) {
-            return this.concepts[id];  
+            return this.concepts[id];
         },
         setAppState(state) {
             this.appInitialized = state;
@@ -246,6 +247,9 @@ export const useSystemStore = defineStore('system', {
         },
         registerPluginInSlot(data) {
             this.registeredPluginSlots[data.slot].push(data);
+        },
+        registerPluginAttribute(data) {
+            this.registeredPluginAttributes[data.datatype] = data;
         },
         registerPluginPreference(data) {
             const category = this.registeredPluginPreferences[data.category];

--- a/resources/js/components/AttributeTemplate.vue
+++ b/resources/js/components/AttributeTemplate.vue
@@ -44,11 +44,33 @@
                     @search-change="searchInAttributeTypes"
                 >
                     <template #option="{ option }">
-                        {{ t(`global.attributes.${option.datatype}`) }}
+                        <div
+                            v-if="option.plugin"
+                            class="w-100 d-flex flex-row justify-content-between align-items-center"
+                        >
+                            <span>
+                                {{ t(`${option.label}`) }}
+                            </span>
+                            <PluginBadge :name="option.plugin" />
+                        </div>
+                        <span v-else>
+                            {{ t(`global.attributes.${option.datatype}`) }}
+                        </span>
                     </template>
                     <template #singlelabel="{ value }">
-                        <div class="multiselect-single-label">
-                            {{ t(`global.attributes.${value.datatype}`) }}
+                        <div class="w-100 multiselect-single-label">
+                            <div
+                                v-if="value.plugin"
+                                class="w-100 d-flex flex-row justify-content-between align-items-center"
+                            >
+                                <span>
+                                    {{ t(`${value.label}`) }}
+                                </span>
+                                <PluginBadge :name="value.plugin" />
+                            </div>
+                            <span v-else>
+                                {{ t(`global.attributes.${value.datatype}`) }}
+                            </span>
                         </div>
                     </template>
                 </multiselect>
@@ -314,10 +336,12 @@
     } from '@/helpers/helpers.js';
 
     import ChainList from './chain/ChainList.vue';
+    import PluginBadge from './plugins/Badge.vue';
 
     export default {
         components: {
             ChainList,
+            PluginBadge,
         },
         props: {
             type: {
@@ -439,7 +463,9 @@
                     break;
             }
             types = types.slice().sort((a, b) => {
-                return t(`global.attributes.${a.datatype}`) > t(`global.attributes.${b.datatype}`);
+                const labelA = a.plugin ? a.label : `global.attributes.${a.datatype}`;
+                const labelB = b.plugin ? b.label : `global.attributes.${b.datatype}`;
+                return t(labelA).localeCompare(t(labelB));
             });
 
             const state = reactive({

--- a/resources/js/components/DataModel.vue
+++ b/resources/js/components/DataModel.vue
@@ -185,7 +185,16 @@
                                         :aria-controls="`dme-attribute-list-${type}-grp-container`"
                                     >
                                         <span class="flex-fill">
-                                            {{ t(`global.attributes.${type}`) }}
+                                            <span v-if="isFromPlugin(type)">
+                                                {{ t(getPluginLabel(type)) }}
+                                                <i
+                                                    class="fas fa-fw fa-puzzle-piece"
+                                                    title="from Plugin"
+                                                />
+                                            </span>
+                                            <span v-else>
+                                                {{ t(`global.attributes.${type}`) }}
+                                            </span>
                                         </span>
                                         <span
                                             class="badge bg-primary mx-2 d-flex flex-row"
@@ -386,6 +395,9 @@
                 return attributeGroupItemCount(items) > 0;
             };
 
+            const isFromPlugin = datatype => attributeStore.isFromPlugin(datatype);
+            const getPluginLabel = datatype => attributeStore.getPluginAttributeLabel(datatype);
+
             // DATA
             const accordionRef = ref(null);
             const state = reactive({
@@ -434,8 +446,12 @@
                     const groupList = Object.entries(state.attributeListGroups);
 
                     return groupList.sort((a, b) => {
-                        const labelA = t(`global.attributes.${a[0]}`);
-                        const labelB = t(`global.attributes.${b[0]}`);
+                        const labelA = isFromPlugin(a[0]) ?
+                            t(getPluginLabel(a[0])) :
+                            t(`global.attributes.${a[0]}`);
+                        const labelB = isFromPlugin(b[0]) ?
+                            t(getPluginLabel(b[0])) :
+                            t(`global.attributes.${b[0]}`);
                         return labelA.localeCompare(labelB);
                     });
                 }),
@@ -463,6 +479,8 @@
                 setAttributeGroupExpand,
                 attributeGroupItemCount,
                 attributeGroupHasItems,
+                isFromPlugin,
+                getPluginLabel,
                 // STATE
                 accordionRef,
                 state,

--- a/resources/js/components/DataModel.vue
+++ b/resources/js/components/DataModel.vue
@@ -187,10 +187,7 @@
                                         <span class="flex-fill">
                                             <span v-if="isFromPlugin(type)">
                                                 {{ t(getPluginLabel(type)) }}
-                                                <i
-                                                    class="fas fa-fw fa-puzzle-piece"
-                                                    title="from Plugin"
-                                                />
+                                                <i class="fas fa-fw fa-puzzle-piece" />
                                             </span>
                                             <span v-else>
                                                 {{ t(`global.attributes.${type}`) }}

--- a/resources/js/components/Plugins.vue
+++ b/resources/js/components/Plugins.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex flex-column h-100">
         <h4>
-            {{ t('main.plugins.title') }}
+            {{ t('main.plugins.title', 2) }}
             <file-upload
                 ref="upload"
                 v-model="state.files"

--- a/resources/js/components/attribute/Attribute.vue
+++ b/resources/js/components/attribute/Attribute.vue
@@ -236,6 +236,17 @@
         :title="getSeparatorTitle(data)"
     />
 
+    <component
+        :is="state.pluginAttributes[data.datatype].component"
+        v-else-if="state.pluginAttributes[data.datatype]"
+        :key="state.pluginAttributes[data.datatype].key"
+        :ref="el => setRef(el)"
+        :disabled="state.disabled"
+        :name="`attr-${data.id}`"
+        :value="state.value"
+        @change="updateDirtyState"
+    />
+
     <default-attribute
         v-else
         :ref="el => setRef(el)"
@@ -257,6 +268,7 @@
     } from 'vue';
 
     import useAttributeStore from '@/bootstrap/stores/attribute.js';
+    import useSystemStore from '@/bootstrap/stores/system.js';
 
     import {
         getEmptyAttributeValue,
@@ -358,6 +370,7 @@
         emits: ['expanded', 'change', 'update-selection'],
         setup(props, context) {
             const attributeStore = useAttributeStore();
+            const systemStore = useSystemStore();
             const {
                 data,
                 valueWrapper,
@@ -377,6 +390,7 @@
             const attrRef = ref({});
             const state = reactive({
                 type: computed(_ => data.value.datatype),
+                pluginAttributes: computed(_ => systemStore.registeredPluginAttributes),
                 disabled: computed(_ => data.value.isDisabled || disabled.value),
                 value: _cloneDeep(getValueOrDefault()),
                 externalUpdate: false,

--- a/resources/js/components/modals/attribute/Edit.vue
+++ b/resources/js/components/modals/attribute/Edit.vue
@@ -67,7 +67,7 @@
                             <input
                                 type="text"
                                 class="form-control"
-                                :value="t(`global.attributes.${state.attribute.datatype}`)"
+                                :value="getLabel(state.attribute.datatype)"
                                 disabled
                             >
                         </div>
@@ -132,6 +132,7 @@
 
     import { useI18n } from 'vue-i18n';
 
+    import useAttributeStore from '@/bootstrap/stores/attribute.js';
     import useEntityStore from '@/bootstrap/stores/entity.js';
 
     import {
@@ -171,6 +172,8 @@
         emits: ['closing', 'confirm'],
         setup(props, context) {
             const { t } = useI18n();
+            const attributeStore = useAttributeStore();
+            const entityStore = useEntityStore();
 
             // FUNCTIONS
             const validateDependencyRule = rule => {
@@ -212,6 +215,13 @@
                     console.error('Invalid separator label', label);
                 }
             };
+            const getLabel = datatype => {
+                if(attributeStore.isFromPlugin(datatype)) {
+                    return t(attributeStore.getPluginAttributeLabel(datatype));
+                } else {
+                    return t(`global.attributes.${datatype}`)
+                }
+            };
 
             // DATA
             const state = reactive({
@@ -229,7 +239,7 @@
                 attribute: {},
                 inputTypeClass: computed(_ => getInputTypeClass(state.attribute.datatype)),
                 supportedEntityTypeAttributes: computed(_ => {
-                    const attributeSelection = useEntityStore().getEntityTypeAttributes(props.entityTypeId);
+                    const attributeSelection = entityStore.getEntityTypeAttributes(props.entityTypeId);
                     const supportedEntityTypeAttributes = attributeSelection.filter(a => {
                         return a.id != props.attributeId && getInputTypeClass(a.datatype) != 'unsupported';
                     });
@@ -266,6 +276,7 @@
                 confirmEdit,
                 closeModal,
                 handleSeparatorRename,
+                getLabel,
                 // STATE
                 state,
             };

--- a/resources/js/components/plugins/Badge.vue
+++ b/resources/js/components/plugins/Badge.vue
@@ -1,8 +1,10 @@
 <template>
-    <span class="badge bg-primary">
+    <div class="badge bg-primary d-flex flex-row align-items-center justify-content-center gap-1">
         <i class="fas fa-fw fa-puzzle-piece" />
-        <span class="fst-italic">{{ name }}</span>-{{ t('main.plugins.title') }}
-    </span>
+        <div>
+            <span class="fst-italic">{{ name }}</span>-{{ t('main.plugins.title') }}
+        </div>
+    </div>
 </template>
 
 <script>

--- a/resources/js/components/plugins/Badge.vue
+++ b/resources/js/components/plugins/Badge.vue
@@ -1,0 +1,30 @@
+<template>
+    <span class="badge bg-primary">
+        <i class="fas fa-fw fa-puzzle-piece" />
+        <span class="fst-italic">{{ name }}</span>-{{ t('main.plugins.title') }}
+    </span>
+</template>
+
+<script>
+    import { useI18n } from 'vue-i18n';
+
+    export default {
+        props: {
+            name: {
+                required: true,
+                type: String,
+            },
+        },
+        setup() {
+            const { t } = useI18n();
+
+            // DATA
+
+            // RETURN
+            return {
+                t,
+                // STATE
+            };
+        },
+    };
+</script>

--- a/resources/js/components/tools/importer/EntityAttributeMapping.vue
+++ b/resources/js/components/tools/importer/EntityAttributeMapping.vue
@@ -22,7 +22,10 @@
                 >
                     {{ attr._name }}
                     <span class="ms-2 opacity-50 small">
-                        {{ t(`global.attributes.${attr.datatype}`) }}
+                        {{ getLabel(attr.datatype) }}
+                        <span v-show="isPluginDatatype(attr.datatype)">
+                            <i class="fas fa-fw fa-puzzle-piece" />
+                        </span>
                     </span>
                 </label>
             </div>
@@ -46,6 +49,8 @@
 <script>
     import { computed } from 'vue';
     import { useI18n } from 'vue-i18n';
+
+    import useAttributeStore from '@/bootstrap/stores/attribute.js';
 
     import {
         multiselectResetClasslist,
@@ -86,6 +91,7 @@
         ],
         setup(props, context) {
             const { t } = useI18n();
+            const attributeStore = useAttributeStore();
 
             const updateAttributeMapping = (id, option) => {
                 const newMapping = Object.assign({}, props.attributeMapping);
@@ -125,6 +131,16 @@
                 return val;
             };
 
+            const isPluginDatatype = datatype => attributeStore.isFromPlugin(datatype);
+
+            const getLabel = datatype => {
+                if(attributeStore.isFromPlugin(datatype)) {
+                    return t(attributeStore.getPluginAttributeLabel(datatype));
+                } else {
+                    return t(`global.attributes.${datatype}`)
+                }
+            };
+
             const availableAttributesSortedByName = computed(_ => {
                 let arr = [];
                 for(const attr of props.availableAttributes) {
@@ -150,8 +166,10 @@
                 // Local
                 availableAttributesSortedByName,
                 deselectWorkAround,
+                getLabel,
                 getMissing,
                 getTotal,
+                isPluginDatatype,
                 multiselectResetClasslist,
                 sortedOptions,
                 updateAttributeMapping,

--- a/resources/js/helpers/plugins.js
+++ b/resources/js/helpers/plugins.js
@@ -1,16 +1,16 @@
 export const appendScript = location => {
     const scriptTag = document.createElement('script');
     scriptTag.type = 'text/javascript';
-    scriptTag.src = `storage/${location}`;
-    document.body.appendChild(scriptTag);
+    scriptTag.src = `/download/plugin?src=${location}`
+    document.head.appendChild(scriptTag);
 };
 
 export const removeScript = location => {
     const scripts = [
-        ...document.body.getElementsByTagName('script')
+        ...document.head.getElementsByTagName('script')
     ];
-    const oldScript = scripts.find(s => s.src.endsWith(location));
+    const oldScript = scripts.find(s => s.src == `/download/plugin?src=${location}`);
     if(oldScript) {
-        document.body.removeChild(oldScript);
+        document.head.removeChild(oldScript);
     }
 };

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -14,6 +14,7 @@
         "edit": "Bearbeiten",
         "edited": "bearbeitet",
         "duplicate": "Duplizieren",
+        "export":"Exportieren",
         "sort": "Sortieren",
         "resort": "Umsortieren",
         "update": "Aktualisieren",
@@ -847,7 +848,7 @@
             }
         },
         "plugins": {
-            "title": "Erweiterungen",
+            "title": "Erweiterung | Erweiterungen",
             "upload": "Plugin hochladen",
             "authors": "Ersteller",
             "deactivate": "Deaktivieren",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -12,9 +12,9 @@
         "close": "Close",
         "add": "Add",
         "edit": "Edit",
-        "export":"Export",
         "edited": "edited",
         "duplicate": "Duplicate",
+        "export":"Export",
         "sort": "Sort",
         "resort": "Re-sort",
         "update": "Update",
@@ -848,7 +848,7 @@
             }
         },
         "plugins": {
-            "title": "Plugins",
+            "title": "Plugin | Plugins",
             "upload": "Upload Plugin",
             "authors": "Authors",
             "deactivate": "Deactivate",

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -22,7 +22,7 @@
 
 
     @foreach($plugins as $plugin)
-        <script src="storage/plugins/{!! sp_slug($plugin->name) !!}-{!! $plugin->uuid !!}.js" defer> 
+        <script src="/download/plugin?src={!! sp_slug($plugin->name) !!}-{!! $plugin->uuid !!}.js" defer>
         </script>
     @endforeach
 </head>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::get('/open', 'HomeController@external')->name('external');
 
 Route::middleware('auth:sanctum')->get('/download/avatar', 'UserController@downloadAvatar');
 Route::middleware('auth:sanctum')->get('/download/bibliography', 'BibliographyController@downloadFile');
+Route::middleware('auth:sanctum')->get('/download/plugin', 'PluginController@downloadScript');
 
 Auth::routes(["middleware" => ["auth:sanctum"]]);
 


### PR DESCRIPTION
This PR adds the logic for plugins to add attribute types. The required steps to see these custom attributes are:

1. Add `<attributes>` section to `info.xml` with all `<attribute>`'s pointing to attribute definition class using `src` property (relative to `lib` folder)
```xml
<attributes>
    <attribute src="App\AttributeTypes\CustomAttribute.php" />
</attributes>
```
The attribute definition class must extend the abstract `AttributeBase` from the core repo and set at least `$type` (attribute datatype, same as in `SpPS.registerComponent()` and `$label` (used for i18n; refering to path in i18n `.json` files)
2. Register the plugin (`SpPS.register({...})`)
3. Register component using the new `SpPS.registerComponent({...})` method
```javascript
SpPS.registerComponent({
    of: PLUGIN-ID',
    type: 'attribute',
    key: DATATYPE,
    datatype: DATATYPE,
    component: IMPORTED-Vue-File,
});
```