### PR TITLE
Fixed ImageTIle and layer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Errors in _map.js_
   - using undeclared & deprecated _TileImage_, now using _ImageTile_
-  - using undefined _layer_ in map.js, now using _layerdata.layer_
+  - using undefined _layer_ in map.js, now using _layerData.layer_
 
 ## 0.11.1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Alerts can now be dismissed
 
+### Fixed
+- Errors in _map.js_
+  - using undeclared & deprecated _TileImage_, now using _ImageTile_
+  - using undefined _layer_ in map.js, now using _layerdata.layer_
+
 ## 0.11.1
 ### Added
 - Unit Tests for Directory.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.12 - (Luxor)
-### Changed
-- Alerts can now be dismissed
-
 ### Fixed
 - Errors in _map.js_
-  - using undeclared & deprecated _TileImage_, now using _ImageTile_
-  - using undefined _layer_ in map.js, now using _layerData.layer_
+### Changed
+  - Alerts can now be dismissed
 
 ## 0.11.1
 ### Added
 - Unit Tests for Directory.php
-### Changed
-- Added path value to XSRF cookie to prevent overwriting by another instance at the same domain
-- _Show x replies_ button in comment list moved to header
 ### Fixed
 - Login not possible on instances in subfolder
 - Last editor not visible in _Entity Detail_ tab
@@ -31,6 +25,9 @@ All notable changes to this project will be documented in this file.
 - Fixed add/remove of plugin correctly setup in store and SpPS
 - Fixed error when generating cite key where bibliography title contained a space separated part of non-alphanumerical characters
 - Reply to comment from notification
+### Changed
+- Added path value to XSRF cookie to prevent overwriting by another instance at the same domain
+- _Show x replies_ button in comment list moved to header
 
 ## 0.11 - Kilcrea
 ### Added

--- a/resources/js/helpers/map.js
+++ b/resources/js/helpers/map.js
@@ -23,6 +23,7 @@ import GeoJSON from 'ol/format/GeoJSON';
 
 import BingMaps from 'ol/source/BingMaps';
 import OSM from 'ol/source/OSM';
+import ImageTile from 'ol/source/ImageTile';
 import TileWMS from 'ol/source/TileWMS';
 import Vector from 'ol/source/Vector';
 
@@ -280,14 +281,14 @@ export function createNewLayer(layerData) {
 
     switch(layerData.type) {
         case 'xyz':
-            source = new TileImage(commonSourceOptions);
+            source = new ImageTile(commonSourceOptions);
             break;
         case 'wms':
             source = new TileWMS({
                 ...commonSourceOptions,
                 serverType: 'geoserver',
                 params: {
-                    layers: layers,
+                    layers: layerData.layers,
                     tiled: true,
                 },
             });


### PR DESCRIPTION
The spacialist map.js caused errors when using the map plugin.

  - Fixed using undeclared & deprecated _TileImage_, now using _ImageTile_
  - Fixed using undefined _layer_ in map.js, now using _layerdata.layer_