### PR TITLE
Removed reduntant api calls and improved metadata handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.12 - (Luxor)
-### Add
-- New Api endpoint for getting all entity details data in one request: GET::v1/entity/{id}/entity_detail
-
+### Added
+- API endpoint for getting all entity details data in one request: GET::v1/entity/{id}/entity_detail
 ### Changed
 - Alerts can now be dismissed
-- Now entity metadata is only loaded when accessing the metadata tab 
-
-## Fix
+- Now entity metadata is only loaded when accessing the metadata tab
+## Fixed
 - Removed redundant calls to the entity endpoint
 - Metadata tab error on submit (unknown variable)
-
 
 ## 0.11.1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.12 - (Luxor)
+### Add
+- New Api endpoint for getting all entity details data in one request: GET::v1/entity/{id}/entity_detail
+
 ### Changed
 - Alerts can now be dismissed
+- Now entity metadata is only loaded when accessing the metadata tab 
+
+## Fix
+- Removed redundant calls to the entity endpoint
+- Metadata tab error on submit (unknown variable)
+
 
 ## 0.11.1
 ### Added

--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -212,12 +212,12 @@ class EntityController extends Controller {
         $data = $entity->getData($aid);
         return response()->json($data);
     }
-    
+
     /**
      * Bundles the requests of data reference, metadata and parentValue
      * to achieve much better performance.
      */
-    public function getEntityDetail(int $id){
+    public function getEntityDetail(int $id) {
          $user = auth()->user();
         if(!$user->can('entity_read') || !$user->can('entity_data_read')) {
             return response()->json([
@@ -226,7 +226,7 @@ class EntityController extends Controller {
         }
 
         $entity = null;
-        try{
+        try {
             $entity = Entity::findOrFail($id);
         } catch(ModelNotFoundException $e) {
             return response()->json([
@@ -242,9 +242,9 @@ class EntityController extends Controller {
                 ], 400);
             }
         }
-        
+
         $data = $entity->getData();
-        
+
         return response()->json([
             'data' => $data,
             'metadata' => $entity->getAllMetadata(),
@@ -1184,13 +1184,13 @@ class EntityController extends Controller {
                 'error' => __('You do not have the permission to modify an entity'),
             ], 403);
         }
-        
+
        $request->validate([
             'rank' => 'required_without:to_end|integer',
             'parent_id' => 'nullable|integer|exists:entities,id',
             'to_end' => 'nullable|boolean',
         ]);
-        
+
         $entity;
         try{
             $entity = Entity::findOrFail($id);
@@ -1199,10 +1199,10 @@ class EntityController extends Controller {
             'error' => __('This entity does not exist'),
             ], 400);
         }
-        
+
         $rank = $request->get('rank') ?? null;
         $parent_id = $request->get('parent_id') ?? null;
-    
+
         try{
             $entity->move($parent_id, $rank, $user);
         } catch(Exception $e) {

--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -212,6 +212,48 @@ class EntityController extends Controller {
         $data = $entity->getData($aid);
         return response()->json($data);
     }
+    
+    /**
+     * Bundles the requests of data reference, metadata and parentValue
+     * to achieve much better performance.
+     */
+    public function getEntityDetail(int $id){
+         $user = auth()->user();
+        if(!$user->can('entity_read') || !$user->can('entity_data_read')) {
+            return response()->json([
+                'error' => __('You do not have the permission to get an entity\'s data'),
+            ], 403);
+        }
+
+        $entity = null;
+        try{
+            $entity = Entity::findOrFail($id);
+        } catch(ModelNotFoundException $e) {
+            return response()->json([
+                'error' => __('This entity does not exist'),
+            ], 400);
+        }
+        if(isset($aid)) {
+            try {
+                Attribute::findOrFail($aid);
+            } catch(ModelNotFoundException $e) {
+                return response()->json([
+                    'error' => __('This attribute does not exist'),
+                ], 400);
+            }
+        }
+        
+        $data = $entity->getData();
+        
+        return response()->json([
+            'data' => $data,
+            'metadata' => $entity->getAllMetadata(),
+            'references' => Reference::getByEntity($id),
+            'parentIds' => $entity->parentIds,
+            'parentNames' => $entity->parentNames,
+            'attributeLinks' => $entity->attributeLinks,
+        ]);
+    }
 
     public function getMetadata($id) {
         $user = auth()->user();

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -36,23 +36,8 @@ class ReferenceController extends Controller {
             ], 400);
         }
 
-        $references = Reference::with(['attribute', 'bibliography'])->where('entity_id', $id)->get();
-
-        $groupedReferences = [];
-        foreach($references as $r) {
-            if(isset($r->attribute)) {
-                $key = $r->attribute->thesaurus_url;
-            } else {
-                $key = 'on_entity';
-            }
-            if(!isset($groupedReferences[$key])) {
-                $groupedReferences[$key] = [];
-            }
-            unset($r->attribute);
-            $groupedReferences[$key][] = $r;
-        }
-
-        return response()->json($groupedReferences);
+        $references = Reference::getByEntity($id);
+        return response()->json($references);
     }
 
     // POST

--- a/app/Reference.php
+++ b/app/Reference.php
@@ -60,6 +60,26 @@ class Reference extends Model
         $this->save();
     }
 
+    public static function getByEntity($entityId) {
+        $references = Reference::with(['attribute', 'bibliography'])->where('entity_id', $entityId)->get();
+
+        $groupedReferences = [];
+        foreach($references as $r) {
+            if(isset($r->attribute)) {
+                $key = $r->attribute->thesaurus_url;
+            } else {
+                $key = 'on_entity';
+            }
+            if(!isset($groupedReferences[$key])) {
+                $groupedReferences[$key] = [];
+            }
+            unset($r->attribute);
+            $groupedReferences[$key][] = $r;
+        }
+
+        return $groupedReferences;
+    }
+
     public function user() {
         return $this->belongsTo('App\User');
     }

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -104,6 +104,9 @@ export async function getEntityParentMetadata(id, fields = ['ids', 'names', 'lin
     );
 }
 
+// TODO: Currently not used anymore as getEntityDetailsData is
+//       bundling multiple requests. Decide if we want to remove the api
+//       or keep it for future use.
 export async function getEntityData(id) {
     return await $httpQueue.add(
         () => http.get(`/entity/${id}/data`)
@@ -117,6 +120,22 @@ export async function getEntityData(id) {
     );
 }
 
+export async function getEntityDetailsData(id) {
+    return await $httpQueue.add(
+        () => http.get(`/entity/${id}/entity_detail`)
+            .then(response => {
+                // PHP returns Array if it is empty
+                if(response.data instanceof Array) {
+                    response.data = {};
+                }
+                return response.data;
+            })
+    );
+}
+
+// TODO: Currently not used anymore as getEntityDetailsData is
+//       bundling multiple requests. Decide if we want to remove the api
+//       or keep it for future use.
 export async function getEntityReferences(id) {
     return await $httpQueue.add(
         () => http.get(`/entity/${id}/reference`)
@@ -357,13 +376,13 @@ export async function duplicateEntity(entity) {
     );
 }
 
-export async function exportEntityTree(root){
+export async function exportEntityTree(root) {
     return $httpQueue.add(
-        () => http.get(`/entity/${root}/export`,{
+        () => http.get(`/entity/${root}/export`, {
             responseType: 'blob'
         })
-        .then(File.saveFileWithFallback('export_no_name'))
-        .catch(e => { throw e; })
+            .then(File.saveFileWithFallback('export_no_name'))
+            .catch(e => { throw e; })
     );
 }
 

--- a/resources/js/bootstrap/stores/entity.js
+++ b/resources/js/bootstrap/stores/entity.js
@@ -34,9 +34,8 @@ import {
     fetchEntityMetadata,
     getEntity,
     getEntityComments,
-    getEntityData,
+    getEntityDetailsData,
     getEntityParentMetadata,
-    getEntityReferences,
     handleModeration,
     moveEntity,
     patchEntityType,
@@ -611,18 +610,7 @@ export const useEntityStore = defineStore('entity', {
             }
         },
         async setById(entityId) {
-            let entity = this.entities[entityId];
-            if(!entity) {
-                const ids = await getEntityParentMetadata(entityId, ['ids']);
-                await openPath(ids);
-                entity = this.entities[entityId];
-            }
-            if(!entity.parentIds) {
-                const parentMetadata = await getEntityParentMetadata(entityId);
-                this.entities[entityId].parentIds = parentMetadata.parentIds;
-                this.entities[entityId].parentNames = parentMetadata.parentNames;
-                this.entities[entityId].attributeLinks = parentMetadata.attributeLinks;
-            }
+            let entity;
             if(!can('entity_data_read')) {
                 entity = {
                     ...entity,
@@ -635,9 +623,21 @@ export const useEntityStore = defineStore('entity', {
                 };
                 fillEntityData(entity.data, entity.entity_type_id);
             } else {
-                entity.data = await getEntityData(entityId);
+                entity = this.entities[entityId];
+                const entityDetail = await getEntityDetailsData(entityId);
+
+                // If the entity was not yet loaded into the cache, it means it's 
+                // an unloaded child entity. Therefore we need to open the path
+                // to that entity.
+                if(!entity) {
+                    await openPath(entityDetail.parentIds);
+                    console.log(this.entities[entityId]);
+                    entity = this.entities[entityId];
+                }
+
+                entity = Object.assign(entity, entityDetail);
+
                 fillEntityData(entity.data, entity.entity_type_id);
-                entity.references = await getEntityReferences(entityId) || {};
                 for(let k in entity.data) {
                     const curr = entity.data[k];
                     if(curr.attribute) {
@@ -646,6 +646,15 @@ export const useEntityStore = defineStore('entity', {
                             entity.references[key] = [];
                         }
                     }
+                }
+
+                // Fetch parent paths if they are not set already.
+                if(!entity.parentIds) {
+                    console.log(entity.parentIds);
+                    const parentMetadata = await getEntityParentMetadata(entityId);
+                    entity.parentIds = parentMetadata.parentIds;
+                    entity.parentNames = parentMetadata.parentNames;
+                    entity.attributeLinks = parentMetadata.attributeLinks;
                 }
             }
             this.set(entity);

--- a/resources/js/bootstrap/stores/entity.js
+++ b/resources/js/bootstrap/stores/entity.js
@@ -626,12 +626,11 @@ export const useEntityStore = defineStore('entity', {
                 entity = this.entities[entityId];
                 const entityDetail = await getEntityDetailsData(entityId);
 
-                // If the entity was not yet loaded into the cache, it means it's 
+                // If the entity was not yet loaded into the cache, it means it's
                 // an unloaded child entity. Therefore we need to open the path
                 // to that entity.
                 if(!entity) {
                     await openPath(entityDetail.parentIds);
-                    console.log(this.entities[entityId]);
                     entity = this.entities[entityId];
                 }
 
@@ -650,7 +649,6 @@ export const useEntityStore = defineStore('entity', {
 
                 // Fetch parent paths if they are not set already.
                 if(!entity.parentIds) {
-                    console.log(entity.parentIds);
                     const parentMetadata = await getEntityParentMetadata(entityId);
                     entity.parentIds = parentMetadata.parentIds;
                     entity.parentNames = parentMetadata.parentNames;

--- a/resources/js/components/EntityDetail.vue
+++ b/resources/js/components/EntityDetail.vue
@@ -337,7 +337,11 @@
                 class="tab-pane fade h-100 active-entity-detail-panel overflow-hidden"
                 role="tabpanel"
             >
-                <MetadataTab class="mb-auto scroll-y-auto h-100 pe-2" />
+                <!-- Only show the metadata tab when in the correct tab to avoid loading metadata. -->
+                <MetadataTab
+                    v-if="state.view === 'metadata'"
+                    class="mb-auto scroll-y-auto h-100 pe-2"
+                />
             </div>
 
             <div
@@ -501,10 +505,13 @@
             const entityStore = useEntityStore();
 
             // FETCH
-            entityStore.setById(route.params.id).then(_ => {
-                entityStore.getEntityTypeAttributeSelections(state.entity.entity_type_id);
-                state.initFinished = true;
-                updateAllDependencies();
+
+            onMounted(() => {
+                entityStore.setById(route.params.id).then(_ => {
+                    entityStore.getEntityTypeAttributeSelections(state.entity.entity_type_id);
+                    state.initFinished = true;
+                    updateAllDependencies();
+                }).catch(console.error);
             });
 
             // DATA
@@ -519,7 +526,6 @@
                 entityMetadata: {},
                 initFinished: false,
                 commentLoadingState: 'not',
-                metadataTabLoaded: false,
                 hiddenAttributeState: false,
                 attributesInTabs: true,
                 routeQuery: computed(_ => route.query),
@@ -685,6 +691,7 @@
                     return state.commentLoadingState === 'failed';
                 }),
                 activeUsers: computed(_ => entityStore.getActiveEntityUsers),
+                view: computed(_ => route.query.view || 'attributes-default')
             });
             const channels = {};
 
@@ -1188,7 +1195,6 @@
                             handleEntityCommentUpdated,
                             handleEntityCommentDeleted,
                         ]);
-                        await entityStore.setById(to.params.id);
                         return true;
                     }
                 } else {

--- a/resources/js/components/entity/MetadataTab.vue
+++ b/resources/js/components/entity/MetadataTab.vue
@@ -179,11 +179,8 @@
             const save = async _ => {
                 if(state.isDirty) {
                     patchEntityMetadata(state.entity.id, state.changedMetadata).then(data => {
-
-                        setMetadata({...metadata});
-
+                        setMetadata({...data.metadata});
                         entityStore.updateEntityMetadata(state.entity.id, data);
-
                         toast.$toast(
                             t('main.entity.toasts.updated_metadata.msg', {
                                 name: data.name

--- a/resources/js/components/tree/Entity.vue
+++ b/resources/js/components/tree/Entity.vue
@@ -346,8 +346,8 @@
                 // if treeSelectionMode is active, itemClick is (wrongly) triggered, but has no data.
                 // Preventing itemClick to trigger would result in not checked checkboxes in node component
                 if(!item.data) return;
-
-                if(state.entity.id == item.data.id) {
+                
+                if(state?.entity?.id == item.data.id) {
                     router.push({
                         append: true,
                         name: 'home',

--- a/resources/js/components/tree/Entity.vue
+++ b/resources/js/components/tree/Entity.vue
@@ -346,7 +346,7 @@
                 // if treeSelectionMode is active, itemClick is (wrongly) triggered, but has no data.
                 // Preventing itemClick to trigger would result in not checked checkboxes in node component
                 if(!item.data) return;
-                
+
                 if(state?.entity?.id == item.data.id) {
                     router.push({
                         append: true,

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,7 @@ Route::middleware('auth:sanctum')->prefix('v1/entity')->group(function() {
     // This route is only used for the map plugin
     Route::get('/entity_type/{etid}/data/{aid}', 'EntityController@getDataForEntityType')->where('etid', '[0-9]+')->where('aid', '[0-9]+');
     Route::get('/{id}/data/{aid?}', 'EntityController@getData')->where('id', '[0-9]+');
+    Route::get('/{id}/entity_detail', 'EntityController@getEntityDetail')->where('id', '[0-9]+');
     Route::get('/{id}/metadata', 'EntityController@getMetadata')->where('id', '[0-9]+');
     Route::get('/{id}/reference', 'ReferenceController@getByEntity')->where('id', '[0-9]+');
     Route::get('/{id}/export', 'EntityController@exportEntityTree')->where('id', '[0-9]+');

--- a/tests/Feature/ApiSearchTest.php
+++ b/tests/Feature/ApiSearchTest.php
@@ -197,13 +197,14 @@ class ApiSearchTest extends TestCase
 
         $content = json_decode($response->getContent());
         $response->assertStatus(200);
-        $response->assertJsonCount(9);
+        $response->assertJsonCount(10);
         // response content is Laravel Paginate Array
         $this->assertObjectHasProperty('data', $content);
         $this->assertObjectHasProperty('from', $content);
         $this->assertObjectHasProperty('to', $content);
         $this->assertObjectHasProperty('per_page', $content);
         $this->assertObjectHasProperty('current_page', $content);
+        $this->assertObjectHasProperty('current_page_url', $content);
         $this->assertObjectHasProperty('first_page_url', $content);
         $this->assertObjectHasProperty('next_page_url', $content);
         $this->assertObjectHasProperty('prev_page_url', $content);


### PR DESCRIPTION
I noticed the application being very slow when changing entities.
This was due to the endpoints being called twice for every entity change and
additionally due to a lot of heavy lifting being done in every middleware on every request.

In this PR I removed the redundant api calls, fixed the metadata tab* only fetching the data when being visited and combined all data that needs to be retrieved
by the entity detail in a single endpoint:
GET::v1/entity/{id}/entity_detail

That returns the data:
```php
[
         'data' => $data,
            'metadata' => $entity->getAllMetadata(),
            'references' => Reference::getByEntity($id),
            'parentIds' => $entity->parentIds,
            'parentNames' => $entity->parentNames,
            'attributeLinks' => $entity->attributeLinks,
]
```

This results in way better performance and therefore a much better responsiveness of the app.

* Furthermore when adjusting the unecessary request with the metadata tab I fixed an error throwing an error when saving the metadata tab (unknown variable).