### PR TITLE
[0.13] Migrate To PEST As Testing Framework And Add Browser Testing

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,6 +1,14 @@
 name: PhpUnit
 
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - main
+      - 'release-**'
+  pull_request:
+    branches:
+      - main
+      - 'release-**'
 
 jobs:
   laravel-tests:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Setup Log Directory
       run: mkdir -p build/logs
     - name: Execute tests (Unit and Feature tests) via PHPUnit
-      run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+      run: vendor/bin/pest --coverage-clover build/logs/clover.xml
     - uses: codecov/codecov-action@v4
       name: Codecov Coverage
       with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         pg-gis-combo: ['16-3.5-alpine', '17-3.5-alpine']
         databases: ['pgsql']
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ npm-debug.log
 yarn-error.log
 yarn.lock
 .env
-.env.testing
+.env.*
 
 # Vite
 /public/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added .env variable `ALLOW_FILESYSTEM_MIGRATIONS` to explcitly enable filesystem migrations
 - API endpoint for getting all entity details data in one request: GET::v1/entity/{id}/entity_detail
+- PEST Browser testing functionality 
 ### Fixed
 - Removed redundant calls to the entity endpoint
 - Metadata tab error on submit (unknown variable)
@@ -12,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Alerts can now be dismissed
 - Now entity metadata is only loaded when accessing the metadata tab
+- Moved to PEST as testing framework
 - Migrations now have logging automatically disabled
 - Migrations that require filesystem changes can now be handled using the `App\Traits\FilesystemMigration` trait (call `$this->safelyMoveDirectoryBetweenDisks(...)` with `ALLOW_FILESYTEM_MIGRATIONS` set to `true`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Alerts can now be dismissed
 - Now entity metadata is only loaded when accessing the metadata tab
-- Moved to PEST as testing framework
 - Migrations now have logging automatically disabled
 - Migrations that require filesystem changes can now be handled using the `App\Traits\FilesystemMigration` trait (call `$this->safelyMoveDirectoryBetweenDisks(...)` with `ALLOW_FILESYTEM_MIGRATIONS` set to `true`)
+- Moved to PEST as testing framework
+- PHP version requirements for testing changed: [8.2, 8.3] =>  [8.3, 8.4]
 
 ## 0.11.1
 ### Added

--- a/app/Traits/FilesystemMigration.php
+++ b/app/Traits/FilesystemMigration.php
@@ -37,7 +37,7 @@ trait FilesystemMigration {
      * @param string|null $destDirectory
      * @return void
      */
-    protected function safelyMoveDirectoryBetweenDisks(string $srcDisk, string $destDisk, string $srcDirectory, string $destDirectory = null): void {
+    protected function safelyMoveDirectoryBetweenDisks(string $srcDisk, string $destDisk, string $srcDirectory, ?string $destDirectory = null): void {
         if($destDirectory === null) {
             $destDirectory = $srcDirectory;
         }

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "^8.1",
-        "pestphp/pest": "*",
-        "pestphp/pest-plugin-drift": "*"
+        "pestphp/pest": "*"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "^8.1",
         "pestphp/pest": "*",
-        "pestphp/pest-plugin-browser": "4.1.1@dev"
+        "pestphp/pest-plugin-browser": "4.1.1"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "^8.1",
-        "pestphp/pest": "*"
+        "pestphp/pest": "*",
+        "pestphp/pest-plugin-browser": "4.1.1@dev"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "~1.0",
         "nunomaduro/collision": "^8.1",
-        "phpunit/phpunit": "^11.0"
+        "pestphp/pest": "*",
+        "pestphp/pest-plugin-drift": "*"
     },
     "autoload": {
         "files": [
@@ -66,13 +67,15 @@
             "@php artisan key:generate"
         ],
         "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump"
         ]
     },
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fe52b66f4e7b14ea565feec08fd888f",
+    "content-hash": "08e85f0d569e306d03d815a657736c94",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -4206,16 +4206,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -4258,37 +4258,37 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.1",
+            "version": "v2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123"
+                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/dfa08f390e509967a15c22493dc0bac5733d9123",
-                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.2.6"
+                "symfony/console": "^7.3.6"
             },
             "require-dev": {
-                "illuminate/console": "^11.44.7",
-                "laravel/pint": "^1.22.0",
+                "illuminate/console": "^11.46.1",
+                "laravel/pint": "^1.25.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.2",
-                "phpstan/phpstan": "^1.12.25",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.2.6",
+                "symfony/var-dumper": "^7.3.5",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -4331,7 +4331,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.1"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
             },
             "funding": [
                 {
@@ -4347,7 +4347,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-08T08:14:37+00:00"
+            "time": "2025-11-20T02:34:59+00:00"
         },
         {
             "name": "paragonie/sodium_compat",
@@ -7065,16 +7065,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
+                "reference": "0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
-                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8",
+                "reference": "0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8",
                 "shasum": ""
             },
             "require": {
@@ -7082,7 +7082,7 @@
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<6.4",
@@ -7096,16 +7096,16 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7139,7 +7139,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.3"
+                "source": "https://github.com/symfony/console/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7159,7 +7159,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2025-11-27T13:27:24+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -7536,23 +7536,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.3.2",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe"
+                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2a6614966ba1074fa93dae0bc804227422df4dfe",
-                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
+                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7580,7 +7580,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.3.2"
+                "source": "https://github.com/symfony/finder/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7600,7 +7600,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2025-11-05T05:42:40+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -8886,16 +8886,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
+                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
+                "reference": "7ca8dc2d0dcf4882658313aba8be5d9fd01026c8",
                 "shasum": ""
             },
             "require": {
@@ -8927,7 +8927,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.3"
+                "source": "https://github.com/symfony/process/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -8947,7 +8947,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-18T09:42:54+00:00"
+            "time": "2025-10-16T11:21:06+00:00"
         },
         {
             "name": "symfony/routing",
@@ -9036,16 +9036,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
@@ -9099,7 +9099,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -9111,43 +9111,46 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.3",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
+                "reference": "f929eccf09531078c243df72398560e32fa4cf4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
-                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f929eccf09531078c243df72398560e32fa4cf4f",
+                "reference": "f929eccf09531078c243df72398560e32fa4cf4f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9186,7 +9189,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.3"
+                "source": "https://github.com/symfony/string/tree/v8.0.0"
             },
             "funding": [
                 {
@@ -9206,7 +9209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-25T06:35:40+00:00"
+            "time": "2025-09-11T14:37:55+00:00"
         },
         {
             "name": "symfony/translation",
@@ -9310,16 +9313,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
+                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
+                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
                 "shasum": ""
             },
             "require": {
@@ -9368,7 +9371,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -9380,11 +9383,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-27T08:32:26+00:00"
+            "time": "2025-07-15T13:41:35+00:00"
         },
         {
             "name": "symfony/uid",
@@ -9934,28 +9941,28 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
@@ -9986,9 +9993,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
@@ -10059,6 +10066,208 @@
                 "source": "https://github.com/beyondcode/laravel-dump-server/tree/2.1.0"
             },
             "time": "2025-02-26T08:27:59+00:00"
+        },
+        {
+            "name": "brianium/paratest",
+            "version": "v7.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^12.5.0",
+                "phpunit/php-file-iterator": "^6",
+                "phpunit/php-timer": "^8",
+                "phpunit/phpunit": "^12.4.4",
+                "sebastian/environment": "^8.0.3",
+                "symfony/console": "^7.3.4 || ^8.0.0",
+                "symfony/process": "^7.3.4 || ^8.0.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-pcntl": "*",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.32",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "symfony/filesystem": "^7.3.2 || ^8.0.0"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2025-11-30T08:08:11+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "filp/whoops",
@@ -10240,6 +10449,66 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -10384,16 +10653,16 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.2",
+            "version": "v8.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb"
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
-                "reference": "60207965f9b7b7a4ce15a0f75d57f9dadb105bdb",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
                 "shasum": ""
             },
             "require": {
@@ -10415,7 +10684,7 @@
                 "laravel/sanctum": "^4.1.1",
                 "laravel/tinker": "^2.10.1",
                 "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2",
+                "pestphp/pest": "^3.8.2 || ^4.0.0",
                 "sebastian/environment": "^7.2.1 || ^8.0"
             },
             "type": "library",
@@ -10479,7 +10748,464 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-06-25T02:12:12+00:00"
+            "time": "2025-11-20T02:55:25+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.14.2",
+                "nunomaduro/collision": "^8.8.3",
+                "nunomaduro/termwind": "^2.3.3",
+                "pestphp/pest-plugin": "^4.0.0",
+                "pestphp/pest-plugin-arch": "^4.0.0",
+                "pestphp/pest-plugin-mutate": "^4.0.1",
+                "pestphp/pest-plugin-profanity": "^4.2.0",
+                "php": "^8.3.0",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/process": "^7.4.0|^8.0.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">12.4.4",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-browser": "^4.1.1",
+                "pestphp/pest-plugin-type-coverage": "^4.0.3",
+                "psy/psysh": "^0.12.15"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v4.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-28T12:04:48+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.3"
+            },
+            "conflict": {
+                "pestphp/pest": "<4.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.8.10",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-08-20T12:35:58+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T13:10:51+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-drift",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-drift.git",
+                "reference": "f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-drift/zipball/f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e",
+                "reference": "f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.6.1",
+                "pestphp/pest": "^4.0.0",
+                "php": "^8.3.0",
+                "symfony/finder": "^7.3.2"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Drift\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Drift\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Drift Plugin",
+            "keywords": [
+                "framework",
+                "laravel",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-drift/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/mandisma",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T12:54:20+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.6.1",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-21T20:19:25+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/c37e5e2c7136ee4eae12082e7952332bc1c6600a",
+                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.9",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.0"
+            },
+            "time": "2025-10-28T23:14:11+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10600,36 +11326,257 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "11.0.11",
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
-                "reference": "4f7722aa9a7b76aa775e2d9d4e95d1ea16eeeef4",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
+            },
+            "time": "2025-11-27T19:50:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
+                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.4.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.0",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.2.3"
+                "nikic/php-parser": "^5.6.2",
+                "php": ">=8.3",
+                "phpunit/php-file-iterator": "^6.0",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^1.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.2"
+                "phpunit/phpunit": "^12.4.4"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -10638,7 +11585,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -10667,7 +11614,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.0"
             },
             "funding": [
                 {
@@ -10687,32 +11634,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-27T14:37:49+00:00"
+            "time": "2025-11-29T07:15:54+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -10740,7 +11687,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
             },
             "funding": [
                 {
@@ -10748,28 +11695,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T05:02:59+00:00"
+            "time": "2025-02-07T04:58:37+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -10777,7 +11724,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -10804,7 +11751,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -10812,32 +11759,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -10864,7 +11811,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -10872,32 +11819,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -10924,7 +11871,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -10932,20 +11879,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.37",
+            "version": "12.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b87c1ad30535b40f14db1aa048e11747ba22e6ff"
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b87c1ad30535b40f14db1aa048e11747ba22e6ff",
-                "reference": "b87c1ad30535b40f14db1aa048e11747ba22e6ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
                 "shasum": ""
             },
             "require": {
@@ -10958,26 +11905,22 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.11",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.2",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.0",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.4.0",
+                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.3",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -10985,7 +11928,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-main": "12.4-dev"
                 }
             },
             "autoload": {
@@ -11017,7 +11960,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.37"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
             },
             "funding": [
                 {
@@ -11041,32 +11984,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T06:21:19+00:00"
+            "time": "2025-11-21T07:39:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -11090,152 +12033,51 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:41:36+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.2",
+            "version": "7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8"
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85c77556683e6eee4323e4c5468641ca0237e2e8",
-                "reference": "85c77556683e6eee4323e4c5468641ca0237e2e8",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
+                "phpunit/phpunit": "^12.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -11243,7 +12085,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -11283,7 +12125,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
             },
             "funding": [
                 {
@@ -11303,33 +12145,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T08:07:46+00:00"
+            "time": "2025-08-20T11:27:00+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11353,7 +12195,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -11361,33 +12203,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11420,7 +12262,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -11428,27 +12270,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -11456,7 +12298,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -11484,7 +12326,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
             },
             "funding": [
                 {
@@ -11504,34 +12346,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2025-08-12T14:11:56+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.0",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/3473f61172093b2da7de1fb5782e1f24cc036dc3",
-                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11574,43 +12416,55 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T09:17:50+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -11636,41 +12490,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -11694,7 +12560,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
             },
             "funding": [
                 {
@@ -11702,34 +12568,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2025-02-07T04:57:28+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11752,7 +12618,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -11760,32 +12626,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11808,7 +12674,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -11816,32 +12682,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11872,7 +12738,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -11892,32 +12758,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.3",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11941,7 +12807,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
@@ -11961,29 +12827,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -12007,7 +12873,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -12015,7 +12881,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -12070,17 +12936,76 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0",
+                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
+            },
+            "time": "2025-04-20T20:23:40+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -12109,7 +13034,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -12117,7 +13042,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08e85f0d569e306d03d815a657736c94",
+    "content-hash": "48bc6cc3a193f759d5f4d35c5c6f772f",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -61,16 +61,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.0",
+            "version": "0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2"
+                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
-                "reference": "113a8ee2656b882d4c3164fa31aa6e12cbb7aaa2",
+                "url": "https://api.github.com/repos/brick/math/zipball/f05858549e5f9d7bb45875a75583240a38a281d0",
+                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0",
                 "shasum": ""
             },
             "require": {
@@ -109,7 +109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.0"
+                "source": "https://github.com/brick/math/tree/0.14.1"
             },
             "funding": [
                 {
@@ -117,7 +117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-29T12:40:03+00:00"
+            "time": "2025-11-24T14:40:29+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -1026,29 +1026,28 @@
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v3.4.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "8c784d071debd117328803d86b2097615b457500"
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/8c784d071debd117328803d86b2097615b457500",
-                "reference": "8c784d071debd117328803d86b2097615b457500",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d61a8a9604ec1f8c3d150d09db6ce98b32675013",
+                "reference": "d61a8a9604ec1f8c3d150d09db6ce98b32675013",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "webmozart/assert": "^1.0"
+                "php": "^8.2|^8.3|^8.4|^8.5"
             },
             "replace": {
                 "mtdowling/cron-expression": "^1.0"
             },
             "require-dev": {
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0"
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.32|^2.1.31",
+                "phpunit/phpunit": "^8.5.48|^9.0"
             },
             "type": "library",
             "extra": {
@@ -1079,7 +1078,7 @@
             ],
             "support": {
                 "issues": "https://github.com/dragonmantank/cron-expression/issues",
-                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.4.0"
+                "source": "https://github.com/dragonmantank/cron-expression/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -1087,7 +1086,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T13:47:03+00:00"
+            "time": "2025-10-31T18:51:33+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -1330,31 +1329,31 @@
         },
         {
             "name": "fruitcake/php-cors",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruitcake/php-cors.git",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b"
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/3d158f36e7875e2f040f37bc0573956240a5a38b",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4|^8.0",
-                "symfony/http-foundation": "^4.4|^5.4|^6|^7"
+                "php": "^8.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan": "^2",
                 "phpunit/phpunit": "^9",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1385,7 +1384,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fruitcake/php-cors/issues",
-                "source": "https://github.com/fruitcake/php-cors/tree/v1.3.0"
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.4.0"
             },
             "funding": [
                 {
@@ -1397,7 +1396,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-12T05:21:21+00:00"
+            "time": "2025-12-03T09:33:47+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -2447,16 +2446,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.28.1",
+            "version": "v12.41.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "868c1f2d3dba4df6d21e3a8d818479f094cfd942"
+                "reference": "3e229b05935fd0300c632fb1f718c73046d664fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/868c1f2d3dba4df6d21e3a8d818479f094cfd942",
-                "reference": "868c1f2d3dba4df6d21e3a8d818479f094cfd942",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/3e229b05935fd0300c632fb1f718c73046d664fc",
+                "reference": "3e229b05935fd0300c632fb1f718c73046d664fc",
                 "shasum": ""
             },
             "require": {
@@ -2568,13 +2567,13 @@
                 "league/flysystem-sftp-v3": "^3.25.1",
                 "mockery/mockery": "^1.6.10",
                 "opis/json-schema": "^2.4.1",
-                "orchestra/testbench-core": "^10.6.5",
+                "orchestra/testbench-core": "^10.8.0",
                 "pda/pheanstalk": "^5.0.6|^7.0.0",
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
                 "predis/predis": "^2.3|^3.0",
-                "resend/resend-php": "^0.10.0",
+                "resend/resend-php": "^0.10.0|^1.0",
                 "symfony/cache": "^7.2.0",
                 "symfony/http-client": "^7.2.0",
                 "symfony/psr-http-message-bridge": "^7.2.0",
@@ -2593,7 +2592,7 @@
                 "ext-pdo": "Required to use all database features.",
                 "ext-posix": "Required to use all features of the queue worker.",
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0|^6.0).",
-                "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+                "fakerphp/faker": "Required to generate fake data using the fake() helper (^1.23).",
                 "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.25.1).",
@@ -2608,7 +2607,7 @@
                 "predis/predis": "Required to use the predis connector (^2.3|^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
-                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
+                "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0|^1.0).",
                 "symfony/cache": "Required to PSR-6 cache bridge (^7.2).",
                 "symfony/filesystem": "Required to enable support for relative symbolic links (^7.2).",
                 "symfony/http-client": "Required to enable support for the Symfony API mail transports (^7.2).",
@@ -2662,20 +2661,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-04T14:58:12+00:00"
+            "time": "2025-12-03T01:02:13+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.6",
+            "version": "v0.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "86a8b692e8661d0fb308cec64f3d176821323077"
+                "reference": "096748cdfb81988f60090bbb839ce3205ace0d35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/86a8b692e8661d0fb308cec64f3d176821323077",
-                "reference": "86a8b692e8661d0fb308cec64f3d176821323077",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/096748cdfb81988f60090bbb839ce3205ace0d35",
+                "reference": "096748cdfb81988f60090bbb839ce3205ace0d35",
                 "shasum": ""
             },
             "require": {
@@ -2691,9 +2690,9 @@
             "require-dev": {
                 "illuminate/collections": "^10.0|^11.0|^12.0",
                 "mockery/mockery": "^1.5",
-                "pestphp/pest": "^2.3|^3.4",
-                "phpstan/phpstan": "^1.11",
-                "phpstan/phpstan-mockery": "^1.1"
+                "pestphp/pest": "^2.3|^3.4|^4.0",
+                "phpstan/phpstan": "^1.12.28",
+                "phpstan/phpstan-mockery": "^1.1.3"
             },
             "suggest": {
                 "ext-pcntl": "Required for the spinner to be animated."
@@ -2719,9 +2718,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.6"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.8"
             },
-            "time": "2025-07-07T14:17:42+00:00"
+            "time": "2025-11-21T20:52:52+00:00"
         },
         {
             "name": "laravel/reverb",
@@ -2871,16 +2870,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.4",
+            "version": "v2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "b352cf0534aa1ae6b4d825d1e762e35d43f8a841"
+                "reference": "cb291e4c998ac50637c7eeb58189c14f5de5b9dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b352cf0534aa1ae6b4d825d1e762e35d43f8a841",
-                "reference": "b352cf0534aa1ae6b4d825d1e762e35d43f8a841",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/cb291e4c998ac50637c7eeb58189c14f5de5b9dd",
+                "reference": "cb291e4c998ac50637c7eeb58189c14f5de5b9dd",
                 "shasum": ""
             },
             "require": {
@@ -2889,7 +2888,7 @@
             "require-dev": {
                 "illuminate/support": "^10.0|^11.0|^12.0",
                 "nesbot/carbon": "^2.67|^3.0",
-                "pestphp/pest": "^2.36|^3.0",
+                "pestphp/pest": "^2.36|^3.0|^4.0",
                 "phpstan/phpstan": "^2.0",
                 "symfony/var-dumper": "^6.2.0|^7.0.0"
             },
@@ -2928,7 +2927,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2025-03-19T13:51:03+00:00"
+            "time": "2025-11-21T20:52:36+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -3061,16 +3060,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca"
+                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/10732241927d3971d28e7ea7b5712721fa2296ca",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
                 "shasum": ""
             },
             "require": {
@@ -3107,7 +3106,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.8-dev"
+                    "dev-main": "2.9-dev"
                 }
             },
             "autoload": {
@@ -3164,7 +3163,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-20T12:47:49+00:00"
+            "time": "2025-11-26T21:48:24+00:00"
         },
         {
             "name": "league/config",
@@ -3250,16 +3249,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.30.0",
+            "version": "3.30.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e"
+                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2203e3151755d874bb2943649dae1eb8533ac93e",
-                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
+                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
                 "shasum": ""
             },
             "require": {
@@ -3327,22 +3326,22 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.30.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.30.2"
             },
-            "time": "2025-06-25T13:29:59+00:00"
+            "time": "2025-11-10T17:13:11+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.30.0",
+            "version": "3.30.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10"
+                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/6691915f77c7fb69adfb87dcd550052dc184ee10",
-                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/ab4f9d0d672f601b102936aa728801dd1a11968d",
+                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d",
                 "shasum": ""
             },
             "require": {
@@ -3376,9 +3375,9 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.0"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.2"
             },
-            "time": "2025-05-21T10:34:19+00:00"
+            "time": "2025-11-10T11:23:37+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -3438,33 +3437,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "f625804987a0a9112d954f9209d91fec52182344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f625804987a0a9112d954f9209d91fec52182344",
+                "reference": "f625804987a0a9112d954f9209d91fec52182344",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.6",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
                 "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
                 "league/uri-components": "Needed to easily manipulate URI objects components",
+                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -3492,6 +3496,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -3504,9 +3509,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -3516,7 +3523,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.6.0"
             },
             "funding": [
                 {
@@ -3524,26 +3531,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/ccbfb51c0445298e7e0b7f4481b942f589665368",
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -3551,6 +3557,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -3575,7 +3582,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -3600,7 +3607,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.6.0"
             },
             "funding": [
                 {
@@ -3608,7 +3615,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -3900,16 +3907,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.10.3",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f"
+                "reference": "bdb375400dcd162624531666db4799b36b64e4a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
-                "reference": "8e3643dcd149ae0fe1d2ff4f2c8e4bbfad7c165f",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/bdb375400dcd162624531666db4799b36b64e4a1",
+                "reference": "bdb375400dcd162624531666db4799b36b64e4a1",
                 "shasum": ""
             },
             "require": {
@@ -3917,9 +3924,9 @@
                 "ext-json": "*",
                 "php": "^8.1",
                 "psr/clock": "^1.0",
-                "symfony/clock": "^6.3.12 || ^7.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0"
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -4001,29 +4008,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-06T13:39:36+00:00"
+            "time": "2025-12-02T21:04:28+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.2",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d"
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/da801d52f0354f70a638673c4a0f04e16529431d",
-                "reference": "da801d52f0354f70a638673c4a0f04e16529431d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^4.0",
-                "php": "8.1 - 8.4"
+                "php": "8.1 - 8.5"
             },
             "require-dev": {
                 "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^1.0",
+                "phpstan/phpstan-nette": "^2.0@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -4033,6 +4040,9 @@
                 }
             },
             "autoload": {
+                "psr-4": {
+                    "Nette\\": "src"
+                },
                 "classmap": [
                     "src/"
                 ]
@@ -4061,26 +4071,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.2"
+                "source": "https://github.com/nette/schema/tree/v1.3.3"
             },
-            "time": "2024-10-06T23:10:23+00:00"
+            "time": "2025-10-30T22:57:59+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.8",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede"
+                "reference": "fa1f0b8261ed150447979eb22e373b7b7ad5a8e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c930ca4e3cf4f17dcfb03037703679d2396d2ede",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede",
+                "url": "https://api.github.com/repos/nette/utils/zipball/fa1f0b8261ed150447979eb22e373b7b7ad5a8e0",
+                "reference": "fa1f0b8261ed150447979eb22e373b7b7ad5a8e0",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.5"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -4103,7 +4113,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -4150,9 +4160,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.8"
+                "source": "https://github.com/nette/utils/tree/v4.1.0"
             },
-            "time": "2025-08-06T21:43:34+00:00"
+            "time": "2025-12-01T17:49:23+00:00"
         },
         {
             "name": "nicolaslopezj/searchable",
@@ -6991,22 +7001,21 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v7.3.0",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24"
+                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
-                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
+                "reference": "832119f9b8dbc6c8e6f65f30c5969eca1e88764f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "php": ">=8.4",
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -7045,7 +7054,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.3.0"
+                "source": "https://github.com/symfony/clock/tree/v8.0.0"
             },
             "funding": [
                 {
@@ -7057,11 +7066,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2025-11-12T15:46:48+00:00"
         },
         {
             "name": "symfony/console",
@@ -7163,16 +7176,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.3.0",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2"
+                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/601a5ce9aaad7bf10797e3663faefce9e26c24e2",
-                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
+                "reference": "ab862f478513e7ca2fe9ec117a6f01a8da6e1135",
                 "shasum": ""
             },
             "require": {
@@ -7208,7 +7221,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7220,11 +7233,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2025-10-30T13:39:42+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -7295,32 +7312,33 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.3.2",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3"
+                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
-                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/48be2b0653594eea32dcef130cca1c811dcf25c2",
+                "reference": "48be2b0653594eea32dcef130cca1c811dcf25c2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "conflict": {
                 "symfony/deprecation-contracts": "<2.5",
                 "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
                 "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
@@ -7352,7 +7370,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.3.2"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7372,28 +7390,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-07T08:17:57+00:00"
+            "time": "2025-11-05T14:29:59+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.3",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
+                "reference": "573f95783a2ec6e38752979db139f09fec033f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/573f95783a2ec6e38752979db139f09fec033f03",
+                "reference": "573f95783a2ec6e38752979db139f09fec033f03",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -7402,13 +7420,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7436,7 +7455,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.0"
             },
             "funding": [
                 {
@@ -7456,7 +7475,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2025-10-30T14:17:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7604,23 +7623,22 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00"
+                "reference": "769c1720b68e964b13b58529c17d4a385c62167b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7475561ec27020196c49bb7c4f178d33d7d3dc00",
-                "reference": "7475561ec27020196c49bb7c4f178d33d7d3dc00",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/769c1720b68e964b13b58529c17d4a385c62167b",
+                "reference": "769c1720b68e964b13b58529c17d4a385c62167b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php83": "^1.27"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.1"
             },
             "conflict": {
                 "doctrine/dbal": "<3.6",
@@ -7629,13 +7647,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
-                "symfony/cache": "^6.4.12|^7.1.5",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/mime": "^6.4|^7.0",
-                "symfony/rate-limiter": "^6.4|^7.0"
+                "symfony/cache": "^6.4.12|^7.1.5|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7663,7 +7681,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7683,29 +7701,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T08:04:18+00:00"
+            "time": "2025-11-13T08:49:24+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b"
+                "reference": "7348193cd384495a755554382e4526f27c456085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/72c304de37e1a1cec6d5d12b81187ebd4850a17b",
-                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7348193cd384495a755554382e4526f27c456085",
+                "reference": "7348193cd384495a755554382e4526f27c456085",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^7.3",
-                "symfony/http-foundation": "^7.3",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^7.3|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -7715,6 +7733,7 @@
                 "symfony/console": "<6.4",
                 "symfony/dependency-injection": "<6.4",
                 "symfony/doctrine-bridge": "<6.4",
+                "symfony/flex": "<2.10",
                 "symfony/form": "<6.4",
                 "symfony/http-client": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
@@ -7732,27 +7751,27 @@
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^6.4|^7.0",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/css-selector": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/dom-crawler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/finder": "^6.4|^7.0",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^7.1",
-                "symfony/routing": "^6.4|^7.0",
-                "symfony/serializer": "^7.1",
-                "symfony/stopwatch": "^6.4|^7.0",
-                "symfony/translation": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^7.1|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^7.1|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^6.4|^7.0",
-                "symfony/validator": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0",
-                "symfony/var-exporter": "^6.4|^7.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0",
                 "twig/twig": "^3.12"
             },
             "type": "library",
@@ -7781,7 +7800,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.3.3"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7801,20 +7820,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T08:23:45+00:00"
+            "time": "2025-11-27T13:38:24+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575"
+                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/a32f3f45f1990db8c4341d5122a7d3a381c7e575",
-                "reference": "a32f3f45f1990db8c4341d5122a7d3a381c7e575",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
+                "reference": "a3d9eea8cfa467ece41f0f54ba28185d74bd53fd",
                 "shasum": ""
             },
             "require": {
@@ -7822,8 +7841,8 @@
                 "php": ">=8.2",
                 "psr/event-dispatcher": "^1",
                 "psr/log": "^1|^2|^3",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/mime": "^7.2",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.2|^8.0",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -7834,10 +7853,10 @@
                 "symfony/twig-bridge": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/twig-bridge": "^6.4|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7865,7 +7884,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.3.3"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7885,24 +7904,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2025-11-21T15:26:00+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.3.2",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1"
+                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/e0a0f859148daf1edf6c60b398eb40bfc96697d1",
-                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/bdb02729471be5d047a3ac4a69068748f1a6be7a",
+                "reference": "bdb02729471be5d047a3ac4a69068748f1a6be7a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
@@ -7917,11 +7937,11 @@
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/property-info": "^6.4|^7.0",
-                "symfony/serializer": "^6.4.3|^7.0.3"
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7953,7 +7973,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.3.2"
+                "source": "https://github.com/symfony/mime/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -7973,7 +7993,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2025-11-16T10:14:42+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8951,16 +8971,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.3.2",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4"
+                "reference": "4720254cb2644a0b876233d258a32bf017330db7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
-                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/4720254cb2644a0b876233d258a32bf017330db7",
+                "reference": "4720254cb2644a0b876233d258a32bf017330db7",
                 "shasum": ""
             },
             "require": {
@@ -8974,11 +8994,11 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9012,7 +9032,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.3.2"
+                "source": "https://github.com/symfony/routing/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -9032,7 +9052,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:36:08+00:00"
+            "time": "2025-11-27T13:27:24+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -9213,34 +9233,27 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v7.3.3",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d"
+                "reference": "82ab368a6fca6358d995b6dd5c41590fb42c03e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e0837b4cbcef63c754d89a4806575cada743a38d",
-                "reference": "e0837b4cbcef63c754d89a4806575cada743a38d",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/82ab368a6fca6358d995b6dd5c41590fb42c03e6",
+                "reference": "82ab368a6fca6358d995b6dd5c41590fb42c03e6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5|^3.0"
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/yaml": "<6.4"
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -9248,17 +9261,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/finder": "^6.4|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^6.4|^7.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9289,7 +9302,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.3.3"
+                "source": "https://github.com/symfony/translation/tree/v8.0.0"
             },
             "funding": [
                 {
@@ -9309,7 +9322,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-01T21:02:37+00:00"
+            "time": "2025-11-27T08:09:45+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -9395,16 +9408,16 @@
         },
         {
             "name": "symfony/uid",
-            "version": "v7.3.1",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "a69f69f3159b852651a6bf45a9fdd149520525bb"
+                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/a69f69f3159b852651a6bf45a9fdd149520525bb",
-                "reference": "a69f69f3159b852651a6bf45a9fdd149520525bb",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2498e9f81b7baa206f44de583f2f48350b90142c",
+                "reference": "2498e9f81b7baa206f44de583f2f48350b90142c",
                 "shasum": ""
             },
             "require": {
@@ -9412,7 +9425,7 @@
                 "symfony/polyfill-uuid": "^1.15"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0"
+                "symfony/console": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -9449,7 +9462,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.3.1"
+                "source": "https://github.com/symfony/uid/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -9461,24 +9474,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-09-25T11:02:55+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.3",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
+                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
-                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/41fd6c4ae28c38b294b42af6db61446594a0dece",
+                "reference": "41fd6c4ae28c38b294b42af6db61446594a0dece",
                 "shasum": ""
             },
             "require": {
@@ -9490,10 +9507,10 @@
                 "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/uid": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
                 "twig/twig": "^3.12"
             },
             "bin": [
@@ -9532,7 +9549,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -9552,7 +9569,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2025-10-27T20:36:44+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -9938,64 +9955,6 @@
                 "source": "https://github.com/wapmorgan/UnifiedArchive/tree/1.3.0"
             },
             "time": "2025-07-29T09:41:58+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
-            },
-            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
@@ -11005,75 +10964,6 @@
                 }
             ],
             "time": "2025-08-20T13:10:51+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-drift",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-drift.git",
-                "reference": "f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-drift/zipball/f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e",
-                "reference": "f4972f2dc6e6e6f1b47db0a8472ca70ca42b622e",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.6.1",
-                "pestphp/pest": "^4.0.0",
-                "php": "^8.3.0",
-                "symfony/finder": "^7.3.2"
-            },
-            "require-dev": {
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Drift\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Drift\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest Drift Plugin",
-            "keywords": [
-                "framework",
-                "laravel",
-                "pest",
-                "php",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-drift/tree/v4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/mandisma",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T12:54:20+00:00"
         },
         {
             "name": "pestphp/pest-plugin-mutate",
@@ -13043,6 +12933,64 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,1230 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48bc6cc3a193f759d5f4d35c5c6f772f",
+    "content-hash": "5d424ff8ae4d5192cd802b2f6c797a17",
     "packages": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-27T21:42:00+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/hpack",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/hpack.git",
+                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
+                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "http2jp/hpack-test-case": "^1",
+                "nikic/php-fuzzer": "^0.0.10",
+                "phpunit/phpunit": "^7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "HTTP/2 HPack implementation.",
+            "homepage": "https://github.com/amphp/hpack",
+            "keywords": [
+                "headers",
+                "hpack",
+                "http-2"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/hpack/issues",
+                "source": "https://github.com/amphp/hpack/tree/v3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:00:16+00:00"
+        },
+        {
+            "name": "amphp/http",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http.git",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http/zipball/3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/hpack": "^3",
+                "amphp/parser": "^1.1",
+                "league/uri-components": "^2.4.2 | ^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "league/uri": "^6.8 | ^7.1",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.26.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/constants.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Basic HTTP primitives which can be shared by servers and clients.",
+            "support": {
+                "issues": "https://github.com/amphp/http/issues",
+                "source": "https://github.com/amphp/http/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-23T14:57:26+00:00"
+        },
+        {
+            "name": "amphp/http-client",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-client.git",
+                "reference": "75ad21574fd632594a2dd914496647816d5106bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-client/zipball/75ad21574fd632594a2dd914496647816d5106bc",
+                "reference": "75ad21574fd632594a2dd914496647816d5106bc",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "league/uri": "^7",
+                "league/uri-components": "^7",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "revolt/event-loop": "^1"
+            },
+            "conflict": {
+                "amphp/file": "<3 | >=5"
+            },
+            "require-dev": {
+                "amphp/file": "^3 | ^4",
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "ext-json": "*",
+                "kelunik/link-header-rfc5988": "^1",
+                "laminas/laminas-diactoros": "^2.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.23"
+            },
+            "suggest": {
+                "amphp/file": "Required for file request bodies and HTTP archive logging",
+                "ext-json": "Required for logging HTTP archives",
+                "ext-zlib": "Allows using compression for response bodies."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "An advanced async HTTP client library for PHP, enabling efficient, non-blocking, and concurrent requests and responses.",
+            "homepage": "https://amphp.org/http-client",
+            "keywords": [
+                "async",
+                "client",
+                "concurrent",
+                "http",
+                "non-blocking",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-client/issues",
+                "source": "https://github.com/amphp/http-client/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-16T20:41:23+00:00"
+        },
+        {
+            "name": "amphp/http-server",
+            "version": "v3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-server.git",
+                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-server/zipball/7aa962b0569f664af3ba23bc819f2a69884329cd",
+                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2.1",
+                "amphp/sync": "^2.2",
+                "league/uri": "^7.1",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "psr/log": "^1 | ^2 | ^3",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-client": "^5",
+                "amphp/log": "^2",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "league/uri-components": "^7.1",
+                "monolog/monolog": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.23"
+            },
+            "suggest": {
+                "ext-zlib": "Allows GZip compression of response bodies"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Driver/functions.php",
+                    "src/Middleware/functions.php",
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Server\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A non-blocking HTTP application server for PHP based on Amp.",
+            "homepage": "https://github.com/amphp/http-server",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-server/issues",
+                "source": "https://github.com/amphp/http-server/tree/v3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-18T15:43:42+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T16:33:53+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:13:44+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^6.5 | ^7",
+                "league/uri-interfaces": "^2.3 | ^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-21T14:33:03+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "amphp/websocket",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket.git",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket/zipball/963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "suggest": {
+                "ext-zlib": "Required for compression"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                }
+            ],
+            "description": "Shared code for websocket servers and clients.",
+            "homepage": "https://github.com/amphp/websocket",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket/issues",
+                "source": "https://github.com/amphp/websocket/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-28T21:28:45+00:00"
+        },
+        {
+            "name": "amphp/websocket-client",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket-client.git",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket-client/zipball/dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2.1",
+                "amphp/http": "^2.1",
+                "amphp/http-client": "^5",
+                "amphp/socket": "^2.2",
+                "amphp/websocket": "^2",
+                "league/uri": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1|^2",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/websocket-server": "^3|^4",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.26.1",
+                "psr/log": "^1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Async WebSocket client for PHP based on Amp.",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket-client/issues",
+                "source": "https://github.com/amphp/websocket-client/tree/v2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-24T17:25:34+00:00"
+        },
         {
             "name": "archtechx/enums",
             "version": "v1.1.2",
@@ -58,6 +1280,99 @@
                 "source": "https://github.com/archtechx/enums/tree/v1.1.2"
             },
             "time": "2025-06-06T23:15:09+00:00"
+        },
+        {
+            "name": "brianium/paratest",
+            "version": "v7.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^12.5.0",
+                "phpunit/php-file-iterator": "^6",
+                "phpunit/php-timer": "^8",
+                "phpunit/phpunit": "^12.4.4",
+                "sebastian/environment": "^8.0.3",
+                "symfony/console": "^7.3.4 || ^8.0.0",
+                "symfony/process": "^7.3.4 || ^8.0.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-pcntl": "*",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.32",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "symfony/filesystem": "^7.3.2 || ^8.0.0"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2025-11-30T08:08:11+00:00"
         },
         {
             "name": "brick/math",
@@ -555,6 +1870,50 @@
             "time": "2025-08-20T19:15:30+00:00"
         },
         {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -628,6 +1987,54 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1264,6 +2671,67 @@
             "time": "2024-11-01T03:51:45+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
             "name": "fileeye/pel",
             "version": "0.12.0",
             "source": {
@@ -1326,6 +2794,77 @@
                 "source": "https://github.com/FileEye/pel/tree/0.12.0"
             },
             "time": "2025-01-17T21:19:20+00:00"
+        },
+        {
+            "name": "filp/whoops",
+            "version": "2.18.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filp/whoops.git",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
+                "whoops/soap": "Formats errors as SOAP responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whoops\\": "src/Whoops/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Filipe Dobreira",
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
+                }
+            ],
+            "description": "php error handling for cool kids",
+            "homepage": "https://filp.github.io/whoops/",
+            "keywords": [
+                "error",
+                "exception",
+                "handling",
+                "library",
+                "throwable",
+                "whoops"
+            ],
+            "support": {
+                "issues": "https://github.com/filp/whoops/issues",
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/denis-sokolov",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -1870,6 +3409,124 @@
                 }
             ],
             "time": "2025-08-22T14:27:06+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
         },
         {
             "name": "laravel-lang/config",
@@ -3534,6 +5191,91 @@
             "time": "2025-11-18T12:17:23+00:00"
         },
         {
+            "name": "league/uri-components",
+            "version": "7.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-components.git",
+                "reference": "ffa1215dbee72ee4b7bc08d983d25293812456c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/ffa1215dbee72ee4b7bc08d983d25293812456c2",
+                "reference": "ffa1215dbee72ee4b7bc08d983d25293812456c2",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri": "^7.6",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "bakame/aide-uri": "A polyfill for PHP8.1 until PHP8.4 to add support to PHP Native URI parser",
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-mbstring": "to use the sorting algorithm of URLSearchParams",
+                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
+                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI components manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "authority",
+                "components",
+                "fragment",
+                "host",
+                "middleware",
+                "modifier",
+                "path",
+                "port",
+                "query",
+                "rfc3986",
+                "scheme",
+                "uri",
+                "url",
+                "userinfo"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-components/tree/7.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-18T12:17:23+00:00"
+        },
+        {
             "name": "league/uri-interfaces",
             "version": "7.6.0",
             "source": {
@@ -3906,6 +5648,66 @@
             "time": "2025-03-24T10:02:05+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "3.11.0",
             "source": {
@@ -4273,6 +6075,105 @@
             "time": "2025-10-21T19:32:17+00:00"
         },
         {
+            "name": "nunomaduro/collision",
+            "version": "v8.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/collision.git",
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "shasum": ""
+            },
+            "require": {
+                "filp/whoops": "^2.18.1",
+                "nunomaduro/termwind": "^2.3.1",
+                "php": "^8.2.0",
+                "symfony/console": "^7.3.0"
+            },
+            "conflict": {
+                "laravel/framework": "<11.44.2 || >=13.0.0",
+                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.8.3",
+                "larastan/larastan": "^3.4.2",
+                "laravel/framework": "^11.44.2 || ^12.18",
+                "laravel/pint": "^1.22.1",
+                "laravel/sail": "^1.43.1",
+                "laravel/sanctum": "^4.1.1",
+                "laravel/tinker": "^2.10.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.4",
+                "pestphp/pest": "^3.8.2 || ^4.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-8.x": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "./src/Adapters/Phpunit/Autoload.php"
+                ],
+                "psr-4": {
+                    "NunoMaduro\\Collision\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Cli error handling for console/command-line PHP applications.",
+            "keywords": [
+                "artisan",
+                "cli",
+                "command-line",
+                "console",
+                "dev",
+                "error",
+                "handling",
+                "laravel",
+                "laravel-zero",
+                "php",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/collision/issues",
+                "source": "https://github.com/nunomaduro/collision"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-11-20T02:55:25+00:00"
+        },
+        {
             "name": "nunomaduro/termwind",
             "version": "v2.3.3",
             "source": {
@@ -4449,6 +6350,770 @@
                 "source": "https://github.com/paragonie/sodium_compat/tree/v2.1.0"
             },
             "time": "2024-09-04T12:51:01+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.14.2",
+                "nunomaduro/collision": "^8.8.3",
+                "nunomaduro/termwind": "^2.3.3",
+                "pestphp/pest-plugin": "^4.0.0",
+                "pestphp/pest-plugin-arch": "^4.0.0",
+                "pestphp/pest-plugin-mutate": "^4.0.1",
+                "pestphp/pest-plugin-profanity": "^4.2.0",
+                "php": "^8.3.0",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/process": "^7.4.0|^8.0.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">12.4.4",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-browser": "^4.1.1",
+                "pestphp/pest-plugin-type-coverage": "^4.0.3",
+                "psy/psysh": "^0.12.15"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v4.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-28T12:04:48+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.3"
+            },
+            "conflict": {
+                "pestphp/pest": "<4.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.8.10",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-08-20T12:35:58+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T13:10:51+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-browser",
+            "version": "v4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-browser.git",
+                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/da70fce21e4b33ba22bef1276f654e77676213d7",
+                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3.1.1",
+                "amphp/http-server": "^3.4.3",
+                "amphp/websocket-client": "^2.0.2",
+                "ext-sockets": "*",
+                "pestphp/pest": "^4.1.0",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "symfony/process": "^7.3.4"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "livewire/livewire": "^3.6.4",
+                "nunomaduro/collision": "^8.8.2",
+                "orchestra/testbench": "^10.6.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-laravel": "^4.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Browser\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Browser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Pest plugin to test browser interactions",
+            "keywords": [
+                "browser",
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v4.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-09-29T01:31:33+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.6.1",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-21T20:19:25+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/c37e5e2c7136ee4eae12082e7952332bc1c6600a",
+                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.9",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.0"
+            },
+            "time": "2025-10-28T23:14:11+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
+            },
+            "time": "2025-11-27T19:50:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpoffice/common",
@@ -4916,6 +7581,492 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
+                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.6.2",
+                "php": ">=8.3",
+                "phpunit/php-file-iterator": "^6.0",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.4.4"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-29T07:15:54+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:37+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:58+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:16+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:38+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.4.0",
+                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.3",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-21T07:39:11+00:00"
         },
         {
             "name": "psr/clock",
@@ -6318,6 +9469,975 @@
             "time": "2023-08-25T11:21:46+00:00"
         },
         {
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+            },
+            "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-14T09:36:45+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "7.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-20T11:27:00+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "8.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-12T14:11:56+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:16:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "8.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-29T11:29:25+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:28+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:48+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:17+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:44:59+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:57:12+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
             "name": "spatie/backtrace",
             "version": "1.8.1",
             "source": {
@@ -6998,6 +11118,58 @@
                 }
             ],
             "time": "2025-02-25T15:59:46+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/clock",
@@ -9572,6 +13744,65 @@
             "time": "2025-10-27T20:36:44+00:00"
         },
         {
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0",
+                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
+            },
+            "time": "2025-04-20T20:23:40+00:00"
+        },
+        {
             "name": "tecnickcom/tcpdf",
             "version": "6.10.0",
             "source": {
@@ -9641,6 +13872,56 @@
                 }
             ],
             "time": "2025-05-27T18:02:28+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -9955,6 +14236,64 @@
                 "source": "https://github.com/wapmorgan/UnifiedArchive/tree/1.3.0"
             },
             "time": "2025-07-29T09:41:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
@@ -10025,279 +14364,6 @@
                 "source": "https://github.com/beyondcode/laravel-dump-server/tree/2.1.0"
             },
             "time": "2025-02-26T08:27:59+00:00"
-        },
-        {
-            "name": "brianium/paratest",
-            "version": "v7.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
-                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-simplexml": "*",
-                "fidry/cpu-core-counter": "^1.3.0",
-                "jean85/pretty-package-versions": "^2.1.1",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^12.5.0",
-                "phpunit/php-file-iterator": "^6",
-                "phpunit/php-timer": "^8",
-                "phpunit/phpunit": "^12.4.4",
-                "sebastian/environment": "^8.0.3",
-                "symfony/console": "^7.3.4 || ^8.0.0",
-                "symfony/process": "^7.3.4 || ^8.0.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^14.0.0",
-                "ext-pcntl": "*",
-                "ext-pcov": "*",
-                "ext-posix": "*",
-                "phpstan/phpstan": "^2.1.32",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.8",
-                "phpstan/phpstan-strict-rules": "^2.0.7",
-                "symfony/filesystem": "^7.3.2 || ^8.0.0"
-            },
-            "bin": [
-                "bin/paratest",
-                "bin/paratest_for_phpstorm"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ParaTest\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brian Scaturro",
-                    "email": "scaturrob@gmail.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Filippo Tessarotto",
-                    "email": "zoeslam@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Parallel testing for PHP",
-            "homepage": "https://github.com/paratestphp/paratest",
-            "keywords": [
-                "concurrent",
-                "parallel",
-                "phpunit",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.15.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/Slamdunk",
-                    "type": "github"
-                },
-                {
-                    "url": "https://paypal.me/filippotessarotto",
-                    "type": "paypal"
-                }
-            ],
-            "time": "2025-11-30T08:08:11+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "1.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
-                "psr/log": "^1 || ^2 || ^3"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
-            },
-            "time": "2025-04-07T20:06:18+00:00"
-        },
-        {
-            "name": "fidry/cpu-core-counter",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "fidry/makefile": "^0.2.0",
-                "fidry/php-cs-fixer-config": "^1.1.2",
-                "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-deprecation-rules": "^2.0.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
-                "webmozarts/strict-phpunit": "^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Fidry\\CpuCoreCounter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Théo FIDRY",
-                    "email": "theo.fidry@gmail.com"
-                }
-            ],
-            "description": "Tiny utility to get the number of CPU cores.",
-            "keywords": [
-                "CPU",
-                "core"
-            ],
-            "support": {
-                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theofidry",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-14T07:29:31+00:00"
-        },
-        {
-            "name": "filp/whoops",
-            "version": "2.18.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/filp/whoops.git",
-                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
-                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
-                "symfony/var-dumper": "^4.0 || ^5.0"
-            },
-            "suggest": {
-                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
-                "whoops/soap": "Formats errors as SOAP responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Whoops\\": "src/Whoops/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Filipe Dobreira",
-                    "homepage": "https://github.com/filp",
-                    "role": "Developer"
-                }
-            ],
-            "description": "php error handling for cool kids",
-            "homepage": "https://filp.github.io/whoops/",
-            "keywords": [
-                "error",
-                "exception",
-                "handling",
-                "library",
-                "throwable",
-                "whoops"
-            ],
-            "support": {
-                "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/denis-sokolov",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -10408,66 +14474,6 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
-            "name": "jean85/pretty-package-versions",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
-                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.1.0",
-                "php": "^7.4|^8.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.2",
-                "jean85/composer-provided-replaced-stub-package": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^7.5|^8.5|^9.6",
-                "rector/rector": "^2.0",
-                "vimeo/psalm": "^4.3 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Jean85\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alessandro Lai",
-                    "email": "alessandro.lai85@gmail.com"
-                }
-            ],
-            "description": "A library to get pretty versions strings of installed dependencies",
-            "keywords": [
-                "composer",
-                "package",
-                "release",
-                "versions"
-            ],
-            "support": {
-                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
-                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
-            },
-            "time": "2025-03-19T14:43:43+00:00"
-        },
-        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -10549,2453 +14555,13 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nunomaduro/collision",
-            "version": "v8.8.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "shasum": ""
-            },
-            "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
-                "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
-            },
-            "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
-            },
-            "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-8.x": "8.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "./src/Adapters/Phpunit/Autoload.php"
-                ],
-                "psr-4": {
-                    "NunoMaduro\\Collision\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Cli error handling for console/command-line PHP applications.",
-            "keywords": [
-                "artisan",
-                "cli",
-                "command-line",
-                "console",
-                "dev",
-                "error",
-                "handling",
-                "laravel",
-                "laravel-zero",
-                "php",
-                "symfony"
-            ],
-            "support": {
-                "issues": "https://github.com/nunomaduro/collision/issues",
-                "source": "https://github.com/nunomaduro/collision"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2025-11-20T02:55:25+00:00"
-        },
-        {
-            "name": "pestphp/pest",
-            "version": "v4.1.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest.git",
-                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae419afd363299c29ad5b17e8b70d118b1068bb4",
-                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4",
-                "shasum": ""
-            },
-            "require": {
-                "brianium/paratest": "^7.14.2",
-                "nunomaduro/collision": "^8.8.3",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest-plugin": "^4.0.0",
-                "pestphp/pest-plugin-arch": "^4.0.0",
-                "pestphp/pest-plugin-mutate": "^4.0.1",
-                "pestphp/pest-plugin-profanity": "^4.2.0",
-                "php": "^8.3.0",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/process": "^7.4.0|^8.0.0"
-            },
-            "conflict": {
-                "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.4.4",
-                "sebastian/exporter": "<7.0.0",
-                "webmozart/assert": "<1.11.0"
-            },
-            "require-dev": {
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-browser": "^4.1.1",
-                "pestphp/pest-plugin-type-coverage": "^4.0.3",
-                "psy/psysh": "^0.12.15"
-            },
-            "bin": [
-                "bin/pest"
-            ],
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Mutate\\Plugins\\Mutate",
-                        "Pest\\Plugins\\Configuration",
-                        "Pest\\Plugins\\Bail",
-                        "Pest\\Plugins\\Cache",
-                        "Pest\\Plugins\\Coverage",
-                        "Pest\\Plugins\\Init",
-                        "Pest\\Plugins\\Environment",
-                        "Pest\\Plugins\\Help",
-                        "Pest\\Plugins\\Memory",
-                        "Pest\\Plugins\\Only",
-                        "Pest\\Plugins\\Printer",
-                        "Pest\\Plugins\\ProcessIsolation",
-                        "Pest\\Plugins\\Profile",
-                        "Pest\\Plugins\\Retry",
-                        "Pest\\Plugins\\Snapshot",
-                        "Pest\\Plugins\\Verbose",
-                        "Pest\\Plugins\\Version",
-                        "Pest\\Plugins\\Shard",
-                        "Pest\\Plugins\\Parallel"
-                    ]
-                },
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Functions.php",
-                    "src/Pest.php"
-                ],
-                "psr-4": {
-                    "Pest\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "The elegant PHP Testing Framework.",
-            "keywords": [
-                "framework",
-                "pest",
-                "php",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.1.6"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-28T12:04:48+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin.git",
-                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
-                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^2.0.0",
-                "composer-runtime-api": "^2.2.2",
-                "php": "^8.3"
-            },
-            "conflict": {
-                "pestphp/pest": "<4.0.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.8.10",
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Pest\\Plugin\\Manager"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Plugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest plugin manager",
-            "keywords": [
-                "framework",
-                "manager",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2025-08-20T12:35:58+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-arch",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-arch.git",
-                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
-                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3",
-                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
-            },
-            "require-dev": {
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Arch\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Autoload.php"
-                ],
-                "psr-4": {
-                    "Pest\\Arch\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Arch plugin for Pest PHP.",
-            "keywords": [
-                "arch",
-                "architecture",
-                "framework",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T13:10:51+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-mutate",
-            "version": "v4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
-                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
-                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.6.1",
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3",
-                "psr/simple-cache": "^3.0.0"
-            },
-            "require-dev": {
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-type-coverage": "^4.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Mutate\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                },
-                {
-                    "name": "Sandro Gehri",
-                    "email": "sandrogehri@gmail.com"
-                }
-            ],
-            "description": "Mutates your code to find untested cases",
-            "keywords": [
-                "framework",
-                "mutate",
-                "mutation",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/gehrisandro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-21T20:19:25+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-profanity",
-            "version": "v4.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
-                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/c37e5e2c7136ee4eae12082e7952332bc1c6600a",
-                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "faissaloux/pest-plugin-inside": "^1.9",
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Profanity\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Profanity\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest Profanity Plugin",
-            "keywords": [
-                "framework",
-                "pest",
-                "php",
-                "plugin",
-                "profanity",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.0"
-            },
-            "time": "2025-10-28T23:14:11+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-phar": "*",
-                "ext-xmlwriter": "*",
-                "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-03T12:33:53+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
-            "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.1",
-                "ext-filter": "*",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.5 || ~1.6.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-webmozart-assert": "^1.2",
-                "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
-            },
-            "time": "2025-11-27T19:50:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
-            },
-            "time": "2025-11-21T15:09:14+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
-            },
-            "time": "2025-08-30T15:50:23+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "12.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
-                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.6.2",
-                "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
-                "phpunit/php-text-template": "^5.0",
-                "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
-                "sebastian/version": "^6.0",
-                "theseer/tokenizer": "^1.3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.4.4"
-            },
-            "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "12.5.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-11-29T07:15:54+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:37+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^12.0"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:58+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:59:16+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "8.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:59:38+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "12.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.4",
-                "phar-io/manifest": "^2.0.4",
-                "phar-io/version": "^3.2.1",
-                "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.4.0",
-                "phpunit/php-file-iterator": "^6.0.0",
-                "phpunit/php-invoker": "^6.0.0",
-                "phpunit/php-text-template": "^5.0.0",
-                "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.3",
-                "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/exporter": "^7.0.2",
-                "sebastian/global-state": "^8.0.2",
-                "sebastian/object-enumerator": "^7.0.0",
-                "sebastian/type": "^6.0.3",
-                "sebastian/version": "^6.0.0",
-                "staabm/side-effects-detector": "^1.0.5"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "12.4-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-11-21T07:39:11+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "4.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-09-14T09:36:45+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "7.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.2"
-            },
-            "suggest": {
-                "ext-bcmath": "For comparing BcMath\\Number objects"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-20T11:27:00+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:25+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:46+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "8.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "suggest": {
-                "ext-posix": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-12T14:11:56+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "7.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-09-24T06:16:11+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "8.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "https://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-29T11:29:25+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:57:28+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:57:48+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:17+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "7.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "https://github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-13T04:44:59+00:00"
-        },
-        {
-            "name": "sebastian/type",
-            "version": "6.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the types of the PHP type system",
-            "homepage": "https://github.com/sebastianbergmann/type",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/type/issues",
-                "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-09T06:57:12+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T05:00:38+00:00"
-        },
-        {
-            "name": "staabm/side-effects-detector",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/staabm/side-effects-detector.git",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^1.12.6",
-                "phpunit/phpunit": "^9.6.21",
-                "symfony/var-dumper": "^5.4.43",
-                "tomasvotruba/type-coverage": "1.0.0",
-                "tomasvotruba/unused-public": "1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "lib/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A static analysis tool to detect side effects in PHP code",
-            "keywords": [
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/staabm/side-effects-detector/issues",
-                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/staabm",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.18.0 || ^5.0.0",
-                "php": "^8.1.0",
-                "phpdocumentor/reflection-docblock": "^5.3.0",
-                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
-                "symfony/finder": "^6.4.0 || ^7.0.0"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.13.7",
-                "phpstan/phpstan": "^1.10.52"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPUnit\\Architecture\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ni Shi",
-                    "email": "futik0ma011@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Methods for testing application architecture",
-            "keywords": [
-                "architecture",
-                "phpunit",
-                "stucture",
-                "test",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
-            },
-            "time": "2025-04-20T20:23:40+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "support": {
-                "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-17T20:03:58+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
-            },
-            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "pestphp/pest-plugin-browser": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,1230 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d424ff8ae4d5192cd802b2f6c797a17",
+    "content-hash": "bc01928f38c719fd7f670ffb107e11ab",
     "packages": [
-        {
-            "name": "amphp/amp",
-            "version": "v3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/amp.git",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "5.23.1"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php",
-                    "src/Future/functions.php",
-                    "src/Internal/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Bob Weinand",
-                    "email": "bobwei9@hotmail.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                }
-            ],
-            "description": "A non-blocking concurrency framework for PHP applications.",
-            "homepage": "https://amphp.org/amp",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "awaitable",
-                "concurrency",
-                "event",
-                "event-loop",
-                "future",
-                "non-blocking",
-                "promise"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-27T21:42:00+00:00"
-        },
-        {
-            "name": "amphp/byte-stream",
-            "version": "v2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
-                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/parser": "^1.1",
-                "amphp/pipeline": "^1",
-                "amphp/serialization": "^1",
-                "amphp/sync": "^2",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2.3"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "5.22.1"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php",
-                    "src/Internal/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\ByteStream\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "A stream abstraction to make working with non-blocking I/O simple.",
-            "homepage": "https://amphp.org/byte-stream",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "io",
-                "non-blocking",
-                "stream"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-16T17:10:27+00:00"
-        },
-        {
-            "name": "amphp/cache",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/cache.git",
-                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
-                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/serialization": "^1",
-                "amphp/sync": "^2",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Amp\\Cache\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                }
-            ],
-            "description": "A fiber-aware cache API based on Amp and Revolt.",
-            "homepage": "https://amphp.org/cache",
-            "support": {
-                "issues": "https://github.com/amphp/cache/issues",
-                "source": "https://github.com/amphp/cache/tree/v2.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-04-19T03:38:06+00:00"
-        },
-        {
-            "name": "amphp/dns",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/dns.git",
-                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
-                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/cache": "^2",
-                "amphp/parser": "^1",
-                "amphp/process": "^2",
-                "daverandom/libdns": "^2.0.2",
-                "ext-filter": "*",
-                "ext-json": "*",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Dns\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Wright",
-                    "email": "addr@daverandom.com"
-                },
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
-                {
-                    "name": "Bob Weinand",
-                    "email": "bobwei9@hotmail.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                }
-            ],
-            "description": "Async DNS resolution for Amp.",
-            "homepage": "https://github.com/amphp/dns",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "client",
-                "dns",
-                "resolve"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/dns/issues",
-                "source": "https://github.com/amphp/dns/tree/v2.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-01-19T15:43:40+00:00"
-        },
-        {
-            "name": "amphp/hpack",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/hpack.git",
-                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
-                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "http2jp/hpack-test-case": "^1",
-                "nikic/php-fuzzer": "^0.0.10",
-                "phpunit/phpunit": "^7 | ^8 | ^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Amp\\Http\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
-                {
-                    "name": "Bob Weinand"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                }
-            ],
-            "description": "HTTP/2 HPack implementation.",
-            "homepage": "https://github.com/amphp/hpack",
-            "keywords": [
-                "headers",
-                "hpack",
-                "http-2"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/hpack/issues",
-                "source": "https://github.com/amphp/hpack/tree/v3.2.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-21T19:00:16+00:00"
-        },
-        {
-            "name": "amphp/http",
-            "version": "v2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/http.git",
-                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http/zipball/3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
-                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/hpack": "^3",
-                "amphp/parser": "^1.1",
-                "league/uri-components": "^2.4.2 | ^7.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1 | ^2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "league/uri": "^6.8 | ^7.1",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.26.1"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php",
-                    "src/Internal/constants.php"
-                ],
-                "psr-4": {
-                    "Amp\\Http\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                }
-            ],
-            "description": "Basic HTTP primitives which can be shared by servers and clients.",
-            "support": {
-                "issues": "https://github.com/amphp/http/issues",
-                "source": "https://github.com/amphp/http/tree/v2.1.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-11-23T14:57:26+00:00"
-        },
-        {
-            "name": "amphp/http-client",
-            "version": "v5.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/http-client.git",
-                "reference": "75ad21574fd632594a2dd914496647816d5106bc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http-client/zipball/75ad21574fd632594a2dd914496647816d5106bc",
-                "reference": "75ad21574fd632594a2dd914496647816d5106bc",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/hpack": "^3",
-                "amphp/http": "^2",
-                "amphp/pipeline": "^1",
-                "amphp/socket": "^2",
-                "amphp/sync": "^2",
-                "league/uri": "^7",
-                "league/uri-components": "^7",
-                "league/uri-interfaces": "^7.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1 | ^2",
-                "revolt/event-loop": "^1"
-            },
-            "conflict": {
-                "amphp/file": "<3 | >=5"
-            },
-            "require-dev": {
-                "amphp/file": "^3 | ^4",
-                "amphp/http-server": "^3",
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "ext-json": "*",
-                "kelunik/link-header-rfc5988": "^1",
-                "laminas/laminas-diactoros": "^2.3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "~5.23"
-            },
-            "suggest": {
-                "amphp/file": "Required for file request bodies and HTTP archive logging",
-                "ext-json": "Required for logging HTTP archives",
-                "ext-zlib": "Allows using compression for response bodies."
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php",
-                    "src/Internal/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Http\\Client\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@gmail.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                }
-            ],
-            "description": "An advanced async HTTP client library for PHP, enabling efficient, non-blocking, and concurrent requests and responses.",
-            "homepage": "https://amphp.org/http-client",
-            "keywords": [
-                "async",
-                "client",
-                "concurrent",
-                "http",
-                "non-blocking",
-                "rest"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/http-client/issues",
-                "source": "https://github.com/amphp/http-client/tree/v5.3.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-16T20:41:23+00:00"
-        },
-        {
-            "name": "amphp/http-server",
-            "version": "v3.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/http-server.git",
-                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http-server/zipball/7aa962b0569f664af3ba23bc819f2a69884329cd",
-                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/cache": "^2",
-                "amphp/hpack": "^3",
-                "amphp/http": "^2",
-                "amphp/pipeline": "^1",
-                "amphp/socket": "^2.1",
-                "amphp/sync": "^2.2",
-                "league/uri": "^7.1",
-                "league/uri-interfaces": "^7.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1 | ^2",
-                "psr/log": "^1 | ^2 | ^3",
-                "revolt/event-loop": "^1"
-            },
-            "require-dev": {
-                "amphp/http-client": "^5",
-                "amphp/log": "^2",
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "league/uri-components": "^7.1",
-                "monolog/monolog": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "~5.23"
-            },
-            "suggest": {
-                "ext-zlib": "Allows GZip compression of response bodies"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/Driver/functions.php",
-                    "src/Middleware/functions.php",
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Http\\Server\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
-                {
-                    "name": "Bob Weinand"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                }
-            ],
-            "description": "A non-blocking HTTP application server for PHP based on Amp.",
-            "homepage": "https://github.com/amphp/http-server",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "http",
-                "non-blocking",
-                "server"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/http-server/issues",
-                "source": "https://github.com/amphp/http-server/tree/v3.4.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-05-18T15:43:42+00:00"
-        },
-        {
-            "name": "amphp/parser",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/parser.git",
-                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
-                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Amp\\Parser\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "A generator parser to make streaming parsers simple.",
-            "homepage": "https://github.com/amphp/parser",
-            "keywords": [
-                "async",
-                "non-blocking",
-                "parser",
-                "stream"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/parser/issues",
-                "source": "https://github.com/amphp/parser/tree/v1.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-21T19:16:53+00:00"
-        },
-        {
-            "name": "amphp/pipeline",
-            "version": "v1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/pipeline.git",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
-                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Amp\\Pipeline\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Asynchronous iterators and operators.",
-            "homepage": "https://amphp.org/pipeline",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "io",
-                "iterator",
-                "non-blocking"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-16T16:33:53+00:00"
-        },
-        {
-            "name": "amphp/process",
-            "version": "v2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/process.git",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
-                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/sync": "^2",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Process\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bob Weinand",
-                    "email": "bobwei9@hotmail.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "A fiber-aware process manager based on Amp and Revolt.",
-            "homepage": "https://amphp.org/process",
-            "support": {
-                "issues": "https://github.com/amphp/process/issues",
-                "source": "https://github.com/amphp/process/tree/v2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-04-19T03:13:44+00:00"
-        },
-        {
-            "name": "amphp/serialization",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Serialization\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Serialization tools for IPC and data storage in PHP.",
-            "homepage": "https://github.com/amphp/serialization",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "serialization",
-                "serialize"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
-            },
-            "time": "2020-03-25T21:39:07+00:00"
-        },
-        {
-            "name": "amphp/socket",
-            "version": "v2.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/dns": "^2",
-                "ext-openssl": "*",
-                "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "amphp/process": "^2",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php",
-                    "src/Internal/functions.php",
-                    "src/SocketAddress/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Socket\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@gmail.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
-            "homepage": "https://github.com/amphp/socket",
-            "keywords": [
-                "amp",
-                "async",
-                "encryption",
-                "non-blocking",
-                "sockets",
-                "tcp",
-                "tls"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-04-21T14:33:03+00:00"
-        },
-        {
-            "name": "amphp/sync",
-            "version": "v2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/sync.git",
-                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
-                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/pipeline": "^1",
-                "amphp/serialization": "^1",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "5.23"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Sync\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Stephen Coakley",
-                    "email": "me@stephencoakley.com"
-                }
-            ],
-            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
-            "homepage": "https://github.com/amphp/sync",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "mutex",
-                "semaphore",
-                "synchronization"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/sync/issues",
-                "source": "https://github.com/amphp/sync/tree/v2.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-08-03T19:31:26+00:00"
-        },
-        {
-            "name": "amphp/websocket",
-            "version": "v2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/websocket.git",
-                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/websocket/zipball/963904b6a883c4b62d9222d1d9749814fac96a3b",
-                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2",
-                "amphp/parser": "^1",
-                "amphp/pipeline": "^1",
-                "amphp/socket": "^2",
-                "php": ">=8.1",
-                "revolt/event-loop": "^1"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.18"
-            },
-            "suggest": {
-                "ext-zlib": "Required for compression"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Websocket\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                },
-                {
-                    "name": "Bob Weinand",
-                    "email": "bobwei9@hotmail.com"
-                }
-            ],
-            "description": "Shared code for websocket servers and clients.",
-            "homepage": "https://github.com/amphp/websocket",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "http",
-                "non-blocking",
-                "websocket"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/websocket/issues",
-                "source": "https://github.com/amphp/websocket/tree/v2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-10-28T21:28:45+00:00"
-        },
-        {
-            "name": "amphp/websocket-client",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/amphp/websocket-client.git",
-                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/amphp/websocket-client/zipball/dc033fdce0af56295a23f63ac4f579b34d470d6c",
-                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3",
-                "amphp/byte-stream": "^2.1",
-                "amphp/http": "^2.1",
-                "amphp/http-client": "^5",
-                "amphp/socket": "^2.2",
-                "amphp/websocket": "^2",
-                "league/uri": "^7.1",
-                "php": ">=8.1",
-                "psr/http-message": "^1|^2",
-                "revolt/event-loop": "^1"
-            },
-            "require-dev": {
-                "amphp/http-server": "^3",
-                "amphp/php-cs-fixer-config": "^2",
-                "amphp/phpunit-util": "^3",
-                "amphp/websocket-server": "^3|^4",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "~5.26.1",
-                "psr/log": "^1"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Amp\\Websocket\\Client\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bob Weinand",
-                    "email": "bobwei9@hotmail.com"
-                },
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Async WebSocket client for PHP based on Amp.",
-            "keywords": [
-                "amp",
-                "amphp",
-                "async",
-                "client",
-                "http",
-                "non-blocking",
-                "websocket"
-            ],
-            "support": {
-                "issues": "https://github.com/amphp/websocket-client/issues",
-                "source": "https://github.com/amphp/websocket-client/tree/v2.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/amphp",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-24T17:25:34+00:00"
-        },
         {
             "name": "archtechx/enums",
             "version": "v1.1.2",
@@ -1280,99 +58,6 @@
                 "source": "https://github.com/archtechx/enums/tree/v1.1.2"
             },
             "time": "2025-06-06T23:15:09+00:00"
-        },
-        {
-            "name": "brianium/paratest",
-            "version": "v7.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
-                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-simplexml": "*",
-                "fidry/cpu-core-counter": "^1.3.0",
-                "jean85/pretty-package-versions": "^2.1.1",
-                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^12.5.0",
-                "phpunit/php-file-iterator": "^6",
-                "phpunit/php-timer": "^8",
-                "phpunit/phpunit": "^12.4.4",
-                "sebastian/environment": "^8.0.3",
-                "symfony/console": "^7.3.4 || ^8.0.0",
-                "symfony/process": "^7.3.4 || ^8.0.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^14.0.0",
-                "ext-pcntl": "*",
-                "ext-pcov": "*",
-                "ext-posix": "*",
-                "phpstan/phpstan": "^2.1.32",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.8",
-                "phpstan/phpstan-strict-rules": "^2.0.7",
-                "symfony/filesystem": "^7.3.2 || ^8.0.0"
-            },
-            "bin": [
-                "bin/paratest",
-                "bin/paratest_for_phpstorm"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ParaTest\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brian Scaturro",
-                    "email": "scaturrob@gmail.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Filippo Tessarotto",
-                    "email": "zoeslam@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Parallel testing for PHP",
-            "homepage": "https://github.com/paratestphp/paratest",
-            "keywords": [
-                "concurrent",
-                "parallel",
-                "phpunit",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.15.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/Slamdunk",
-                    "type": "github"
-                },
-                {
-                    "url": "https://paypal.me/filippotessarotto",
-                    "type": "paypal"
-                }
-            ],
-            "time": "2025-11-30T08:08:11+00:00"
         },
         {
             "name": "brick/math",
@@ -1870,50 +555,6 @@
             "time": "2025-08-20T19:15:30+00:00"
         },
         {
-            "name": "daverandom/libdns",
-            "version": "v2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/DaveRandom/LibDNS.git",
-                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
-                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "Required for IDN support"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "LibDNS\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "DNS protocol implementation written in pure PHP",
-            "keywords": [
-                "dns"
-            ],
-            "support": {
-                "issues": "https://github.com/DaveRandom/LibDNS/issues",
-                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
-            },
-            "time": "2024-04-12T12:12:48+00:00"
-        },
-        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -1987,54 +628,6 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "1.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
-                "psr/log": "^1 || ^2 || ^3"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
-            },
-            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2611,20 +1204,20 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.18.0",
+            "version": "v4.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "cb56001e54359df7ae76dc522d08845dc741621b"
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/cb56001e54359df7ae76dc522d08845dc741621b",
-                "reference": "cb56001e54359df7ae76dc522d08845dc741621b",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
                 "cerdic/css-tidy": "^1.7 || ^2.0",
@@ -2666,70 +1259,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.18.0"
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
             },
-            "time": "2024-11-01T03:51:45+00:00"
-        },
-        {
-            "name": "fidry/cpu-core-counter",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
-                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "fidry/makefile": "^0.2.0",
-                "fidry/php-cs-fixer-config": "^1.1.2",
-                "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-deprecation-rules": "^2.0.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
-                "webmozarts/strict-phpunit": "^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Fidry\\CpuCoreCounter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Théo FIDRY",
-                    "email": "theo.fidry@gmail.com"
-                }
-            ],
-            "description": "Tiny utility to get the number of CPU cores.",
-            "keywords": [
-                "CPU",
-                "core"
-            ],
-            "support": {
-                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theofidry",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-14T07:29:31+00:00"
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "fileeye/pel",
@@ -2794,77 +1326,6 @@
                 "source": "https://github.com/FileEye/pel/tree/0.12.0"
             },
             "time": "2025-01-17T21:19:20+00:00"
-        },
-        {
-            "name": "filp/whoops",
-            "version": "2.18.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/filp/whoops.git",
-                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
-                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
-                "symfony/var-dumper": "^4.0 || ^5.0"
-            },
-            "suggest": {
-                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
-                "whoops/soap": "Formats errors as SOAP responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Whoops\\": "src/Whoops/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Filipe Dobreira",
-                    "homepage": "https://github.com/filp",
-                    "role": "Developer"
-                }
-            ],
-            "description": "php error handling for cool kids",
-            "homepage": "https://filp.github.io/whoops/",
-            "keywords": [
-                "error",
-                "exception",
-                "handling",
-                "library",
-                "throwable",
-                "whoops"
-            ],
-            "support": {
-                "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/denis-sokolov",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -3411,142 +1872,24 @@
             "time": "2025-08-22T14:27:06+00:00"
         },
         {
-            "name": "jean85/pretty-package-versions",
-            "version": "2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
-                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.1.0",
-                "php": "^7.4|^8.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.2",
-                "jean85/composer-provided-replaced-stub-package": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^7.5|^8.5|^9.6",
-                "rector/rector": "^2.0",
-                "vimeo/psalm": "^4.3 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Jean85\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alessandro Lai",
-                    "email": "alessandro.lai85@gmail.com"
-                }
-            ],
-            "description": "A library to get pretty versions strings of installed dependencies",
-            "keywords": [
-                "composer",
-                "package",
-                "release",
-                "versions"
-            ],
-            "support": {
-                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
-                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
-            },
-            "time": "2025-03-19T14:43:43+00:00"
-        },
-        {
-            "name": "kelunik/certificate",
-            "version": "v1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kelunik/certificate.git",
-                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
-                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "amphp/php-cs-fixer-config": "^2",
-                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Kelunik\\Certificate\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Access certificate details and transform between different formats.",
-            "keywords": [
-                "DER",
-                "certificate",
-                "certificates",
-                "openssl",
-                "pem",
-                "x509"
-            ],
-            "support": {
-                "issues": "https://github.com/kelunik/certificate/issues",
-                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
-            },
-            "time": "2023-02-03T21:26:53+00:00"
-        },
-        {
             "name": "laravel-lang/config",
-            "version": "1.14.0",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/config.git",
-                "reference": "0f6a41a1d5f4bde6ff59fbfd9e349ac64b737c69"
+                "reference": "080b7cf77eeebdd7e7c267f1b2c3c7fc20408f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/config/zipball/0f6a41a1d5f4bde6ff59fbfd9e349ac64b737c69",
-                "reference": "0f6a41a1d5f4bde6ff59fbfd9e349ac64b737c69",
+                "url": "https://api.github.com/repos/Laravel-Lang/config/zipball/080b7cf77eeebdd7e7c267f1b2c3c7fc20408f3c",
+                "reference": "080b7cf77eeebdd7e7c267f1b2c3c7fc20408f3c",
                 "shasum": ""
             },
             "require": {
                 "archtechx/enums": "^1.0",
                 "illuminate/config": "^10.0 || ^11.0 || ^12.0",
                 "illuminate/support": "^10.0 || ^11.0 || ^12.0",
-                "laravel-lang/locale-list": "^1.5",
+                "laravel-lang/locale-list": "^1.6",
                 "php": "^8.1"
             },
             "require-dev": {
@@ -3598,22 +1941,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/config/issues",
-                "source": "https://github.com/Laravel-Lang/config/tree/1.14.0"
+                "source": "https://github.com/Laravel-Lang/config/tree/1.15.0"
             },
-            "time": "2025-04-11T07:31:54+00:00"
+            "time": "2025-12-04T09:58:46+00:00"
         },
         {
             "name": "laravel-lang/lang",
-            "version": "15.24.5",
+            "version": "15.26.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/lang.git",
-                "reference": "495096372a2c45a69f9a2759973495c9d013367f"
+                "reference": "4f49e4a77ced9ace7955db2159234e4a9c0b22a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/495096372a2c45a69f9a2759973495c9d013367f",
-                "reference": "495096372a2c45a69f9a2759973495c9d013367f",
+                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/4f49e4a77ced9ace7955db2159234e4a9c0b22a3",
+                "reference": "4f49e4a77ced9ace7955db2159234e4a9c0b22a3",
                 "shasum": ""
             },
             "require": {
@@ -3664,20 +2007,20 @@
                 "issues": "https://github.com/Laravel-Lang/lang/issues",
                 "source": "https://github.com/Laravel-Lang/lang"
             },
-            "time": "2025-09-10T20:41:54+00:00"
+            "time": "2025-10-29T12:19:07+00:00"
         },
         {
             "name": "laravel-lang/locale-list",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/locale-list.git",
-                "reference": "060475db218a97a54612163112b44782024d79c1"
+                "reference": "98227230d737b32279f8376a3149be43965513c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/locale-list/zipball/060475db218a97a54612163112b44782024d79c1",
-                "reference": "060475db218a97a54612163112b44782024d79c1",
+                "url": "https://api.github.com/repos/Laravel-Lang/locale-list/zipball/98227230d737b32279f8376a3149be43965513c6",
+                "reference": "98227230d737b32279f8376a3149be43965513c6",
                 "shasum": ""
             },
             "require": {
@@ -3721,7 +2064,7 @@
                 "issues": "https://github.com/Laravel-Lang/locale-list/issues",
                 "source": "https://github.com/Laravel-Lang/locale-list"
             },
-            "time": "2025-06-23T09:39:26+00:00"
+            "time": "2025-11-16T18:22:05+00:00"
         },
         {
             "name": "laravel-lang/locales",
@@ -3798,16 +2141,16 @@
         },
         {
             "name": "laravel-lang/native-country-names",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/native-country-names.git",
-                "reference": "70eba5c3b7a4035da085123a81c076e52367b30c"
+                "reference": "22a9d18d9094fdf0b3384f37feefd3c7d91f1db9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/native-country-names/zipball/70eba5c3b7a4035da085123a81c076e52367b30c",
-                "reference": "70eba5c3b7a4035da085123a81c076e52367b30c",
+                "url": "https://api.github.com/repos/Laravel-Lang/native-country-names/zipball/22a9d18d9094fdf0b3384f37feefd3c7d91f1db9",
+                "reference": "22a9d18d9094fdf0b3384f37feefd3c7d91f1db9",
                 "shasum": ""
             },
             "require": {
@@ -3866,20 +2209,20 @@
                 "issues": "https://github.com/Laravel-Lang/native-country-names/issues",
                 "source": "https://github.com/Laravel-Lang/native-country-names"
             },
-            "time": "2025-06-23T09:38:47+00:00"
+            "time": "2025-11-18T07:59:31+00:00"
         },
         {
             "name": "laravel-lang/native-currency-names",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/native-currency-names.git",
-                "reference": "b376c69778be7184f7292cb92424ac7d7415d55d"
+                "reference": "cc871b6d2574b4397728b78e4522e6cfd53cdb79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/native-currency-names/zipball/b376c69778be7184f7292cb92424ac7d7415d55d",
-                "reference": "b376c69778be7184f7292cb92424ac7d7415d55d",
+                "url": "https://api.github.com/repos/Laravel-Lang/native-currency-names/zipball/cc871b6d2574b4397728b78e4522e6cfd53cdb79",
+                "reference": "cc871b6d2574b4397728b78e4522e6cfd53cdb79",
                 "shasum": ""
             },
             "require": {
@@ -3935,20 +2278,20 @@
                 "issues": "https://github.com/Laravel-Lang/native-currency-names/issues",
                 "source": "https://github.com/Laravel-Lang/native-currency-names"
             },
-            "time": "2025-06-23T09:38:58+00:00"
+            "time": "2025-11-18T07:53:26+00:00"
         },
         {
             "name": "laravel-lang/native-locale-names",
-            "version": "2.5.1",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/native-locale-names.git",
-                "reference": "38278ef43fb3460c9fb7a056ac2e8043e4faa963"
+                "reference": "a5fe634a4db570160dbf3ac68882d281fc88436e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/native-locale-names/zipball/38278ef43fb3460c9fb7a056ac2e8043e4faa963",
-                "reference": "38278ef43fb3460c9fb7a056ac2e8043e4faa963",
+                "url": "https://api.github.com/repos/Laravel-Lang/native-locale-names/zipball/a5fe634a4db570160dbf3ac68882d281fc88436e",
+                "reference": "a5fe634a4db570160dbf3ac68882d281fc88436e",
                 "shasum": ""
             },
             "require": {
@@ -3959,7 +2302,7 @@
             "require-dev": {
                 "illuminate/support": "^10.31 || ^11.0 || ^12.0",
                 "laravel-lang/locale-list": "^1.2",
-                "pestphp/pest": "^2.24.3",
+                "pestphp/pest": "^2.24.3 || ^3.0",
                 "punic/punic": "^3.8",
                 "symfony/console": "^6.3 || ^7.0",
                 "symfony/process": "^6.3 || ^7.0",
@@ -4001,7 +2344,7 @@
                 "issues": "https://github.com/Laravel-Lang/native-locale-names/issues",
                 "source": "https://github.com/Laravel-Lang/native-locale-names"
             },
-            "time": "2025-06-23T09:38:52+00:00"
+            "time": "2025-11-18T08:10:42+00:00"
         },
         {
             "name": "laravel-lang/publisher",
@@ -4381,16 +2724,16 @@
         },
         {
             "name": "laravel/reverb",
-            "version": "v1.5.1",
+            "version": "v1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/reverb.git",
-                "reference": "c82751070c9a5397095d91ff743aefb0549917c3"
+                "reference": "b97d21650bcfaa462dfa4735048dbc33359514e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/reverb/zipball/c82751070c9a5397095d91ff743aefb0549917c3",
-                "reference": "c82751070c9a5397095d91ff743aefb0549917c3",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/b97d21650bcfaa462dfa4735048dbc33359514e1",
+                "reference": "b97d21650bcfaa462dfa4735048dbc33359514e1",
                 "shasum": ""
             },
             "require": {
@@ -4410,8 +2753,8 @@
                 "symfony/http-foundation": "^6.3|^7.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^8.0|^9.0|^10.0",
-                "pestphp/pest": "^2.0|^3.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
                 "phpstan/phpstan": "^1.10",
                 "ratchet/pawl": "^0.4.1",
                 "react/async": "^4.2",
@@ -4457,22 +2800,22 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/reverb/issues",
-                "source": "https://github.com/laravel/reverb/tree/v1.5.1"
+                "source": "https://github.com/laravel/reverb/tree/v1.6.3"
             },
-            "time": "2025-06-16T13:48:47+00:00"
+            "time": "2025-11-28T20:12:49+00:00"
         },
         {
             "name": "laravel/sanctum",
-            "version": "v4.2.0",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sanctum.git",
-                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677"
+                "reference": "f5fb373be39a246c74a060f2cf2ae2c2145b3664"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
-                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/f5fb373be39a246c74a060f2cf2ae2c2145b3664",
+                "reference": "f5fb373be39a246c74a060f2cf2ae2c2145b3664",
                 "shasum": ""
             },
             "require": {
@@ -4486,9 +2829,8 @@
             },
             "require-dev": {
                 "mockery/mockery": "^1.6",
-                "orchestra/testbench": "^9.0|^10.0",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^11.3"
+                "orchestra/testbench": "^9.15|^10.8",
+                "phpstan/phpstan": "^1.10"
             },
             "type": "library",
             "extra": {
@@ -4523,7 +2865,7 @@
                 "issues": "https://github.com/laravel/sanctum/issues",
                 "source": "https://github.com/laravel/sanctum"
             },
-            "time": "2025-07-09T19:45:24+00:00"
+            "time": "2025-11-21T13:59:03+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -4588,16 +2930,16 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.10.1",
+            "version": "v2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3"
+                "reference": "3bcb5f62d6f837e0f093a601e26badafb127bd4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/22177cc71807d38f2810c6204d8f7183d88a57d3",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/3bcb5f62d6f837e0f093a601e26badafb127bd4c",
+                "reference": "3bcb5f62d6f837e0f093a601e26badafb127bd4c",
                 "shasum": ""
             },
             "require": {
@@ -4648,9 +2990,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.10.1"
+                "source": "https://github.com/laravel/tinker/tree/v2.10.2"
             },
-            "time": "2025-01-27T14:24:01+00:00"
+            "time": "2025-11-20T16:29:12+00:00"
         },
         {
             "name": "laravel/ui",
@@ -5094,20 +3436,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.6.0",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "f625804987a0a9112d954f9209d91fec52182344"
+                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f625804987a0a9112d954f9209d91fec52182344",
-                "reference": "f625804987a0a9112d954f9209d91fec52182344",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
+                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.6",
+                "league/uri-interfaces": "^7.7",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -5180,7 +3522,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.6.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.7.0"
             },
             "funding": [
                 {
@@ -5188,105 +3530,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T12:17:23+00:00"
-        },
-        {
-            "name": "league/uri-components",
-            "version": "7.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/uri-components.git",
-                "reference": "ffa1215dbee72ee4b7bc08d983d25293812456c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/ffa1215dbee72ee4b7bc08d983d25293812456c2",
-                "reference": "ffa1215dbee72ee4b7bc08d983d25293812456c2",
-                "shasum": ""
-            },
-            "require": {
-                "league/uri": "^7.6",
-                "php": "^8.1"
-            },
-            "suggest": {
-                "bakame/aide-uri": "A polyfill for PHP8.1 until PHP8.4 to add support to PHP Native URI parser",
-                "ext-bcmath": "to improve IPV4 host parsing",
-                "ext-fileinfo": "to create Data URI from file contennts",
-                "ext-gmp": "to improve IPV4 host parsing",
-                "ext-intl": "to handle IDN host with the best performance",
-                "ext-mbstring": "to use the sorting algorithm of URLSearchParams",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
-                "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle WHATWG URL",
-                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Uri\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ignace Nyamagana Butera",
-                    "email": "nyamsprod@gmail.com",
-                    "homepage": "https://nyamsprod.com"
-                }
-            ],
-            "description": "URI components manipulation library",
-            "homepage": "http://uri.thephpleague.com",
-            "keywords": [
-                "authority",
-                "components",
-                "fragment",
-                "host",
-                "middleware",
-                "modifier",
-                "path",
-                "port",
-                "query",
-                "rfc3986",
-                "scheme",
-                "uri",
-                "url",
-                "userinfo"
-            ],
-            "support": {
-                "docs": "https://uri.thephpleague.com",
-                "forum": "https://thephpleague.slack.com",
-                "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-components/tree/7.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/nyamsprod",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-18T12:17:23+00:00"
+            "time": "2025-12-07T16:02:06+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.6.0",
+            "version": "7.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368"
+                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/ccbfb51c0445298e7e0b7f4481b942f589665368",
-                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
+                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
                 "shasum": ""
             },
             "require": {
@@ -5349,7 +3606,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.6.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.7.0"
             },
             "funding": [
                 {
@@ -5357,26 +3614,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T12:17:23+00:00"
+            "time": "2025-12-07T16:03:21+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "3.1.2",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f"
+                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/aeadcf5c412332eb426c0f9b4485f6accba2a99f",
-                "reference": "aeadcf5c412332eb426c0f9b4485f6accba2a99f",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
+                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "ext-zlib": "*",
-                "php-64bit": "^8.2"
+                "php-64bit": "^8.3"
             },
             "require-dev": {
                 "brianium/paratest": "^7.7",
@@ -5385,7 +3642,7 @@
                 "guzzlehttp/guzzle": "^7.5",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.5",
-                "phpunit/phpunit": "^11.0",
+                "phpunit/phpunit": "^12.0",
                 "vimeo/psalm": "^6.0"
             },
             "suggest": {
@@ -5427,7 +3684,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.1.2"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.0"
             },
             "funding": [
                 {
@@ -5435,7 +3692,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-27T12:07:53+00:00"
+            "time": "2025-07-17T11:15:13+00:00"
         },
         {
             "name": "markbaker/complex",
@@ -5646,66 +3903,6 @@
                 }
             ],
             "time": "2025-03-24T10:02:05+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -6018,16 +4215,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -6070,108 +4267,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
-        },
-        {
-            "name": "nunomaduro/collision",
-            "version": "v8.8.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "shasum": ""
-            },
-            "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
-                "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
-            },
-            "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
-            },
-            "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-8.x": "8.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "./src/Adapters/Phpunit/Autoload.php"
-                ],
-                "psr-4": {
-                    "NunoMaduro\\Collision\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Cli error handling for console/command-line PHP applications.",
-            "keywords": [
-                "artisan",
-                "cli",
-                "command-line",
-                "console",
-                "dev",
-                "error",
-                "handling",
-                "laravel",
-                "laravel-zero",
-                "php",
-                "symfony"
-            ],
-            "support": {
-                "issues": "https://github.com/nunomaduro/collision/issues",
-                "source": "https://github.com/nunomaduro/collision"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2025-11-20T02:55:25+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -6262,16 +4360,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v2.1.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "a673d5f310477027cead2e2f2b6db5d8368157cb"
+                "reference": "547e2dc4d45107440e76c17ab5a46e4252460158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/a673d5f310477027cead2e2f2b6db5d8368157cb",
-                "reference": "a673d5f310477027cead2e2f2b6db5d8368157cb",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/547e2dc4d45107440e76c17ab5a46e4252460158",
+                "reference": "547e2dc4d45107440e76c17ab5a46e4252460158",
                 "shasum": ""
             },
             "require": {
@@ -6279,8 +4377,10 @@
                 "php-64bit": "*"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7|^8|^9",
-                "vimeo/psalm": "^4|^5"
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^7|^8|^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
             },
             "suggest": {
                 "ext-sodium": "Better performance, password hashing (Argon2i), secure memory management (memzero), and better security."
@@ -6294,7 +4394,10 @@
             "autoload": {
                 "files": [
                     "autoload.php"
-                ]
+                ],
+                "psr-4": {
+                    "ParagonIE\\Sodium\\": "namespaced/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6347,773 +4450,9 @@
             ],
             "support": {
                 "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v2.1.0"
+                "source": "https://github.com/paragonie/sodium_compat/tree/v2.4.0"
             },
-            "time": "2024-09-04T12:51:01+00:00"
-        },
-        {
-            "name": "pestphp/pest",
-            "version": "v4.1.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest.git",
-                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae419afd363299c29ad5b17e8b70d118b1068bb4",
-                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4",
-                "shasum": ""
-            },
-            "require": {
-                "brianium/paratest": "^7.14.2",
-                "nunomaduro/collision": "^8.8.3",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest-plugin": "^4.0.0",
-                "pestphp/pest-plugin-arch": "^4.0.0",
-                "pestphp/pest-plugin-mutate": "^4.0.1",
-                "pestphp/pest-plugin-profanity": "^4.2.0",
-                "php": "^8.3.0",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/process": "^7.4.0|^8.0.0"
-            },
-            "conflict": {
-                "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.4.4",
-                "sebastian/exporter": "<7.0.0",
-                "webmozart/assert": "<1.11.0"
-            },
-            "require-dev": {
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-browser": "^4.1.1",
-                "pestphp/pest-plugin-type-coverage": "^4.0.3",
-                "psy/psysh": "^0.12.15"
-            },
-            "bin": [
-                "bin/pest"
-            ],
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Mutate\\Plugins\\Mutate",
-                        "Pest\\Plugins\\Configuration",
-                        "Pest\\Plugins\\Bail",
-                        "Pest\\Plugins\\Cache",
-                        "Pest\\Plugins\\Coverage",
-                        "Pest\\Plugins\\Init",
-                        "Pest\\Plugins\\Environment",
-                        "Pest\\Plugins\\Help",
-                        "Pest\\Plugins\\Memory",
-                        "Pest\\Plugins\\Only",
-                        "Pest\\Plugins\\Printer",
-                        "Pest\\Plugins\\ProcessIsolation",
-                        "Pest\\Plugins\\Profile",
-                        "Pest\\Plugins\\Retry",
-                        "Pest\\Plugins\\Snapshot",
-                        "Pest\\Plugins\\Verbose",
-                        "Pest\\Plugins\\Version",
-                        "Pest\\Plugins\\Shard",
-                        "Pest\\Plugins\\Parallel"
-                    ]
-                },
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Functions.php",
-                    "src/Pest.php"
-                ],
-                "psr-4": {
-                    "Pest\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "The elegant PHP Testing Framework.",
-            "keywords": [
-                "framework",
-                "pest",
-                "php",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.1.6"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-28T12:04:48+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin.git",
-                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
-                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^2.0.0",
-                "composer-runtime-api": "^2.2.2",
-                "php": "^8.3"
-            },
-            "conflict": {
-                "pestphp/pest": "<4.0.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.8.10",
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Pest\\Plugin\\Manager"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Plugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest plugin manager",
-            "keywords": [
-                "framework",
-                "manager",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2025-08-20T12:35:58+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-arch",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-arch.git",
-                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
-                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3",
-                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
-            },
-            "require-dev": {
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Arch\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Autoload.php"
-                ],
-                "psr-4": {
-                    "Pest\\Arch\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Arch plugin for Pest PHP.",
-            "keywords": [
-                "arch",
-                "architecture",
-                "framework",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T13:10:51+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-browser",
-            "version": "v4.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-browser.git",
-                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/da70fce21e4b33ba22bef1276f654e77676213d7",
-                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7",
-                "shasum": ""
-            },
-            "require": {
-                "amphp/amp": "^3.1.1",
-                "amphp/http-server": "^3.4.3",
-                "amphp/websocket-client": "^2.0.2",
-                "ext-sockets": "*",
-                "pestphp/pest": "^4.1.0",
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3",
-                "symfony/process": "^7.3.4"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "ext-posix": "*",
-                "livewire/livewire": "^3.6.4",
-                "nunomaduro/collision": "^8.8.2",
-                "orchestra/testbench": "^10.6.0",
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-laravel": "^4.0",
-                "pestphp/pest-plugin-type-coverage": "^4.0.2"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Browser\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Autoload.php"
-                ],
-                "psr-4": {
-                    "Pest\\Browser\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Pest plugin to test browser interactions",
-            "keywords": [
-                "browser",
-                "framework",
-                "pest",
-                "php",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v4.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/nunomaduro",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2025-09-29T01:31:33+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-mutate",
-            "version": "v4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
-                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
-                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.6.1",
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3",
-                "psr/simple-cache": "^3.0.0"
-            },
-            "require-dev": {
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-type-coverage": "^4.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Mutate\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                },
-                {
-                    "name": "Sandro Gehri",
-                    "email": "sandrogehri@gmail.com"
-                }
-            ],
-            "description": "Mutates your code to find untested cases",
-            "keywords": [
-                "framework",
-                "mutate",
-                "mutation",
-                "pest",
-                "php",
-                "plugin",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/gehrisandro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-21T20:19:25+00:00"
-        },
-        {
-            "name": "pestphp/pest-plugin-profanity",
-            "version": "v4.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
-                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/c37e5e2c7136ee4eae12082e7952332bc1c6600a",
-                "reference": "c37e5e2c7136ee4eae12082e7952332bc1c6600a",
-                "shasum": ""
-            },
-            "require": {
-                "pestphp/pest-plugin": "^4.0.0",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "faissaloux/pest-plugin-inside": "^1.9",
-                "pestphp/pest": "^4.0.0",
-                "pestphp/pest-dev-tools": "^4.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "pest": {
-                    "plugins": [
-                        "Pest\\Profanity\\Plugin"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Pest\\Profanity\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "The Pest Profanity Plugin",
-            "keywords": [
-                "framework",
-                "pest",
-                "php",
-                "plugin",
-                "profanity",
-                "test",
-                "testing",
-                "unit"
-            ],
-            "support": {
-                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.0"
-            },
-            "time": "2025-10-28T23:14:11+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
-                "reference": "54750ef60c58e43759730615a392c31c80e23176",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-phar": "*",
-                "ext-xmlwriter": "*",
-                "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-03T12:33:53+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
-            "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.1",
-                "ext-filter": "*",
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.5 || ~1.6.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-webmozart-assert": "^1.2",
-                "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
-            },
-            "time": "2025-11-27T19:50:05+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
-            },
-            "time": "2025-11-21T15:09:14+00:00"
+            "time": "2025-10-06T08:47:40+00:00"
         },
         {
             "name": "phpoffice/common",
@@ -7295,16 +4634,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.30.0",
+            "version": "1.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "2f39286e0136673778b7a142b3f0d141e43d1714"
+                "reference": "fa8257a579ec623473eabfe49731de5967306c4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/2f39286e0136673778b7a142b3f0d141e43d1714",
-                "reference": "2f39286e0136673778b7a142b3f0d141e43d1714",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/fa8257a579ec623473eabfe49731de5967306c4c",
+                "reference": "fa8257a579ec623473eabfe49731de5967306c4c",
                 "shasum": ""
             },
             "require": {
@@ -7326,7 +4665,7 @@
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": "^7.4 || ^8.0",
+                "php": ">=7.4.0 <8.5.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
@@ -7395,9 +4734,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.1"
             },
-            "time": "2025-08-10T06:28:02+00:00"
+            "time": "2025-10-26T16:01:04+00:00"
         },
         {
             "name": "phpoffice/phpword",
@@ -7581,492 +4920,6 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
-            },
-            "time": "2025-08-30T15:50:23+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "12.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
-                "reference": "bca180c050dd3ae15f87c26d25cabb34fe1a0a5a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.6.2",
-                "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
-                "phpunit/php-text-template": "^5.0",
-                "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
-                "sebastian/version": "^6.0",
-                "theseer/tokenizer": "^1.3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.4.4"
-            },
-            "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "12.5.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-11-29T07:15:54+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:37+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^12.0"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:58+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:59:16+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "8.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:59:38+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "12.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.4",
-                "phar-io/manifest": "^2.0.4",
-                "phar-io/version": "^3.2.1",
-                "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.4.0",
-                "phpunit/php-file-iterator": "^6.0.0",
-                "phpunit/php-invoker": "^6.0.0",
-                "phpunit/php-text-template": "^5.0.0",
-                "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.3",
-                "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/exporter": "^7.0.2",
-                "sebastian/global-state": "^8.0.2",
-                "sebastian/object-enumerator": "^7.0.0",
-                "sebastian/type": "^6.0.3",
-                "sebastian/version": "^6.0.0",
-                "staabm/side-effects-detector": "^1.0.5"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "12.4-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-11-21T07:39:11+00:00"
         },
         {
             "name": "psr/clock",
@@ -8482,16 +5335,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.10",
+            "version": "v0.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22"
+                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/6e80abe6f2257121f1eb9a4c55bf29d921025b22",
-                "reference": "6e80abe6f2257121f1eb9a4c55bf29d921025b22",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
+                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
                 "shasum": ""
             },
             "require": {
@@ -8499,18 +5352,19 @@
                 "ext-tokenizer": "*",
                 "nikic/php-parser": "^5.0 || ^4.0",
                 "php": "^8.0 || ^7.4",
-                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
-                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
             },
             "conflict": {
                 "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.2"
+                "bamarni/composer-bin-plugin": "^1.2",
+                "composer/class-map-generator": "^1.6"
             },
             "suggest": {
+                "composer/class-map-generator": "Improved tab completion performance with better class discovery.",
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
-                "ext-pdo-sqlite": "The doc command requires SQLite to work.",
                 "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
             },
             "bin": [
@@ -8554,9 +5408,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.10"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.16"
             },
-            "time": "2025-08-04T12:39:37+00:00"
+            "time": "2025-12-07T03:39:01+00:00"
         },
         {
             "name": "pusher/pusher-php-server",
@@ -8950,16 +5804,16 @@
         },
         {
             "name": "react/dns",
-            "version": "v1.13.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
-                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
                 "shasum": ""
             },
             "require": {
@@ -9014,7 +5868,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
             },
             "funding": [
                 {
@@ -9022,20 +5876,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-06-13T14:18:03+00:00"
+            "time": "2025-11-18T19:34:28+00:00"
         },
         {
             "name": "react/event-loop",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
                 "shasum": ""
             },
             "require": {
@@ -9086,7 +5940,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
             },
             "funding": [
                 {
@@ -9094,7 +5948,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-11-13T13:48:05+00:00"
+            "time": "2025-11-17T20:46:25+00:00"
         },
         {
             "name": "react/promise",
@@ -9250,16 +6104,16 @@
         },
         {
             "name": "react/socket",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/socket.git",
-                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
-                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
                 "shasum": ""
             },
             "require": {
@@ -9318,7 +6172,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/socket/issues",
-                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
             },
             "funding": [
                 {
@@ -9326,7 +6180,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-07-26T10:38:09+00:00"
+            "time": "2025-11-19T20:47:34+00:00"
         },
         {
             "name": "react/stream",
@@ -9467,975 +6321,6 @@
                 "source": "https://github.com/renanbr/bibtex-parser/tree/2.2.0"
             },
             "time": "2023-08-25T11:21:46+00:00"
-        },
-        {
-            "name": "revolt/event-loop",
-            "version": "v1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^9",
-                "psalm/phar": "^5.15"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Revolt\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Piotrowski",
-                    "email": "aaron@trowski.com"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "ceesjank@gmail.com"
-                },
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering"
-                },
-                {
-                    "name": "Niklas Keller",
-                    "email": "me@kelunik.com"
-                }
-            ],
-            "description": "Rock-solid event loop for concurrent PHP applications.",
-            "keywords": [
-                "async",
-                "asynchronous",
-                "concurrency",
-                "event",
-                "event-loop",
-                "non-blocking",
-                "scheduler"
-            ],
-            "support": {
-                "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
-            },
-            "time": "2025-08-27T21:33:23+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "4.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-09-14T09:36:45+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "7.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.2"
-            },
-            "suggest": {
-                "ext-bcmath": "For comparing BcMath\\Number objects"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-20T11:27:00+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:25+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0",
-                "symfony/process": "^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:55:46+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "8.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "suggest": {
-                "ext-posix": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-12T14:11:56+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "7.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-09-24T06:16:11+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "8.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "8.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "https://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-29T11:29:25+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:57:28+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "7.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:57:48+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T04:58:17+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "7.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "7.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "https://github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-13T04:44:59+00:00"
-        },
-        {
-            "name": "sebastian/type",
-            "version": "6.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^12.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the types of the PHP type system",
-            "homepage": "https://github.com/sebastianbergmann/type",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/type/issues",
-                "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-09T06:57:12+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "6.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "6.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "spatie/backtrace",
@@ -10972,16 +6857,16 @@
         },
         {
             "name": "spatie/laravel-permission",
-            "version": "6.21.0",
+            "version": "6.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-permission.git",
-                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3"
+                "reference": "9e41247bd512b1e6c229afbc1eb528f7565ae3bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/6a118e8855dfffcd90403aab77bbf35a03db51b3",
-                "reference": "6a118e8855dfffcd90403aab77bbf35a03db51b3",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/9e41247bd512b1e6c229afbc1eb528f7565ae3bb",
+                "reference": "9e41247bd512b1e6c229afbc1eb528f7565ae3bb",
                 "shasum": ""
             },
             "require": {
@@ -11043,7 +6928,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-permission/issues",
-                "source": "https://github.com/spatie/laravel-permission/tree/6.21.0"
+                "source": "https://github.com/spatie/laravel-permission/tree/6.23.0"
             },
             "funding": [
                 {
@@ -11051,7 +6936,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-23T16:08:05+00:00"
+            "time": "2025-11-03T20:16:13+00:00"
         },
         {
             "name": "spatie/laravel-searchable",
@@ -11118,58 +7003,6 @@
                 }
             ],
             "time": "2025-02-25T15:59:46+00:00"
-        },
-        {
-            "name": "staabm/side-effects-detector",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/staabm/side-effects-detector.git",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
-                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^1.12.6",
-                "phpunit/phpunit": "^9.6.21",
-                "symfony/var-dumper": "^5.4.43",
-                "tomasvotruba/type-coverage": "1.0.0",
-                "tomasvotruba/unused-public": "1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "lib/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A static analysis tool to detect side effects in PHP code",
-            "keywords": [
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/staabm/side-effects-detector/issues",
-                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/staabm",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/clock",
@@ -11250,16 +7083,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.0",
+            "version": "v7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8"
+                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8",
-                "reference": "0bc0f45254b99c58d45a8fbf9fb955d46cbd1bb8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
+                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
                 "shasum": ""
             },
             "require": {
@@ -11324,7 +7157,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.0"
+                "source": "https://github.com/symfony/console/tree/v7.4.1"
             },
             "funding": [
                 {
@@ -11344,7 +7177,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2025-12-05T15:23:39+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -11795,16 +7628,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.0",
+            "version": "v7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "769c1720b68e964b13b58529c17d4a385c62167b"
+                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/769c1720b68e964b13b58529c17d4a385c62167b",
-                "reference": "769c1720b68e964b13b58529c17d4a385c62167b",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bd1af1e425811d6f077db240c3a588bdb405cd27",
+                "reference": "bd1af1e425811d6f077db240c3a588bdb405cd27",
                 "shasum": ""
             },
             "require": {
@@ -11853,7 +7686,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.1"
             },
             "funding": [
                 {
@@ -11873,20 +7706,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-13T08:49:24+00:00"
+            "time": "2025-12-07T11:13:10+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.0",
+            "version": "v7.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "7348193cd384495a755554382e4526f27c456085"
+                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/7348193cd384495a755554382e4526f27c456085",
-                "reference": "7348193cd384495a755554382e4526f27c456085",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f6e6f0a5fa8763f75a504b930163785fb6dd055f",
+                "reference": "f6e6f0a5fa8763f75a504b930163785fb6dd055f",
                 "shasum": ""
             },
             "require": {
@@ -11972,7 +7805,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.2"
             },
             "funding": [
                 {
@@ -11992,7 +7825,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:38:24+00:00"
+            "time": "2025-12-08T07:43:37+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -13315,16 +9148,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.0",
+            "version": "v8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f929eccf09531078c243df72398560e32fa4cf4f"
+                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f929eccf09531078c243df72398560e32fa4cf4f",
-                "reference": "f929eccf09531078c243df72398560e32fa4cf4f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ba65a969ac918ce0cc3edfac6cdde847eba231dc",
+                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc",
                 "shasum": ""
             },
             "require": {
@@ -13381,7 +9214,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.0"
+                "source": "https://github.com/symfony/string/tree/v8.0.1"
             },
             "funding": [
                 {
@@ -13401,20 +9234,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:37:55+00:00"
+            "time": "2025-12-01T09:13:36+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.0",
+            "version": "v8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "82ab368a6fca6358d995b6dd5c41590fb42c03e6"
+                "reference": "770e3b8b0ba8360958abedcabacd4203467333ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/82ab368a6fca6358d995b6dd5c41590fb42c03e6",
-                "reference": "82ab368a6fca6358d995b6dd5c41590fb42c03e6",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/770e3b8b0ba8360958abedcabacd4203467333ca",
+                "reference": "770e3b8b0ba8360958abedcabacd4203467333ca",
                 "shasum": ""
             },
             "require": {
@@ -13474,7 +9307,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.0"
+                "source": "https://github.com/symfony/translation/tree/v8.0.1"
             },
             "funding": [
                 {
@@ -13494,7 +9327,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T08:09:45+00:00"
+            "time": "2025-12-01T09:13:36+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -13744,76 +9577,17 @@
             "time": "2025-10-27T20:36:44+00:00"
         },
         {
-            "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
-                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.18.0 || ^5.0.0",
-                "php": "^8.1.0",
-                "phpdocumentor/reflection-docblock": "^5.3.0",
-                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
-                "symfony/finder": "^6.4.0 || ^7.0.0"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.13.7",
-                "phpstan/phpstan": "^1.10.52"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPUnit\\Architecture\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ni Shi",
-                    "email": "futik0ma011@gmail.com"
-                },
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Methods for testing application architecture",
-            "keywords": [
-                "architecture",
-                "phpunit",
-                "stucture",
-                "test",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
-            },
-            "time": "2025-04-20T20:23:40+00:00"
-        },
-        {
             "name": "tecnickcom/tcpdf",
-            "version": "6.10.0",
+            "version": "6.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "ca5b6de294512145db96bcbc94e61696599c391d"
+                "reference": "7a2701251e5d52fc3d508fd71704683eb54f5939"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/ca5b6de294512145db96bcbc94e61696599c391d",
-                "reference": "ca5b6de294512145db96bcbc94e61696599c391d",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/7a2701251e5d52fc3d508fd71704683eb54f5939",
+                "reference": "7a2701251e5d52fc3d508fd71704683eb54f5939",
                 "shasum": ""
             },
             "require": {
@@ -13863,7 +9637,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.10.0"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.10.1"
             },
             "funding": [
                 {
@@ -13871,57 +9645,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-27T18:02:28+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "support": {
-                "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-11-21T10:58:21+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -14236,41 +9960,41 @@
                 "source": "https://github.com/wapmorgan/UnifiedArchive/tree/1.3.0"
             },
             "time": "2025-07-29T09:41:58+00:00"
-        },
+        }
+    ],
+    "packages-dev": [
         {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
+            "name": "amphp/amp",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
             },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
             "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
                 "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
+                    "Amp\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -14279,24 +10003,1188 @@
             ],
             "authors": [
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
             "keywords": [
-                "assert",
-                "check",
-                "validate"
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
             ],
             "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
             },
-            "time": "2025-10-29T15:56:20+00:00"
-        }
-    ],
-    "packages-dev": [
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-27T21:42:00+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/hpack",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/hpack.git",
+                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
+                "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "http2jp/hpack-test-case": "^1",
+                "nikic/php-fuzzer": "^0.0.10",
+                "phpunit/phpunit": "^7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "HTTP/2 HPack implementation.",
+            "homepage": "https://github.com/amphp/hpack",
+            "keywords": [
+                "headers",
+                "hpack",
+                "http-2"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/hpack/issues",
+                "source": "https://github.com/amphp/hpack/tree/v3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:00:16+00:00"
+        },
+        {
+            "name": "amphp/http",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http.git",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http/zipball/3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/hpack": "^3",
+                "amphp/parser": "^1.1",
+                "league/uri-components": "^2.4.2 | ^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "league/uri": "^6.8 | ^7.1",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.26.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/constants.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Basic HTTP primitives which can be shared by servers and clients.",
+            "support": {
+                "issues": "https://github.com/amphp/http/issues",
+                "source": "https://github.com/amphp/http/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-23T14:57:26+00:00"
+        },
+        {
+            "name": "amphp/http-client",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-client.git",
+                "reference": "75ad21574fd632594a2dd914496647816d5106bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-client/zipball/75ad21574fd632594a2dd914496647816d5106bc",
+                "reference": "75ad21574fd632594a2dd914496647816d5106bc",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "league/uri": "^7",
+                "league/uri-components": "^7",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "revolt/event-loop": "^1"
+            },
+            "conflict": {
+                "amphp/file": "<3 | >=5"
+            },
+            "require-dev": {
+                "amphp/file": "^3 | ^4",
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "ext-json": "*",
+                "kelunik/link-header-rfc5988": "^1",
+                "laminas/laminas-diactoros": "^2.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.23"
+            },
+            "suggest": {
+                "amphp/file": "Required for file request bodies and HTTP archive logging",
+                "ext-json": "Required for logging HTTP archives",
+                "ext-zlib": "Allows using compression for response bodies."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "An advanced async HTTP client library for PHP, enabling efficient, non-blocking, and concurrent requests and responses.",
+            "homepage": "https://amphp.org/http-client",
+            "keywords": [
+                "async",
+                "client",
+                "concurrent",
+                "http",
+                "non-blocking",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-client/issues",
+                "source": "https://github.com/amphp/http-client/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-16T20:41:23+00:00"
+        },
+        {
+            "name": "amphp/http-server",
+            "version": "v3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-server.git",
+                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-server/zipball/7aa962b0569f664af3ba23bc819f2a69884329cd",
+                "reference": "7aa962b0569f664af3ba23bc819f2a69884329cd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2.1",
+                "amphp/sync": "^2.2",
+                "league/uri": "^7.1",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "psr/log": "^1 | ^2 | ^3",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-client": "^5",
+                "amphp/log": "^2",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "league/uri-components": "^7.1",
+                "monolog/monolog": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.23"
+            },
+            "suggest": {
+                "ext-zlib": "Allows GZip compression of response bodies"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Driver/functions.php",
+                    "src/Middleware/functions.php",
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Server\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A non-blocking HTTP application server for PHP based on Amp.",
+            "homepage": "https://github.com/amphp/http-server",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-server/issues",
+                "source": "https://github.com/amphp/http-server/tree/v3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-18T15:43:42+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T16:33:53+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:13:44+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
+                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^6.5 | ^7",
+                "league/uri-interfaces": "^2.3 | ^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-21T14:33:03+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "amphp/websocket",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket.git",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket/zipball/963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "suggest": {
+                "ext-zlib": "Required for compression"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                }
+            ],
+            "description": "Shared code for websocket servers and clients.",
+            "homepage": "https://github.com/amphp/websocket",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket/issues",
+                "source": "https://github.com/amphp/websocket/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-28T21:28:45+00:00"
+        },
+        {
+            "name": "amphp/websocket-client",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket-client.git",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket-client/zipball/dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2.1",
+                "amphp/http": "^2.1",
+                "amphp/http-client": "^5",
+                "amphp/socket": "^2.2",
+                "amphp/websocket": "^2",
+                "league/uri": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1|^2",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/websocket-server": "^3|^4",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.26.1",
+                "psr/log": "^1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Async WebSocket client for PHP based on Amp.",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket-client/issues",
+                "source": "https://github.com/amphp/websocket-client/tree/v2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-24T17:25:34+00:00"
+        },
         {
             "name": "beyondcode/laravel-dump-server",
             "version": "2.1.0",
@@ -14364,6 +11252,323 @@
                 "source": "https://github.com/beyondcode/laravel-dump-server/tree/2.1.0"
             },
             "time": "2025-02-26T08:27:59+00:00"
+        },
+        {
+            "name": "brianium/paratest",
+            "version": "v7.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "reference": "272ff9d59b2ed0bd97c86c3cfe97c9784dabf786",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^12.5.0",
+                "phpunit/php-file-iterator": "^6",
+                "phpunit/php-timer": "^8",
+                "phpunit/phpunit": "^12.4.4",
+                "sebastian/environment": "^8.0.3",
+                "symfony/console": "^7.3.4 || ^8.0.0",
+                "symfony/process": "^7.3.4 || ^8.0.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-pcntl": "*",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.32",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "symfony/filesystem": "^7.3.2 || ^8.0.0"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2025-11-30T08:08:11+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
+            "name": "filp/whoops",
+            "version": "2.18.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filp/whoops.git",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
+                "whoops/soap": "Formats errors as SOAP responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whoops\\": "src/Whoops/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Filipe Dobreira",
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
+                }
+            ],
+            "description": "php error handling for cool kids",
+            "homepage": "https://filp.github.io/whoops/",
+            "keywords": [
+                "error",
+                "exception",
+                "handling",
+                "library",
+                "throwable",
+                "whoops"
+            ],
+            "support": {
+                "issues": "https://github.com/filp/whoops/issues",
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/denis-sokolov",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -14474,6 +11679,209 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
+        },
+        {
+            "name": "league/uri-components",
+            "version": "7.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-components.git",
+                "reference": "005f8693ce8c1f16f80e88a05cbf08da04c1c374"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/005f8693ce8c1f16f80e88a05cbf08da04c1c374",
+                "reference": "005f8693ce8c1f16f80e88a05cbf08da04c1c374",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri": "^7.7",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "bakame/aide-uri": "A polyfill for PHP8.1 until PHP8.4 to add support to PHP Native URI parser",
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-mbstring": "to use the sorting algorithm of URLSearchParams",
+                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
+                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI components manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "authority",
+                "components",
+                "fragment",
+                "host",
+                "middleware",
+                "modifier",
+                "path",
+                "port",
+                "query",
+                "rfc3986",
+                "scheme",
+                "uri",
+                "url",
+                "userinfo"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-components/tree/7.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-07T16:02:56+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -14555,13 +11963,2608 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nunomaduro/collision",
+            "version": "v8.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/collision.git",
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "shasum": ""
+            },
+            "require": {
+                "filp/whoops": "^2.18.1",
+                "nunomaduro/termwind": "^2.3.1",
+                "php": "^8.2.0",
+                "symfony/console": "^7.3.0"
+            },
+            "conflict": {
+                "laravel/framework": "<11.44.2 || >=13.0.0",
+                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.8.3",
+                "larastan/larastan": "^3.4.2",
+                "laravel/framework": "^11.44.2 || ^12.18",
+                "laravel/pint": "^1.22.1",
+                "laravel/sail": "^1.43.1",
+                "laravel/sanctum": "^4.1.1",
+                "laravel/tinker": "^2.10.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.4",
+                "pestphp/pest": "^3.8.2 || ^4.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-8.x": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "./src/Adapters/Phpunit/Autoload.php"
+                ],
+                "psr-4": {
+                    "NunoMaduro\\Collision\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Cli error handling for console/command-line PHP applications.",
+            "keywords": [
+                "artisan",
+                "cli",
+                "command-line",
+                "console",
+                "dev",
+                "error",
+                "handling",
+                "laravel",
+                "laravel-zero",
+                "php",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/collision/issues",
+                "source": "https://github.com/nunomaduro/collision"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-11-20T02:55:25+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "reference": "ae419afd363299c29ad5b17e8b70d118b1068bb4",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.14.2",
+                "nunomaduro/collision": "^8.8.3",
+                "nunomaduro/termwind": "^2.3.3",
+                "pestphp/pest-plugin": "^4.0.0",
+                "pestphp/pest-plugin-arch": "^4.0.0",
+                "pestphp/pest-plugin-mutate": "^4.0.1",
+                "pestphp/pest-plugin-profanity": "^4.2.0",
+                "php": "^8.3.0",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/process": "^7.4.0|^8.0.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">12.4.4",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-browser": "^4.1.1",
+                "pestphp/pest-plugin-type-coverage": "^4.0.3",
+                "psy/psysh": "^0.12.15"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v4.1.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-28T12:04:48+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.3"
+            },
+            "conflict": {
+                "pestphp/pest": "<4.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.8.10",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-08-20T12:35:58+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "reference": "25bb17e37920ccc35cbbcda3b00d596aadf3e58d",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T13:10:51+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-browser",
+            "version": "v4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-browser.git",
+                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/da70fce21e4b33ba22bef1276f654e77676213d7",
+                "reference": "da70fce21e4b33ba22bef1276f654e77676213d7",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3.1.1",
+                "amphp/http-server": "^3.4.3",
+                "amphp/websocket-client": "^2.0.2",
+                "ext-sockets": "*",
+                "pestphp/pest": "^4.1.0",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "symfony/process": "^7.3.4"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "livewire/livewire": "^3.6.4",
+                "nunomaduro/collision": "^8.8.2",
+                "orchestra/testbench": "^10.6.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-laravel": "^4.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Browser\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Browser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Pest plugin to test browser interactions",
+            "keywords": [
+                "browser",
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v4.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-09-29T01:31:33+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.6.1",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-21T20:19:25+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "343cfa6f3564b7e35df0ebb77b7fa97039f72b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/343cfa6f3564b7e35df0ebb77b7fa97039f72b27",
+                "reference": "343cfa6f3564b7e35df0ebb77b7fa97039f72b27",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.9",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.1"
+            },
+            "time": "2025-12-08T00:13:17+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
+            },
+            "time": "2025-11-27T19:50:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+            },
+            "time": "2025-08-30T15:50:23+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "c467c59a4f6e04b942be422844e7a6352fa01b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c467c59a4f6e04b942be422844e7a6352fa01b57",
+                "reference": "c467c59a4f6e04b942be422844e7a6352fa01b57",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-file-iterator": "^6.0",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-08T07:17:58+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
+                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:37+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:58+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:16+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:38+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.4.0",
+                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.3",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-21T07:39:11+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+            },
+            "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-14T09:36:45+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "7.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-20T11:27:00+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "8.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-12T14:11:56+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:16:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "8.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-29T11:29:25+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:28+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:48+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:17+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:44:59+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:57:12+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/cf6fb197b676ba716837c886baca842e4db29005",
+                "reference": "cf6fb197b676ba716837c886baca842e4db29005",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0",
+                "phpunit/phpunit": "^10.5.5  || ^11.0.0 || ^12.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.5"
+            },
+            "time": "2025-04-20T20:23:40+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+            },
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "pestphp/pest-plugin-browser": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/config/logging.php
+++ b/config/logging.php
@@ -32,7 +32,13 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['single', 'error'],
+        ],
+        
+        'error' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/error.log'),
+            'level' => 'error',
         ],
 
         'single' => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "p-queue": "^8.0.1",
                 "picmo": "^5.8.2",
                 "pinia": "^3.0.0",
+                "playwright": "^1.57.0",
                 "process": "^0.11.10",
                 "proj4": "^2.9.0",
                 "string-similarity-js": "^2.1.4",
@@ -18376,6 +18377,50 @@
                 "node": ">=8"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+            "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.57.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+            "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/portfinder": {
             "version": "1.0.32",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -19071,24 +19116,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pretty-error": {
@@ -23639,20 +23666,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "p-queue": "^8.0.1",
         "picmo": "^5.8.2",
         "pinia": "^3.0.0",
+        "playwright": "^1.57.0",
         "process": "^0.11.10",
         "proj4": "^2.9.0",
         "string-similarity-js": "^2.1.4",

--- a/tests/Browser/LoginBrowserTest.php
+++ b/tests/Browser/LoginBrowserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+beforeEach(function () {
+    $this->unsetTestUser();
+});
+
+it('login page accessible', function () {    
+    visit('/')
+        ->assertSee('Spacialist')
+        ->assertSee('Login')
+        ;
+});
+
+it('redirected to login page, when accessing protected page unauthenticated', function () {
+    visit('/#/data-model')
+        ->assertSee('Spacialist')
+        ->assertSee('Login')
+        // ->assertQueryStringHas('redirectTo', '/') // TODO: This seems wrong, it should point to /#/data-model; Those assertions are not working with Vue Hash Routing!
+        ;
+});
+
+it('login page displays all required fields', function () {
+    
+        visit('/')
+            ->assertSee('E-Mail')
+            ->assertSee('Password')
+            ->assertSee('Login')
+                
+            // Ignore exceptions from unauthenticated access
+            ->assertPresent('input[name=email]')
+            ->assertPresent('input[name="email"]')
+            ->assertPresent('button[type=submit]')
+            ;
+});
+
+it('login with invalid credentials fails', function () {
+    visit('/')
+        ->type('email', 'invalid@mail.com')
+        ->type('password', 'wrongpassword')
+        ->click('[type="submit"]')
+        ->assertDontSee('Entities')
+        ->assertSee('Invalid Credentials')
+        ->assertSee('Login')
+        ;
+});
+
+it('login with email succeeds', function () {
+    visit('/')
+        ->type('email', 'admin@localhost')
+        ->type('password', 'admin')
+        ->click('[type="submit"]')
+        ->assertSee('Entities')
+        ;
+});
+
+it('login with nickname succeeds', function () {
+    visit('/')
+        ->type('email', 'admin')
+        ->type('password', 'admin')
+        ->click('[type="submit"]')
+        ->assertSee('Entities')
+        ;
+});

--- a/tests/Browser/_InitBrowserTest.php
+++ b/tests/Browser/_InitBrowserTest.php
@@ -1,0 +1,17 @@
+<?php
+
+it('may welcome the user', function () {
+    $this->unsetTestUser();
+    
+    $page = visit('/');
+ 
+    $page->assertSee('Spacialist');
+});
+
+it('get 404 on invalid root page', function () {
+    $this->unsetTestUser();
+    
+    $page = visit('/invalid-page');
+ 
+    $page->assertSee('404');
+});

--- a/tests/Browser/_InitBrowserTest.php
+++ b/tests/Browser/_InitBrowserTest.php
@@ -3,15 +3,13 @@
 it('may welcome the user', function () {
     $this->unsetTestUser();
     
-    $page = visit('/');
- 
-    $page->assertSee('Spacialist');
+    visit('/')
+      ->assertSee('Spacialist');
 });
 
 it('get 404 on invalid root page', function () {
     $this->unsetTestUser();
     
-    $page = visit('/invalid-page');
- 
-    $page->assertSee('404');
+    visit('/invalid-page')
+      ->assertSee('404');
 });

--- a/tests/Feature/ApiActivityTest.php
+++ b/tests/Feature/ApiActivityTest.php
@@ -1,260 +1,226 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Entity;
 use App\User;
-use Tests\TestCase;
 use Spatie\Activitylog\Models\Activity;
 
-class ApiActivityTest extends TestCase
-{
-    // Testing GET requests
 
-    /**
-     * Test getting all logged activity.
-     *
-     * @return void
-     */
-    public function testGetAllActivityEndpoint()
-    {
-        $actCnt = Activity::count();
-        $this->assertEquals(0, $actCnt);
+test('get all activity endpoint', function () {
+    $actCnt = Activity::count();
+    expect($actCnt)->toEqual(0);
 
-        $response = $this->userRequest()
-            ->post('/api/v1/entity', [
-                'name' => 'Unit-Test Entity I',
-                'entity_type_id' => 3,
-                'root_entity_id' => 1
-            ]);
-        $entity = Entity::latest()->first();
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/entity/4/attributes', [
-                [
-                    'params' => [
-                        'aid' => 19,
-                        'cid' => 4
-                    ],
-                    'op' => 'add',
-                    'value' => 'Test'
-                ]
-            ]);
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/entity/4/attributes', [
-                [
-                    'params' => [
-                        'aid' => 19,
-                        'cid' => 4
-                    ],
-                    'op' => 'replace',
-                    'value' => 'Test2'
-                ]
-            ]);
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/entity/'.$entity->id);
-
-        $response->assertStatus(204);
-        $actCnt = Activity::count();
-        $this->assertGreaterThanOrEqual(5, $actCnt);
-        $this->assertLessThanOrEqual(6, $actCnt);
-
-        $response = $this->userRequest()
-            ->get('/api/v1/activity');
-
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'log_name',
-                'description',
-                'subject_id',
-                'subject',
-                'subject_type',
-                'causer_id',
-                'causer',
-                'properties',
-                'created_at',
-                'updated_at',
-            ]
+    $response = $this->userRequest()
+        ->post('/api/v1/entity', [
+            'name' => 'Unit-Test Entity I',
+            'entity_type_id' => 3,
+            'root_entity_id' => 1
         ]);
-        $response->assertJson([
+    $entity = Entity::latest()->first();
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/entity/4/attributes', [
             [
-                'log_name' => 'default',
-                'description' => 'created',
-                'causer_id' => 1,
-                'subject_id' => $entity->id,
-                'subject_type' => 'App\\Entity',
+                'params' => [
+                    'aid' => 19,
+                    'cid' => 4
+                ],
+                'op' => 'add',
+                'value' => 'Test'
             ]
         ]);
 
-        // With start and end before now
+    $response = $this->userRequest()
+        ->patch('/api/v1/entity/4/attributes', [
+            [
+                'params' => [
+                    'aid' => 19,
+                    'cid' => 4
+                ],
+                'op' => 'replace',
+                'value' => 'Test2'
+            ]
+        ]);
+
+    $response = $this->userRequest()
+        ->delete('/api/v1/entity/'.$entity->id);
+
+    $response->assertStatus(204);
+    $actCnt = Activity::count();
+    expect($actCnt)->toBeGreaterThanOrEqual(5);
+    expect($actCnt)->toBeLessThanOrEqual(6);
+
+    $response = $this->userRequest()
+        ->get('/api/v1/activity');
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'log_name',
+            'description',
+            'subject_id',
+            'subject',
+            'subject_type',
+            'causer_id',
+            'causer',
+            'properties',
+            'created_at',
+            'updated_at',
+        ]
+    ]);
+    $response->assertJson([
+        [
+            'log_name' => 'default',
+            'description' => 'created',
+            'causer_id' => 1,
+            'subject_id' => $entity->id,
+            'subject_type' => 'App\\Entity',
+        ]
+    ]);
+
+    // With start and end before now
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'timespan' => [
+                'from' => '2017-12-20 09:30:00',
+                'to' => '2018-12-20 09:30:00',
+            ]
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect($content->data)->toEqual([]);
+
+    // With start before now
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'timespan' => [
+                'from' => '2017-12-20 09:30:00',
+            ]
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toBeGreaterThanOrEqual(5);
+    expect(count($content->data))->toBeLessThanOrEqual(6);
+
+    // With single text search string
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'text' => 'tEst'
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toEqual(4);
+
+    // With multiple text search strings
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'text' => 'unit entity'
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toEqual(2);
+
+    // With file only
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'text' => 'Entity FooBar'
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toEqual(0);
+
+    // With user id=2 and id=3
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'users' => [2, 3]
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toEqual(0);
+
+    // With user id=1 only
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'users' => [1]
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toBeGreaterThanOrEqual(5);
+    expect(count($content->data))->toBeLessThanOrEqual(6);
+
+    // With user id=1,2,5
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'users' => [1, 2, 5]
+        ]);
+
+    $response->assertStatus(200);
+    $content = json_decode($response->getContent());
+    expect(count($content->data))->toBeGreaterThanOrEqual(5);
+    expect(count($content->data))->toBeLessThanOrEqual(6);
+});
+
+test('permissions', function () {
+    User::first()->roles()->detach();
+
+    $calls = [
+        ['url' => '/activity', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'get'],
+        ['url' => '/activity/2', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'get'],
+        ['url' => '/activity', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'post'],
+    ];
+
+    $response = null;
+    foreach($calls as $c) {
         $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'timespan' => [
-                    'from' => '2017-12-20 09:30:00',
-                    'to' => '2018-12-20 09:30:00',
-                ]
-            ]);
+            ->json($c['verb'], '/api/v1' . $c['url']);
 
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertEquals([], $content->data);
-
-        // With start before now
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'timespan' => [
-                    'from' => '2017-12-20 09:30:00',
-                ]
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertGreaterThanOrEqual(5, count($content->data));
-        $this->assertLessThanOrEqual(6, count($content->data));
-
-        // With single text search string
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'text' => 'tEst'
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertEquals(4, count($content->data));
-
-        // With multiple text search strings
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'text' => 'unit entity'
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertEquals(2, count($content->data));
-
-        // With file only
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'text' => 'Entity FooBar'
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertEquals(0, count($content->data));
-
-        // With user id=2 and id=3
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'users' => [2, 3]
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertEquals(0, count($content->data));
-
-        // With user id=1 only
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'users' => [1]
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertGreaterThanOrEqual(5, count($content->data));
-        $this->assertLessThanOrEqual(6, count($content->data));
-
-        // With user id=1,2,5
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'users' => [1, 2, 5]
-            ]);
-
-        $response->assertStatus(200);
-        $content = json_decode($response->getContent());
-        $this->assertGreaterThanOrEqual(5, count($content->data));
-        $this->assertLessThanOrEqual(6, count($content->data));
+        $response->assertStatus(403);
+        $response->assertSimilarJson([
+            'error' => $c['error']
+        ]);
     }
+});
 
-    // Testing exceptions and permissions
+test('exceptions', function () {
+    $calls = [
+        ['url' => '/activity/99', 'error' => 'This user does not exist', 'verb' => 'get'],
+    ];
 
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testPermissions()
-    {
-        User::first()->roles()->detach();
+    foreach($calls as $c) {
+        $response = $this->withHeaders([
+                'Authorization' => "Bearer $this->token"
+            ])
+            ->json($c['verb'], '/api/v1' . $c['url']);
 
-        $calls = [
-            ['url' => '/activity', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'get'],
-            ['url' => '/activity/2', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'get'],
-            ['url' => '/activity', 'error' => 'You do not have the permission to view activity logs', 'verb' => 'post'],
-        ];
-
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->json($c['verb'], '/api/v1' . $c['url']);
-
-            $response->assertStatus(403);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
+        $response->assertStatus(400);
+        $response->assertSimilarJson([
+            'error' => $c['error']
+        ]);
     }
+});
 
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testExceptions()
-    {
-        $calls = [
-            ['url' => '/activity/99', 'error' => 'This user does not exist', 'verb' => 'get'],
-        ];
+test('validations', function () {
+    $userError = 'The users must be an array.';
 
-        foreach($calls as $c) {
-            $response = $this->withHeaders([
-                    'Authorization' => "Bearer $this->token"
-                ])
-                ->json($c['verb'], '/api/v1' . $c['url']);
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'users' => 1
+        ]);
 
-            $response->assertStatus(400);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
-    }
+    $this->assertStatus($response, 422);
+    $response->assertJson(['message' => $userError, 'errors' => ['users' => [$userError]]]);
 
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testValidations()
-    {
+    $response = $this->userRequest()
+        ->post('/api/v1/activity', [
+            'timespan' => '2017-12-20 09:30:00'
+        ]);
 
-        $userError = 'The users must be an array.';
-
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'users' => 1
-            ]);
-
-        $this->assertStatus($response, 422);
-        $response->assertJson(['message' => $userError, 'errors' => ['users' => [$userError]]]);
-
-        $response = $this->userRequest()
-            ->post('/api/v1/activity', [
-                'timespan' => '2017-12-20 09:30:00'
-            ]);
-
-        $this->assertEquals('The timespan must be an array.', $response->exception->getMessage());
-    }
-}
+    expect($response->exception->getMessage())->toEqual('The timespan must be an array.');
+});

--- a/tests/Feature/ApiBibliographyTest.php
+++ b/tests/Feature/ApiBibliographyTest.php
@@ -5,7 +5,6 @@ use Illuminate\Http\UploadedFile;
 use Tests\Permission;
 use Tests\ResponseTester;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 /**
@@ -135,19 +134,19 @@ test('add', function () {
     ]);
 });
 
-function importTest($filename, $results)
+function importTest($test, $filename, $results)
 {
     $path = storage_path() . "/framework/testing/$filename";
     $file = new UploadedFile($path, $filename, 'application/x-bibtex', null, true);
 
-    $response = $this->userRequest()
+    $response = $test->userRequest()
         ->post('/api/v1/bibliography/import', [
             'file' => $file
         ]);
 
     $inserted = $response->json();
 
-    $this->assertStatus($response, 201);
+    $test->assertStatus($response, 201);
     $response->assertJsonCount(16);
     $response->assertJsonStructure([ "*" => [
         "entry" => getBibliographyStructure()]
@@ -169,17 +168,17 @@ function importTest($filename, $results)
         // Note: I don't like the reliance on the $addedItem["entry"]["id"] here.
         //       But Postgres does not rollback the sequence when a transaction is rolled back.
         //       Therefore all alternative also seem to be more complex than this.
-        $response = $this->userRequest()
+        $response = $test->userRequest()
             ->get('/api/v1/bibliography/'. $addedItem["entry"]["id"]);
 
-        $this->assertStatus($response, 200);
+        $test->assertStatus($response, 200);
         $response->assertJsonStructure(getBibliographyStructure());
         $response->assertJson($r);
     }
 }
 
 test('mandatory import', function () {
-    importTest('import_mandatory.bib', [
+    importTest($this, 'import_mandatory.bib', [
         [
             "entry_type" => "article",
             "citekey" => "Smith2021",
@@ -305,7 +304,7 @@ test('mandatory import', function () {
 });
 
 test('optional import', function () {
-    importTest("import_optional.bib", [
+    importTest($this, "import_optional.bib", [
         [
             "entry_type" => "article",
             "citekey" => "Smith2021",

--- a/tests/Feature/ApiBibliographyTest.php
+++ b/tests/Feature/ApiBibliographyTest.php
@@ -1,719 +1,688 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Bibliography;
 use Illuminate\Http\UploadedFile;
 use Tests\Permission;
 use Tests\ResponseTester;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiBibliographyTest extends TestCase
+
+/**
+ * Tests the get all (GET /bibliography/) and
+ * add entry (POST /bibliography/) API endpoints
+ * @return void
+ */
+function getBibliographyStructure(): array
 {
-    /**
-     * Tests the get all (GET /bibliography/) and
-     * add entry (POST /bibliography/) API endpoints
-     * @return void
-     */
-     public function getBibliographyStructure(): array {
-        return [
-            // system fields
-            'id',
-            'entry_type',
-            'file',
-            'user_id',
-            'created_at',
-            'updated_at',
-            // bibtex fields
-            'address',
-            'annote',
-            'author',
-            'booktitle',
-            'chapter',
-            'citekey',
-            'crossref',
-            'edition',
-            'editor',
-            'howpublished',
-            'institution',
-            'journal',
-            'key',
-            'misc',
-            'month',
-            'note',
-            'number',
-            'organization',
-            'pages',
-            'publisher',
-            'school',
-            'series',
-            'title',
-            'type',
-            'volume',
-            'year',
-        ];
-     }
+    return [
+        // system fields
+        'id',
+        'entry_type',
+        'file',
+        'user_id',
+        'created_at',
+        'updated_at',
+        // bibtex fields
+        'address',
+        'annote',
+        'author',
+        'booktitle',
+        'chapter',
+        'citekey',
+        'crossref',
+        'edition',
+        'editor',
+        'howpublished',
+        'institution',
+        'journal',
+        'key',
+        'misc',
+        'month',
+        'note',
+        'number',
+        'organization',
+        'pages',
+        'publisher',
+        'school',
+        'series',
+        'title',
+        'type',
+        'volume',
+        'year',
+    ];
+}
 
-     #[TestDox('GET /api/v1/bibliography/')]
-     public function testGetAll() {
-        $response = $this->userRequest()
-            ->get('/api/v1/bibliography');
+test('get all', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/bibliography');
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(6);
-     }
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(6);
+});
 
+test('get single', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/bibliography/1320');
 
-    #[TestDox('GET /api/v1/bibliography/{id}')]
-     public function testGetSingle() {
-        $response = $this->userRequest()
-            ->get('/api/v1/bibliography/1320');
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure(getBibliographyStructure());
+    $response->assertJson([
+        'id' => 1320,
+        'entry_type' => 'article',
+        'title' => '{Finite diagrams stable in power}',
+        'author' => 'Shelah, Saharon',
+        'journal' => 'Annals of Mathematical Logic',
+        'pages' => '69--118',
+        'volume' => '2',
+        'citekey' => 'Sh:3'
+    ]);
+});
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure($this->getBibliographyStructure());
-        $response->assertJson([
-            'id' => 1320,
-            'entry_type' => 'article',
-            'title' => '{Finite diagrams stable in power}',
-            'author' => 'Shelah, Saharon',
-            'journal' => 'Annals of Mathematical Logic',
-            'pages' => '69--118',
-            'volume' => '2',
-            'citekey' => 'Sh:3'
-        ]);
-     }
+test('get reference count endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/bibliography/1319/ref_count');
 
-     #[TestDox('GET /api/v1/bibliography/{id}/ref_count')]
-    public function testGetReferenceCountEndpoint() {
-        $response = $this->userRequest()
-            ->get('/api/v1/bibliography/1319/ref_count');
+    $this->assertStatus($response, 200);
+    $response->assertSimilarJson([1]);
+});
 
-        $this->assertStatus($response, 200);
-        $response->assertSimilarJson([1]);
-    }
-
-    #[TestDox('POST /api/v1/bibliography/')]
-    public function testAdd() {
-        $response = $this->userRequest()
-            ->post('/api/v1/bibliography', [
-                'entry_type' => 'article',
-                'title' => 'Schweinegerichte und deren gesundheitliche Auswirkungen',
-                'author' => 'Dietmar Köppke and Jürgen Sauer',
-                'journal' => 'Kulinarik 101',
-                'pages' => '10-15',
-                'year' => '2021'
-            ]);
-
-        $this->assertStatus($response, 201);
-        $response->assertJsonStructure($this->getBibliographyStructure());
-
-        $entry_id = 1324;
-        $response->assertJson([
-            'id' => $entry_id,
+test('add', function () {
+    $response = $this->userRequest()
+        ->post('/api/v1/bibliography', [
             'entry_type' => 'article',
             'title' => 'Schweinegerichte und deren gesundheitliche Auswirkungen',
             'author' => 'Dietmar Köppke and Jürgen Sauer',
             'journal' => 'Kulinarik 101',
             'pages' => '10-15',
-            'year' => '2021',
-            'citekey' => 'Dietmar Köppke_Schweinegerichte_sudga_2021'
+            'year' => '2021'
         ]);
 
-        $response = $this->userRequest()
-            ->get('/api/v1/bibliography');
+    $this->assertStatus($response, 201);
+    $response->assertJsonStructure(getBibliographyStructure());
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(7);
+    $entry_id = 1324;
+    $response->assertJson([
+        'id' => $entry_id,
+        'entry_type' => 'article',
+        'title' => 'Schweinegerichte und deren gesundheitliche Auswirkungen',
+        'author' => 'Dietmar Köppke and Jürgen Sauer',
+        'journal' => 'Kulinarik 101',
+        'pages' => '10-15',
+        'year' => '2021',
+        'citekey' => 'Dietmar Köppke_Schweinegerichte_sudga_2021'
+    ]);
 
-        $response = $this->userRequest()
-            ->get("/api/v1/bibliography/$entry_id");
+    $response = $this->userRequest()
+        ->get('/api/v1/bibliography');
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure($this->getBibliographyStructure());
-        $response->assertJson([
-            'entry_type' => 'article',
-            'title' => 'Schweinegerichte und deren gesundheitliche Auswirkungen',
-            'author' => 'Dietmar Köppke and Jürgen Sauer',
-            'journal' => 'Kulinarik 101',
-            'pages' => '10-15',
-            'year' => '2021',
-            'citekey' => 'Dietmar Köppke_Schweinegerichte_sudga_2021'
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(7);
+
+    $response = $this->userRequest()
+        ->get("/api/v1/bibliography/$entry_id");
+
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure(getBibliographyStructure());
+    $response->assertJson([
+        'entry_type' => 'article',
+        'title' => 'Schweinegerichte und deren gesundheitliche Auswirkungen',
+        'author' => 'Dietmar Köppke and Jürgen Sauer',
+        'journal' => 'Kulinarik 101',
+        'pages' => '10-15',
+        'year' => '2021',
+        'citekey' => 'Dietmar Köppke_Schweinegerichte_sudga_2021'
+    ]);
+});
+
+function importTest($filename, $results)
+{
+    $path = storage_path() . "/framework/testing/$filename";
+    $file = new UploadedFile($path, $filename, 'application/x-bibtex', null, true);
+
+    $response = $this->userRequest()
+        ->post('/api/v1/bibliography/import', [
+            'file' => $file
         ]);
-    }
 
-    private function importTest($filename, $results) {
-        $path = storage_path() . "/framework/testing/$filename";
-        $file = new UploadedFile($path, $filename, 'application/x-bibtex', null, true);
+    $inserted = $response->json();
 
-        $response = $this->userRequest()
-            ->post('/api/v1/bibliography/import', [
-                'file' => $file
-            ]);
+    $this->assertStatus($response, 201);
+    $response->assertJsonCount(16);
+    $response->assertJsonStructure([ "*" => [
+        "entry" => getBibliographyStructure()]
+    ]);
 
-        $inserted = $response->json();
-
-        $this->assertStatus($response, 201);
-        $response->assertJsonCount(16);
-        $response->assertJsonStructure([ "*" => [
-            "entry" => $this->getBibliographyStructure()]
-        ]);
-
-        $response->assertJson(array_map(function($e) {
-            return [
-                "entry" => $e,
-                "added" => true
-            ];
-        }, $results));
-
-        $cnt = Bibliography::count();
-        $this->assertEquals(22, $cnt);
-
-        $i = 0;
-        foreach($results as $r) {
-            $addedItem = $inserted[$i++];
-            // Note: I don't like the reliance on the $addedItem["entry"]["id"] here.
-            //       But Postgres does not rollback the sequence when a transaction is rolled back.
-            //       Therefore all alternative also seem to be more complex than this.
-            $response = $this->userRequest()
-                ->get('/api/v1/bibliography/'. $addedItem["entry"]["id"]);
-
-            $this->assertStatus($response, 200);
-            $response->assertJsonStructure($this->getBibliographyStructure());
-            $response->assertJson($r);
-        }
-    }
-
-    #[TestDox('POST /api/v1/bibliography/import (mandatory fields)')]
-    public function testMandatoryImport() {
-       $this->importTest('import_mandatory.bib', [
-           [
-               "entry_type" => "article",
-               "citekey" => "Smith2021",
-               "author" => "John Smith and Jane Doe and Alice Brown",
-               "title" => "A Comprehensive Study on Testing",
-               "journal" => "Journal of Testing",
-               "year" => "2021"
-           ],
-           [
-               "entry_type" => "book",
-               "citekey" => "Doe2020",
-               "author" => "Jane Doe and John Smith and Carol Green",
-               "title" => "The Art of Testing",
-               "publisher" => "Testing Publishers",
-               "year" => "2020"
-           ],
-           [
-               "entry_type" => "book",
-               "citekey" => "EditorBook2022",
-               "editor" => "Emily Editor and David Black and Eve Gray",
-               "title" => "Edited Volume on Testing",
-               "publisher" => "Testing Publishers",
-               "year" => "2022"
-           ],
-           [
-               "entry_type" => "booklet",
-               "citekey" => "Booklet2022",
-               "title" => "Testing Booklet"
-           ],
-           [
-               "entry_type" => "conference",
-               "citekey" => "White2018",
-               "author" => "Bob White and Carol Green and David Black",
-               "title" => "Conference on Testing Methods",
-               "booktitle" => "Annual Testing Conference",
-               "year" => "2018"
-           ],
-           [
-               "entry_type" => "inbook",
-               "citekey" => "Taylor2023",
-               "author" => "Laura Taylor and John Smith and Emily Brown",
-               "title" => "In-depth Testing Techniques",
-               "chapter" => "5",
-               "pages" => "123-145",
-               "publisher" => "Advanced Testing Publishers",
-               "year" => "2023"
-           ],
-           [
-               "entry_type" => "inbook",
-               "citekey" => "EditorInBook2023",
-               "editor" => "Nancy Editor and Alice White and Bob Smith",
-               "title" => "Advanced Testing Strategies",
-               "chapter" => "7",
-               "pages" => "200-220",
-               "publisher" => "Expert Testing Publishers",
-               "year" => "2023"
-           ],
-           [
-               "entry_type" => "incollection",
-               "citekey" => "Johnson2022",
-               "author" => "Michael Johnson and Alice White and Bob Smith",
-               "title" => "Chapter on Testing",
-               "booktitle" => "Handbook of Testing",
-               "publisher" => "Testing Publishers",
-               "year" => "2022"
-           ],
-           [
-               "entry_type" => "inproceedings",
-               "citekey" => "Brown2019",
-               "author" => "Alice Brown and David Green and Eve Gray",
-               "title" => "Proceedings of the Testing Conference",
-               "booktitle" => "International Conference on Testing",
-               "year" => "2019"
-           ],
-           [
-               "entry_type" => "manual",
-               "citekey" => "Manual2014",
-               "title" => "Testing Manual"
-           ],
-           [
-               "entry_type" => "mastersthesis",
-               "citekey" => "Black2016",
-               "author" => "David Black and Jane White and Bob Smith",
-               "title" => "Testing in Software Engineering",
-               "school" => "Institute of Testing",
-               "year" => "2016"
-           ],
-           [
-               "entry_type" => "misc",
-               "citekey" => "Misc2013",
-               "note" => "Misc has no mandatory fields"
-           ],
-           [
-               "entry_type" => "phdthesis",
-               "citekey" => "Green2017",
-               "author" => "Carol Green and John Doe and Alice Brown",
-               "title" => "Advanced Testing Techniques",
-               "school" => "University of Testing",
-               "year" => "2017"
-           ],
-           [
-               "entry_type" => "proceedings",
-               "citekey" => "Proceedings2021",
-               "title" => "Proceedings of the 2021 Testing Symposium",
-               "year" => "2021"
-           ],
-           [
-               "entry_type" => "techreport",
-               "citekey" => "Gray2015",
-               "author" => "Eve Gray and Bob Smith and Carol Green",
-               "title" => "Testing Report 2015",
-               "institution" => "Testing Institute",
-               "year" => "2015"
-           ],
-           [
-               "entry_type" => "unpublished",
-               "citekey" => "Unpublished2023",
-               "author" => "Frank Unpublished and Emily Editor and David Black",
-               "title" => "Unpublished Testing Research",
-               "note" => "Manuscript in preparation"
-           ]
-           ]);
-    }
-
-    #[TestDox('POST /api/v1/bibliography/import (with optional fields)')]
-    public function testOptionalImport() {
-        $this->importTest("import_optional.bib", [
-            [
-                "entry_type" => "article",
-                "citekey" => "Smith2021",
-                "author" => "John Smith and Jane Doe and Alice Brown",
-                "title" => "A Comprehensive Study on Testing",
-                "journal" => "Journal of Testing",
-                "year" => "2021",
-                "volume" => "3",
-                "number" => "2",
-                "month" => "Apr",
-                "note" => "A significant piece of work"
-            ],
-            [
-                "entry_type" => "book",
-                "citekey" => "Doe2020",
-                "author" => "Jane Doe and John Smith and Carol Green",
-                "title" => "The Art of Testing",
-                "publisher" => "Testing Publishers",
-                "year" => "2020",
-                "series" => "In-depth Series",
-                "address" => "Boston",
-                "edition" => "Third",
-                "month" => "May",
-                "note" => "Great book"
-            ],
-            [
-                "entry_type" => "book",
-                "citekey" => "EditorBook2022",
-                "editor" => "Emily Editor and David Black and Eve Gray",
-                "title" => "Edited Volume on Testing",
-                "publisher" => "Testing Publishers",
-                "year" => "2022",
-                "series" => "Edited Series",
-                "address" => "New York",
-                "month" => "Oct",
-                "note" => "Edited volume"
-            ],
-            [
-                "entry_type" => "booklet",
-                "citekey" => "Booklet2022",
-                "title" => "Testing Booklet",
-                "author" => "Richard Roe",
-                "howpublished" => "Website",
-                "address" => "Heidelberg, Germany",
-                "month" => "Jun",
-                "year" => "2022",
-                "note" => "A booklet on testing"
-            ],
-            [
-                "entry_type" => "conference",
-                "citekey" => "White2018",
-                "author" => "Bob White and Carol Green and David Black",
-                "title" => "Conference on Testing Methods",
-                "booktitle" => "Annual Testing Conference",
-                "year" => "2018",
-                "volume" => "6",
-                "series" => "Workshop Series",
-                "pages" => "100-120",
-                "address" => "London, UK",
-                "month" => "Dec",
-                "organization" => "Testing Society",
-                "publisher" => "Testing Publishers",
-                "note" => "Conference paper"
-            ],
-            [
-                "entry_type" => "inbook",
-                "citekey" => "Taylor2023",
-                "author" => "Laura Taylor and John Smith and Emily Brown",
-                "title" => "In-depth Testing Techniques",
-                "chapter" => "5",
-                "pages" => "123-145",
-                "publisher" => "Advanced Testing Publishers",
-                "year" => "2023",
-                "volume" => "4",
-                "series" => "In-depth Series",
-                "type" => "Technical",
-                "address" => "Boston",
-                "edition" => "3rd",
-                "month" => "Jun",
-                "note" => "A detailed chapter"
-            ],
-            [
-                "entry_type" => "inbook",
-                "citekey" => "EditorInBook2023",
-                "author" => "Nancy Editor and Alice White and Bob Smith",
-                "title" => "Advanced Testing Strategies",
-                "chapter" => "7",
-                "pages" => "200-220",
-                "publisher" => "Expert Testing Publishers",
-                "year" => "2023",
-                "volume" => "5",
-                "series" => "Strategies Series",
-                "type" => "Research",
-                "address" => "Seattle",
-                "edition" => "First",
-                "month" => "Jul",
-                "note" => "An insightful chapter"
-            ],
-            [
-                "entry_type" => "incollection",
-                "citekey" => "Johnson2022",
-                "author" => "Michael Johnson and Alice White and Bob Smith",
-                "title" => "Chapter on Testing",
-                "booktitle" => "Handbook of Testing",
-                "publisher" => "Testing Publishers",
-                "year" => "2022",
-                "editor" => "Nancy Editor",
-                "volume" => "3",
-                "series" => "Testing Handbook Series",
-                "type" => "Research",
-                "chapter" => "10",
-                "pages" => "150-170",
-                "address" => "Atlanta",
-                "edition" => "Fourth",
-                "month" => "Mar",
-                "note" => "A key chapter"
-            ],
-            [
-                "entry_type" => "inproceedings",
-                "citekey" => "Brown2019",
-                "author" => "Alice Brown and David Green and Eve Gray",
-                "title" => "Proceedings of the Testing Conference",
-                "booktitle" => "International Conference on Testing",
-                "year" => "2019",
-                "editor" => "Michael Johnson",
-                "volume" => "6",
-                "series" => "Conference Proceedings",
-                "pages" => "300-320",
-                "address" => "New York",
-                "month" => "Aug",
-                "organization" => "Testing Society",
-                "publisher" => "Proceedings Publishers",
-                "note" => "A notable conference paper"
-            ],
-            [
-                "entry_type" => "manual",
-                "citekey" => "Manual2014",
-                "title" => "Testing Manual",
-                "author" => "John Smith",
-                "organization" => "Testing Organization",
-                "address" => "Los Angeles",
-                "edition" => "1st",
-                "month" => "Sep",
-                "year" => "2014",
-                "note" => "A comprehensive manual"
-            ],
-            [
-                "entry_type" => "mastersthesis",
-                "citekey" => "Black2016",
-                "author" => "David Black and Jane White and Bob Smith",
-                "title" => "Testing in Software Engineering",
-                "school" => "Institute of Testing",
-                "year" => "2016",
-                "type" => "Master's Thesis",
-                "address" => "Boston",
-                "month" => "Oct",
-                "note" => "A significant thesis"
-            ],
-            [
-                "entry_type" => "misc",
-                "citekey" => "Misc2013",
-                "title" => "Miscellaneous Testing",
-                "author" => "John Doe",
-                "howpublished" => "Unpublished",
-                "month" => "Nov",
-                "year" => "2013",
-                "note" => "Misc has no mandatory fields"
-            ],
-            [
-                "entry_type" => "phdthesis",
-                "citekey" => "Green2017",
-                "author" => "Carol Green and John Doe and Alice Brown",
-                "title" => "Advanced Testing Techniques",
-                "school" => "University of Testing",
-                "year" => "2017",
-                "type" => "PhD Thesis",
-                "address" => "San Francisco",
-                "month" => "Dec",
-                "note" => "A groundbreaking thesis"
-            ],
-            [
-                "entry_type" => "proceedings",
-                "citekey" => "Proceedings2021",
-                "title" => "Proceedings of the 2021 Testing Symposium",
-                "year" => "2021",
-                "editor" => "Michael Johnson and Alice White",
-                "volume" => "7",
-                "series" => "Symposium Series",
-                "address" => "Chicago, USA",
-                "month" => "Nov",
-                "organization" => "Testing Society",
-                "publisher" => "Symposium Publishers",
-                "note" => "A significant symposium"
-            ],
-            [
-                "entry_type" => "techreport",
-                "citekey" => "Gray2015",
-                "author" => "Eve Gray and Bob Smith and Carol Green",
-                "title" => "Testing Report 2015",
-                "institution" => "Testing Institute",
-                "year" => "2015",
-                "type" => "Technical Report",
-                "number" => "TR-2015-01",
-                "address" => "Chicago",
-                "month" => "Jan",
-                "note" => "A detailed technical report"
-            ],
-            [
-                "entry_type" => "unpublished",
-                "citekey" => "Unpublished2023",
-                "author" => "Frank Unpublished and Emily Editor and David Black",
-                "title" => "Unpublished Testing Research",
-                "note" => "Manuscript in preparation",
-                "month" => "Feb",
-                "year" => "2023"
-            ]
-            ]);
-    }
-
-    #[TestDox('POST /api/v1/bibliography/import (with invalid data)')]
-    public function testInvalidImport() {
-        $name = 'import_wrong_structure.bib';
-        $path = storage_path() . "/framework/testing/$name";
-        $file = new UploadedFile($path, $name, 'application/x-bibtex', null, true);
-
-        $response = $this->userRequest()
-            ->post('/api/v1/bibliography/import', [
-                'file' => $file
-            ]);
-
-        $this->assertStatus($response, 400);
-        $response->assertSimilarJson([
-            'error' => "Unexpected character '\\0' at line 10 column 1"
-        ]);
-    }
-
-    #[TestDox('POST /api/v1/bibliography/export')]
-    public function testExport() {
-        $response = $this->userRequest()
-                ->post('/api/v1/bibliography/export');
-
-        $this->assertStatus($response, 200);
-        $this->assertTrue($response->headers->get('content-type') == 'application/x-bibtex');
-        $this->assertTrue($response->headers->get('content-disposition') == 'attachment; filename=export.bib');
-        $content = $response->streamedContent();
-        $expectedContent = file_get_contents(storage_path() . "/framework/testing/demo.bib");
-        $this->assertSame($expectedContent, $content);
-    }
-
-    public function getUpdateData() {
+    $response->assertJson(array_map(function($e) {
         return [
-            'entry_type'        => 'book',
-            'author'            => 'Köppke, Dietmar and Sauer, Jürgen',
-            'editor'            => 'King, Robert and Smith, John',
-            'title'             => 'Patched Title',
-            'journal'           => 'Patched Journal',
-            'year'              => 'Patched Year',
-            'pages'             => 'Patched Pages',
-            'volume'            => 'Patched Volume',
-            'number'            => 'Patched Number',
-            'booktitle'         => 'Patched Booktitle',
-            'publisher'         => 'Patched Publisher',
-            'address'           => 'Patched Address',
-            'misc'              => 'Patched Misc',
-            'howpublished'      => 'Patched Howpublished',
-            'annote'            => 'Patched Annote',
-            'chapter'           => 'Patched Chapter',
-            'crossref'          => 'Patched Crossref',
-            'edition'           => 'Patched Edition',
-            'institution'       => 'Patched Institution',
-            'key'               => 'Patched Key',
-            'month'             => 'Patched Month',
-            'note'              => 'Patched Note',
-            'organization'      => 'Patched Organization',
-            'school'            => 'Patched School',
-            'series'            => 'Patched Series',
-            'type'              => 'Patched Type',
-            'abstract'          => 'Patched Abstract',
-            'doi'               => 'Patched Doi',
-            'isbn'              => 'Patched Isbn',
-            'issn'              => 'Patched Issn',
-            'language'          => 'Patched Language',
+            "entry" => $e,
+            "added" => true
         ];
-    }
+    }, $results));
 
+    $cnt = Bibliography::count();
+    expect($cnt)->toEqual(22);
 
-    /*
-     * TODO: We are not simply updating all table cells according to
-     *       the passed data but instead sanatizing the data and
-     *       only updating the fields that fit the entry_type.
-     *       All other fields are set to NULL. This is at the time of writing the
-     *       desired behavior. We therefore need to test every entry type.
-     *       This is not yet implemented.
-     *
-     *      [SO/VR]
-     */
-
-     #[TestDox('POST /api/v1/bibliography/{id}')]
-    public function testPatchItem() {
-        $data = $this->getUpdateData();
+    $i = 0;
+    foreach($results as $r) {
+        $addedItem = $inserted[$i++];
+        // Note: I don't like the reliance on the $addedItem["entry"]["id"] here.
+        //       But Postgres does not rollback the sequence when a transaction is rolled back.
+        //       Therefore all alternative also seem to be more complex than this.
         $response = $this->userRequest()
-            ->post('/api/v1/bibliography/1320', $data);
+            ->get('/api/v1/bibliography/'. $addedItem["entry"]["id"]);
 
         $this->assertStatus($response, 200);
-        $response->assertJsonStructure([
-            'id',
-            'type',
-            'citekey',
-            'title',
-            'author',
-            'editor',
-            'journal',
-            'year',
-            'pages',
-            'volume',
-            'number',
-            'booktitle',
-            'publisher',
-            'address',
-            'misc',
-            'howpublished',
-            'annote',
-            'chapter',
-            'crossref',
-            'edition',
-            'institution',
-            'key',
-            'month',
-            'note',
-            'organization',
-            'school',
-            'series',
-            'user_id',
-            'created_at',
-            'updated_at'
-        ]);
-        $response->assertJson(array_merge($data, [
-          // Set all non-book fields to NULL
-            'annote'            => null,
-            'booktitle'         => null,
-            'chapter'           => null,
-            'crossref'          => null,
-            'howpublished'      => null,
-            'institution'       => null,
-            'issn'              => null,
-            'journal'           => null,
-            'key'               => null,
-            'misc'              => null,
-            'number'            => null,
-            'organization'      => null,
-            'pages'             => null,
-            'school'            => null,
-            'type'              => null,
-            'volume'            => null,
-        ]));
-     }
-
-     #[TestDox('DELETE /api/v1/bibliography/{id}')]
-     public function testDelete() {
-        $bib = Bibliography::latest()->first();
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/bibliography/'.$bib->id);
-
-        $this->assertStatus($response, 204);
-        $cnt = Bibliography::count();
-        $this->assertEquals(5, $cnt);
-        $this->assertEquals("", $response->getContent());
-    }
-
-    /// TODO: Add tests for the following endpoints:
-    // - DELETE /{id}/file
-    // - UPLOAD file in all requests
-
-    #[DataProvider('permissions')]
-    public function testWithoutPermission($permission) {
-        (new ResponseTester($this))->testMissingPermission($permission);
-    }
-
-    #[DataProvider('exceptionPermissions')]
-    public function testSucceedWithPermission($permission) {
-        (new ResponseTester($this))->testExceptions($permission);
-    }
-
-    // TODO: We should test the success of each endpoint by using a user that has only the single required permission. [SO]
-    public static function permissions() {
-        return [
-            'permission to add item'    => Permission::for("post", '/api/v1/bibliography' ,'You do not have the permission to add new bibliography'),
-            'permission to update item' => Permission::for("post", '/api/v1/bibliography/9000', 'You do not have the permission to edit existing bibliography'),
-            'permission to delete item' => Permission::for("delete", '/api/v1/bibliography/9000', 'You do not have the permission to remove bibliography entries'),
-            'permission to import item' => Permission::for("post", '/api/v1/bibliography/import', 'You do not have the permission to add new/modify existing bibliography items'),
-        ];
-    }
-
-    public static function exceptionPermissions() {
-        return [
-            "missing ref count" => Permission::for("get", '/api/v1/bibliography/99/ref_count', 'This bibliography item does not exist'),
-            "update missing item" => Permission::for("post", '/api/v1/bibliography/99', 'This bibliography item does not exist'),
-            "delete missing item" => Permission::for("delete", '/api/v1/bibliography/99', 'This bibliography item does not exist'),
-        ];
+        $response->assertJsonStructure(getBibliographyStructure());
+        $response->assertJson($r);
     }
 }
+
+test('mandatory import', function () {
+    importTest('import_mandatory.bib', [
+        [
+            "entry_type" => "article",
+            "citekey" => "Smith2021",
+            "author" => "John Smith and Jane Doe and Alice Brown",
+            "title" => "A Comprehensive Study on Testing",
+            "journal" => "Journal of Testing",
+            "year" => "2021"
+        ],
+        [
+            "entry_type" => "book",
+            "citekey" => "Doe2020",
+            "author" => "Jane Doe and John Smith and Carol Green",
+            "title" => "The Art of Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2020"
+        ],
+        [
+            "entry_type" => "book",
+            "citekey" => "EditorBook2022",
+            "editor" => "Emily Editor and David Black and Eve Gray",
+            "title" => "Edited Volume on Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2022"
+        ],
+        [
+            "entry_type" => "booklet",
+            "citekey" => "Booklet2022",
+            "title" => "Testing Booklet"
+        ],
+        [
+            "entry_type" => "conference",
+            "citekey" => "White2018",
+            "author" => "Bob White and Carol Green and David Black",
+            "title" => "Conference on Testing Methods",
+            "booktitle" => "Annual Testing Conference",
+            "year" => "2018"
+        ],
+        [
+            "entry_type" => "inbook",
+            "citekey" => "Taylor2023",
+            "author" => "Laura Taylor and John Smith and Emily Brown",
+            "title" => "In-depth Testing Techniques",
+            "chapter" => "5",
+            "pages" => "123-145",
+            "publisher" => "Advanced Testing Publishers",
+            "year" => "2023"
+        ],
+        [
+            "entry_type" => "inbook",
+            "citekey" => "EditorInBook2023",
+            "editor" => "Nancy Editor and Alice White and Bob Smith",
+            "title" => "Advanced Testing Strategies",
+            "chapter" => "7",
+            "pages" => "200-220",
+            "publisher" => "Expert Testing Publishers",
+            "year" => "2023"
+        ],
+        [
+            "entry_type" => "incollection",
+            "citekey" => "Johnson2022",
+            "author" => "Michael Johnson and Alice White and Bob Smith",
+            "title" => "Chapter on Testing",
+            "booktitle" => "Handbook of Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2022"
+        ],
+        [
+            "entry_type" => "inproceedings",
+            "citekey" => "Brown2019",
+            "author" => "Alice Brown and David Green and Eve Gray",
+            "title" => "Proceedings of the Testing Conference",
+            "booktitle" => "International Conference on Testing",
+            "year" => "2019"
+        ],
+        [
+            "entry_type" => "manual",
+            "citekey" => "Manual2014",
+            "title" => "Testing Manual"
+        ],
+        [
+            "entry_type" => "mastersthesis",
+            "citekey" => "Black2016",
+            "author" => "David Black and Jane White and Bob Smith",
+            "title" => "Testing in Software Engineering",
+            "school" => "Institute of Testing",
+            "year" => "2016"
+        ],
+        [
+            "entry_type" => "misc",
+            "citekey" => "Misc2013",
+            "note" => "Misc has no mandatory fields"
+        ],
+        [
+            "entry_type" => "phdthesis",
+            "citekey" => "Green2017",
+            "author" => "Carol Green and John Doe and Alice Brown",
+            "title" => "Advanced Testing Techniques",
+            "school" => "University of Testing",
+            "year" => "2017"
+        ],
+        [
+            "entry_type" => "proceedings",
+            "citekey" => "Proceedings2021",
+            "title" => "Proceedings of the 2021 Testing Symposium",
+            "year" => "2021"
+        ],
+        [
+            "entry_type" => "techreport",
+            "citekey" => "Gray2015",
+            "author" => "Eve Gray and Bob Smith and Carol Green",
+            "title" => "Testing Report 2015",
+            "institution" => "Testing Institute",
+            "year" => "2015"
+        ],
+        [
+            "entry_type" => "unpublished",
+            "citekey" => "Unpublished2023",
+            "author" => "Frank Unpublished and Emily Editor and David Black",
+            "title" => "Unpublished Testing Research",
+            "note" => "Manuscript in preparation"
+        ]
+        ]);
+});
+
+test('optional import', function () {
+    importTest("import_optional.bib", [
+        [
+            "entry_type" => "article",
+            "citekey" => "Smith2021",
+            "author" => "John Smith and Jane Doe and Alice Brown",
+            "title" => "A Comprehensive Study on Testing",
+            "journal" => "Journal of Testing",
+            "year" => "2021",
+            "volume" => "3",
+            "number" => "2",
+            "month" => "Apr",
+            "note" => "A significant piece of work"
+        ],
+        [
+            "entry_type" => "book",
+            "citekey" => "Doe2020",
+            "author" => "Jane Doe and John Smith and Carol Green",
+            "title" => "The Art of Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2020",
+            "series" => "In-depth Series",
+            "address" => "Boston",
+            "edition" => "Third",
+            "month" => "May",
+            "note" => "Great book"
+        ],
+        [
+            "entry_type" => "book",
+            "citekey" => "EditorBook2022",
+            "editor" => "Emily Editor and David Black and Eve Gray",
+            "title" => "Edited Volume on Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2022",
+            "series" => "Edited Series",
+            "address" => "New York",
+            "month" => "Oct",
+            "note" => "Edited volume"
+        ],
+        [
+            "entry_type" => "booklet",
+            "citekey" => "Booklet2022",
+            "title" => "Testing Booklet",
+            "author" => "Richard Roe",
+            "howpublished" => "Website",
+            "address" => "Heidelberg, Germany",
+            "month" => "Jun",
+            "year" => "2022",
+            "note" => "A booklet on testing"
+        ],
+        [
+            "entry_type" => "conference",
+            "citekey" => "White2018",
+            "author" => "Bob White and Carol Green and David Black",
+            "title" => "Conference on Testing Methods",
+            "booktitle" => "Annual Testing Conference",
+            "year" => "2018",
+            "volume" => "6",
+            "series" => "Workshop Series",
+            "pages" => "100-120",
+            "address" => "London, UK",
+            "month" => "Dec",
+            "organization" => "Testing Society",
+            "publisher" => "Testing Publishers",
+            "note" => "Conference paper"
+        ],
+        [
+            "entry_type" => "inbook",
+            "citekey" => "Taylor2023",
+            "author" => "Laura Taylor and John Smith and Emily Brown",
+            "title" => "In-depth Testing Techniques",
+            "chapter" => "5",
+            "pages" => "123-145",
+            "publisher" => "Advanced Testing Publishers",
+            "year" => "2023",
+            "volume" => "4",
+            "series" => "In-depth Series",
+            "type" => "Technical",
+            "address" => "Boston",
+            "edition" => "3rd",
+            "month" => "Jun",
+            "note" => "A detailed chapter"
+        ],
+        [
+            "entry_type" => "inbook",
+            "citekey" => "EditorInBook2023",
+            "author" => "Nancy Editor and Alice White and Bob Smith",
+            "title" => "Advanced Testing Strategies",
+            "chapter" => "7",
+            "pages" => "200-220",
+            "publisher" => "Expert Testing Publishers",
+            "year" => "2023",
+            "volume" => "5",
+            "series" => "Strategies Series",
+            "type" => "Research",
+            "address" => "Seattle",
+            "edition" => "First",
+            "month" => "Jul",
+            "note" => "An insightful chapter"
+        ],
+        [
+            "entry_type" => "incollection",
+            "citekey" => "Johnson2022",
+            "author" => "Michael Johnson and Alice White and Bob Smith",
+            "title" => "Chapter on Testing",
+            "booktitle" => "Handbook of Testing",
+            "publisher" => "Testing Publishers",
+            "year" => "2022",
+            "editor" => "Nancy Editor",
+            "volume" => "3",
+            "series" => "Testing Handbook Series",
+            "type" => "Research",
+            "chapter" => "10",
+            "pages" => "150-170",
+            "address" => "Atlanta",
+            "edition" => "Fourth",
+            "month" => "Mar",
+            "note" => "A key chapter"
+        ],
+        [
+            "entry_type" => "inproceedings",
+            "citekey" => "Brown2019",
+            "author" => "Alice Brown and David Green and Eve Gray",
+            "title" => "Proceedings of the Testing Conference",
+            "booktitle" => "International Conference on Testing",
+            "year" => "2019",
+            "editor" => "Michael Johnson",
+            "volume" => "6",
+            "series" => "Conference Proceedings",
+            "pages" => "300-320",
+            "address" => "New York",
+            "month" => "Aug",
+            "organization" => "Testing Society",
+            "publisher" => "Proceedings Publishers",
+            "note" => "A notable conference paper"
+        ],
+        [
+            "entry_type" => "manual",
+            "citekey" => "Manual2014",
+            "title" => "Testing Manual",
+            "author" => "John Smith",
+            "organization" => "Testing Organization",
+            "address" => "Los Angeles",
+            "edition" => "1st",
+            "month" => "Sep",
+            "year" => "2014",
+            "note" => "A comprehensive manual"
+        ],
+        [
+            "entry_type" => "mastersthesis",
+            "citekey" => "Black2016",
+            "author" => "David Black and Jane White and Bob Smith",
+            "title" => "Testing in Software Engineering",
+            "school" => "Institute of Testing",
+            "year" => "2016",
+            "type" => "Master's Thesis",
+            "address" => "Boston",
+            "month" => "Oct",
+            "note" => "A significant thesis"
+        ],
+        [
+            "entry_type" => "misc",
+            "citekey" => "Misc2013",
+            "title" => "Miscellaneous Testing",
+            "author" => "John Doe",
+            "howpublished" => "Unpublished",
+            "month" => "Nov",
+            "year" => "2013",
+            "note" => "Misc has no mandatory fields"
+        ],
+        [
+            "entry_type" => "phdthesis",
+            "citekey" => "Green2017",
+            "author" => "Carol Green and John Doe and Alice Brown",
+            "title" => "Advanced Testing Techniques",
+            "school" => "University of Testing",
+            "year" => "2017",
+            "type" => "PhD Thesis",
+            "address" => "San Francisco",
+            "month" => "Dec",
+            "note" => "A groundbreaking thesis"
+        ],
+        [
+            "entry_type" => "proceedings",
+            "citekey" => "Proceedings2021",
+            "title" => "Proceedings of the 2021 Testing Symposium",
+            "year" => "2021",
+            "editor" => "Michael Johnson and Alice White",
+            "volume" => "7",
+            "series" => "Symposium Series",
+            "address" => "Chicago, USA",
+            "month" => "Nov",
+            "organization" => "Testing Society",
+            "publisher" => "Symposium Publishers",
+            "note" => "A significant symposium"
+        ],
+        [
+            "entry_type" => "techreport",
+            "citekey" => "Gray2015",
+            "author" => "Eve Gray and Bob Smith and Carol Green",
+            "title" => "Testing Report 2015",
+            "institution" => "Testing Institute",
+            "year" => "2015",
+            "type" => "Technical Report",
+            "number" => "TR-2015-01",
+            "address" => "Chicago",
+            "month" => "Jan",
+            "note" => "A detailed technical report"
+        ],
+        [
+            "entry_type" => "unpublished",
+            "citekey" => "Unpublished2023",
+            "author" => "Frank Unpublished and Emily Editor and David Black",
+            "title" => "Unpublished Testing Research",
+            "note" => "Manuscript in preparation",
+            "month" => "Feb",
+            "year" => "2023"
+        ]
+        ]);
+});
+
+test('invalid import', function () {
+    $name = 'import_wrong_structure.bib';
+    $path = storage_path() . "/framework/testing/$name";
+    $file = new UploadedFile($path, $name, 'application/x-bibtex', null, true);
+
+    $response = $this->userRequest()
+        ->post('/api/v1/bibliography/import', [
+            'file' => $file
+        ]);
+
+    $this->assertStatus($response, 400);
+    $response->assertSimilarJson([
+        'error' => "Unexpected character '\\0' at line 10 column 1"
+    ]);
+});
+
+test('export', function () {
+    $response = $this->userRequest()
+            ->post('/api/v1/bibliography/export');
+
+    $this->assertStatus($response, 200);
+    expect($response->headers->get('content-type') == 'application/x-bibtex')->toBeTrue();
+    expect($response->headers->get('content-disposition') == 'attachment; filename=export.bib')->toBeTrue();
+    $content = $response->streamedContent();
+    $expectedContent = file_get_contents(storage_path() . "/framework/testing/demo.bib");
+    expect($content)->toBe($expectedContent);
+});
+
+function getUpdateData()
+{
+    return [
+        'entry_type'        => 'book',
+        'author'            => 'Köppke, Dietmar and Sauer, Jürgen',
+        'editor'            => 'King, Robert and Smith, John',
+        'title'             => 'Patched Title',
+        'journal'           => 'Patched Journal',
+        'year'              => 'Patched Year',
+        'pages'             => 'Patched Pages',
+        'volume'            => 'Patched Volume',
+        'number'            => 'Patched Number',
+        'booktitle'         => 'Patched Booktitle',
+        'publisher'         => 'Patched Publisher',
+        'address'           => 'Patched Address',
+        'misc'              => 'Patched Misc',
+        'howpublished'      => 'Patched Howpublished',
+        'annote'            => 'Patched Annote',
+        'chapter'           => 'Patched Chapter',
+        'crossref'          => 'Patched Crossref',
+        'edition'           => 'Patched Edition',
+        'institution'       => 'Patched Institution',
+        'key'               => 'Patched Key',
+        'month'             => 'Patched Month',
+        'note'              => 'Patched Note',
+        'organization'      => 'Patched Organization',
+        'school'            => 'Patched School',
+        'series'            => 'Patched Series',
+        'type'              => 'Patched Type',
+        'abstract'          => 'Patched Abstract',
+        'doi'               => 'Patched Doi',
+        'isbn'              => 'Patched Isbn',
+        'issn'              => 'Patched Issn',
+        'language'          => 'Patched Language',
+    ];
+}
+
+test('patch item', function () {
+    $data = getUpdateData();
+    $response = $this->userRequest()
+        ->post('/api/v1/bibliography/1320', $data);
+
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure([
+        'id',
+        'type',
+        'citekey',
+        'title',
+        'author',
+        'editor',
+        'journal',
+        'year',
+        'pages',
+        'volume',
+        'number',
+        'booktitle',
+        'publisher',
+        'address',
+        'misc',
+        'howpublished',
+        'annote',
+        'chapter',
+        'crossref',
+        'edition',
+        'institution',
+        'key',
+        'month',
+        'note',
+        'organization',
+        'school',
+        'series',
+        'user_id',
+        'created_at',
+        'updated_at'
+    ]);
+    $response->assertJson(array_merge($data, [
+      // Set all non-book fields to NULL
+        'annote'            => null,
+        'booktitle'         => null,
+        'chapter'           => null,
+        'crossref'          => null,
+        'howpublished'      => null,
+        'institution'       => null,
+        'issn'              => null,
+        'journal'           => null,
+        'key'               => null,
+        'misc'              => null,
+        'number'            => null,
+        'organization'      => null,
+        'pages'             => null,
+        'school'            => null,
+        'type'              => null,
+        'volume'            => null,
+    ]));
+});
+
+test('delete', function () {
+    $bib = Bibliography::latest()->first();
+
+    $response = $this->userRequest()
+        ->delete('/api/v1/bibliography/'.$bib->id);
+
+    $this->assertStatus($response, 204);
+    $cnt = Bibliography::count();
+    expect($cnt)->toEqual(5);
+    expect($response->getContent())->toEqual("");
+});
+
+test('without permission', function ($permission) {
+    (new ResponseTester($this))->testMissingPermission($permission);
+})->with('permissions');
+
+test('succeed with permission', function ($permission) {
+    (new ResponseTester($this))->testExceptions($permission);
+})->with('exceptionPermissions');
+
+// TODO: We should test the success of each endpoint by using a user that has only the single required permission. [SO]
+dataset('permissions', function () {
+    return [
+        'permission to add item'    => Permission::for("post", '/api/v1/bibliography' ,'You do not have the permission to add new bibliography'),
+        'permission to update item' => Permission::for("post", '/api/v1/bibliography/9000', 'You do not have the permission to edit existing bibliography'),
+        'permission to delete item' => Permission::for("delete", '/api/v1/bibliography/9000', 'You do not have the permission to remove bibliography entries'),
+        'permission to import item' => Permission::for("post", '/api/v1/bibliography/import', 'You do not have the permission to add new/modify existing bibliography items'),
+    ];
+});
+
+dataset('exceptionPermissions', function () {
+    return [
+        "missing ref count" => Permission::for("get", '/api/v1/bibliography/99/ref_count', 'This bibliography item does not exist'),
+        "update missing item" => Permission::for("post", '/api/v1/bibliography/99', 'This bibliography item does not exist'),
+        "delete missing item" => Permission::for("delete", '/api/v1/bibliography/99', 'This bibliography item does not exist'),
+    ];
+});

--- a/tests/Feature/ApiCommentTest.php
+++ b/tests/Feature/ApiCommentTest.php
@@ -4,8 +4,7 @@ use App\Comment;
 use Carbon\Carbon;
 use Tests\Permission;
 use Tests\ResponseTester;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
+
 
 
 test('get comments', function ($url, $result) {
@@ -244,17 +243,31 @@ test('unprocessable', function ($permission, $errors) {
 })->with('unprocessable');
 
 dataset('permissions', function () {
+    $testComment = [
+        'content' => 'Test comment content',
+        'resource_type' => 'entity',
+        'resource_id' => 1,
+        'metadata' => [],
+    ];
+    
     return [
         "GET    /api/v1/comment/resource/1?r=entity"                    => Permission::for("get",   "/api/v1/comment/resource/1?r=entity",                  "You do not have the permission to get comments"),
         "GET    /api/v1/comment/resource/8?r=attribute_value&aid=5"     => Permission::for("get",   "/api/v1/comment/resource/8?r=attribute_value&aid=5",   "You do not have the permission to get comments"),
-        "POST   /api/v1/comment"                                        => Permission::for("post",  "/api/v1/comment",                                      "You do not have the permission to add comments", self::$testComment),
-        "PATCH  /api/v1/comment/1"                                      => Permission::for("patch", "/api/v1/comment/1",                                    "You do not have the permission to edit a comment", self::$testComment),
+        "POST   /api/v1/comment"                                        => Permission::for("post",  "/api/v1/comment",                                      "You do not have the permission to add comments", $testComment),
+        "PATCH  /api/v1/comment/1"                                      => Permission::for("patch", "/api/v1/comment/1",                                    "You do not have the permission to edit a comment", $testComment),
         "DELETE /api/v1/comment/1"                                      => Permission::for("delete","/api/v1/comment/1",                                      "You do not have the permission to delete a comment"),
     ];
 });
 
 //TODO:: Test certainties
 dataset('exceptions', function () {
+    $testComment = [
+        'content' => 'Test comment content',
+        'resource_type' => 'entity',
+        'resource_id' => 1,
+        'metadata' => [],
+    ];
+    
     return [
         "GET    /api/v1/comment/resource/99?r=entity -> invalid entity"                         => Permission::for("get",   "/api/v1/comment/resource/99?r=entity",                     "This entity does not exist"),
         "GET    /api/v1/comment/resource/99?r=attribute_value&aid=5 -> invalid entity"          => Permission::for("get",   "/api/v1/comment/resource/99?r=attribute_value&aid=5",      "This attribute value does not exist"),
@@ -263,9 +276,9 @@ dataset('exceptions', function () {
          // DISCUSS: I would expect a comment to fail if it is empty. But due to the nature of
         //          the comments being intertwined with the certainty system, this is currently not possible.
         // "POST   /api/v1/comment -> empty content"                                               => Permission::for("post",  "/api/v1/comment",                                          "The resource_id field is required.", ['content' => '', 'resource_id' => 1, 'resource_type' => 'entity']),
-        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
-        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
-        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", $testComment),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", $testComment),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", $testComment),
         "DELETE /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("delete","/api/v1/comment/99",                                       "This comment does not exist"),
     ];
 });

--- a/tests/Feature/ApiCommentTest.php
+++ b/tests/Feature/ApiCommentTest.php
@@ -1,327 +1,279 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Comment;
-use Tests\TestCase;
-
 use Carbon\Carbon;
-use Exception;
 use Tests\Permission;
 use Tests\ResponseTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiCommentTest extends TestCase
-{
 
-    // ==========================================
-    //              [[ GET ]]
-    // ==========================================
+test('get comments', function ($url, $result) {
+    $response = $this->userRequest()
+        ->get("/api/v1/comment/$url");
 
-    #[DataProvider('getProvider')]
-    #[TestDox('GET    /api/v1/comment/resource/{id} - Get comments')]
-    public function testGetComments($url, $result) {
-        $response = $this->userRequest()
-            ->get("/api/v1/comment/$url");
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(count($result));
+    $response->assertJson($result);
+})->with('getProvider');
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(count($result));
-        $response->assertJson($result);
-    }
-
-    public static function getProvider() {
-        return [
-            "Entity" => [
-                "resource/1?r=entity", [
-                    [
-                        "user_id" => 1,
-                        "content" => "(1) This is a comment on an entity by user admin without any mentions."
-                    ],[
-                        "user_id" => 2,
-                        "reply_to" => 1,
-                        "content" => "(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention."
-                    ],[
-                        "user_id" => 2,
-                        "content" => "(3) This is a regular post of John Doe (2) on the same entity."
-                    ]
-                ]
-            ],
-            "Attribute Value" => [
-                "resource/1?r=attribute_value&aid=15",
+dataset('getProvider', function () {
+    return [
+        "Entity" => [
+            "resource/1?r=entity", [
                 [
-                    [
-                        "user_id" => 2,
-                        "reply_to" => NULL,
-                        'content' => '(4) This is John Doe on attribute value (1)',
-                        'created_at' => '2017-12-20T09:53:35.000000Z',
-                        'updated_at' => '2017-12-20T09:53:35.000000Z',
-                    ],[
-                        "user_id" => 1,
-                        "reply_to" => 4,
-                        'content' => '(5) This is admin (1) replying to John Doe (2) on attribute value (1)',
-                        'created_at' => '2017-12-20T09:53:35.000000Z',
-                        'updated_at' => '2017-12-20T09:53:35.000000Z',
-                    ],[
-                        "user_id" => 1,
-                        "reply_to" => NULL,
-                        'content' => '(6) This is admin (1) on attribute value (1)',
-                        'created_at' => '2017-12-20T09:53:35.000000Z',
-                        'updated_at' => '2017-12-20T09:53:35.000000Z',
-                    ]
-                ]
-            ],
-            "Replies" => [
-                "1/reply",
-                [
-                    [
-                        'content' => '(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention.',
-                    ]
+                    "user_id" => 1,
+                    "content" => "(1) This is a comment on an entity by user admin without any mentions."
+                ],[
+                    "user_id" => 2,
+                    "reply_to" => 1,
+                    "content" => "(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention."
+                ],[
+                    "user_id" => 2,
+                    "content" => "(3) This is a regular post of John Doe (2) on the same entity."
                 ]
             ]
-        ];
-    }
-
-    // ==========================================
-    //              [[ POST ]]
-    // ==========================================
-
-    #[DataProvider('postProvider')]
-    #[TestDox('POST   /api/v1/comment - Post request')]
-    public function testAddComment($url, $input, $result) {
-        $response = $this->userRequest()
-            ->post("/api/v1/comment", $input);
-
-        $this->assertStatus($response, 201);
-        $getResponse = $this->userRequest()
-            ->get("/api/v1/comment/resource/$url");
-
-        $this->assertStatus($getResponse, 200);
-        $content = json_decode($getResponse->getContent());
-        $getResponse->assertJson($result);
-    }
-
-    public static function postProvider() {
-        return [
-            "Attribute Comment" => [
-                "8?r=attribute_value&aid=5",
+        ],
+        "Attribute Value" => [
+            "resource/1?r=attribute_value&aid=15",
+            [
                 [
-                    'content' => 'This is an attribute_value',
-                    'resource_type' => 'attribute_value',
-                    'resource_id' => 73,
-                    'metadata' => [],
+                    "user_id" => 2,
+                    "reply_to" => NULL,
+                    'content' => '(4) This is John Doe on attribute value (1)',
+                    'created_at' => '2017-12-20T09:53:35.000000Z',
+                    'updated_at' => '2017-12-20T09:53:35.000000Z',
                 ],[
-                    ['content' => 'This is an attribute_value'],
+                    "user_id" => 1,
+                    "reply_to" => 4,
+                    'content' => '(5) This is admin (1) replying to John Doe (2) on attribute value (1)',
+                    'created_at' => '2017-12-20T09:53:35.000000Z',
+                    'updated_at' => '2017-12-20T09:53:35.000000Z',
+                ],[
+                    "user_id" => 1,
+                    "reply_to" => NULL,
+                    'content' => '(6) This is admin (1) on attribute value (1)',
+                    'created_at' => '2017-12-20T09:53:35.000000Z',
+                    'updated_at' => '2017-12-20T09:53:35.000000Z',
                 ]
-                ],
-            "Entity Comment" => [
-                "2?r=entity",
+            ]
+        ],
+        "Replies" => [
+            "1/reply",
+            [
                 [
-                    'content' => 'This is an entitiy',
-                    'resource_type' => 'entity',
-                    'resource_id' => 2,
-                    'metadata' => [],
-                ],[
-                    ['content' => 'This is an entitiy'],
+                    'content' => '(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention.',
                 ]
+            ]
+        ]
+    ];
+});
+
+test('add comment', function ($url, $input, $result) {
+    $response = $this->userRequest()
+        ->post("/api/v1/comment", $input);
+
+    $this->assertStatus($response, 201);
+    $getResponse = $this->userRequest()
+        ->get("/api/v1/comment/resource/$url");
+
+    $this->assertStatus($getResponse, 200);
+    $content = json_decode($getResponse->getContent());
+    $getResponse->assertJson($result);
+})->with('postProvider');
+
+dataset('postProvider', function () {
+    return [
+        "Attribute Comment" => [
+            "8?r=attribute_value&aid=5",
+            [
+                'content' => 'This is an attribute_value',
+                'resource_type' => 'attribute_value',
+                'resource_id' => 73,
+                'metadata' => [],
+            ],[
+                ['content' => 'This is an attribute_value'],
+            ]
             ],
-            "Attribute Comment With Certainty Change" => [
-                "8?r=attribute_value&aid=5",
+        "Entity Comment" => [
+            "2?r=entity",
+            [
+                'content' => 'This is an entitiy',
+                'resource_type' => 'entity',
+                'resource_id' => 2,
+                'metadata' => [],
+            ],[
+                ['content' => 'This is an entitiy'],
+            ]
+        ],
+        "Attribute Comment With Certainty Change" => [
+            "8?r=attribute_value&aid=5",
+            [
+                'content' => 'This is an attribute_value',
+                'resource_type' => 'attribute_value',
+                'resource_id' => 73,
+                'metadata' => [
+                    "certainty_from" => 100,
+                    "certainty_to"   => 37
+                ],
+            ],[
                 [
                     'content' => 'This is an attribute_value',
-                    'resource_type' => 'attribute_value',
-                    'resource_id' => 73,
                     'metadata' => [
-                        "certainty_from" => 100,
-                        "certainty_to"   => 37
-                    ],
-                ],[
-                    [
-                        'content' => 'This is an attribute_value',
-                        'metadata' => [
-                            'certainty_to' => 37,
-                            'certainty_from' => 100,
-                        ]
-                    ],
-                ]
-            ],
-            // "Reply To Comment" => [
-            //     "1?r=entity",
-            //     [
-            //         'content' => 'This is an entitiy',
-            //         'resource_type' => 'entity',
-            //         'resource_id' => 1,
-            //         'metadata' => [],
-            //         'reply_to' => 2
-            //     ],[
-            //         ['content' => '(1) This is a comment on an entity by user admin without any mentions.'],
-            //         ['content' => '(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention.'],
-            //         ['content' => '(3) This is a regular post of John Doe (2) on the same entity.'],
-            //         [
-            //             'content' => 'This is an entitiy',
-            //             "reply_to" => 2,
-            //         ],
-            //     ]
-            // ]
-        ];
+                        'certainty_to' => 37,
+                        'certainty_from' => 100,
+                    ]
+                ],
+            ]
+        ],
+        // "Reply To Comment" => [
+        //     "1?r=entity",
+        //     [
+        //         'content' => 'This is an entitiy',
+        //         'resource_type' => 'entity',
+        //         'resource_id' => 1,
+        //         'metadata' => [],
+        //         'reply_to' => 2
+        //     ],[
+        //         ['content' => '(1) This is a comment on an entity by user admin without any mentions.'],
+        //         ['content' => '(2) This is a reply from John Doe (2) to the previous comment (1) of the @admin with a mention.'],
+        //         ['content' => '(3) This is a regular post of John Doe (2) on the same entity.'],
+        //         [
+        //             'content' => 'This is an entitiy',
+        //             "reply_to" => 2,
+        //         ],
+        //     ]
+        // ]
+    ];
+});
+
+test('edit comment', function ($id, $url, $input, $result) {
+    $response = $this->userRequest()
+        ->patch("/api/v1/comment/$id", $input);
+
+    $this->assertStatus($response, 200);
+    $getResponse = $this->userRequest()
+        ->get("/api/v1/comment/resource/$url");
+
+    $this->assertStatus($getResponse, 200);
+    $content = json_decode($getResponse->getContent());
+    $getResponse->assertJson($result);
+
+    /**
+     * As the target comment is not always the first element in the array
+     * we need to find the index of the target comment in the array
+     * the requirement for this is, that every item has a created_at
+     * set otherwise this will fail.
+     */
+    $idx = 0;
+    while(!isset($result[$idx]["created_at"])) {
+        $idx ++;
+        if($idx > 10) throw new Exception("Out Of Range");
     }
 
-    // ==========================================
-    //              [[ PATCH ]]
-    // ==========================================
+    $updatedAt = Carbon::parse($content[$idx]->updated_at);
+    expect($updatedAt->diffInSeconds(Carbon::now()) < 5)->toBeTrue("The 'updated_at' value is not withing 5s of the current time");
+})->with('patchProvider');
 
-    #[DataProvider('patchProvider')]
-    #[TestDox('PATCH  /api/v1/comment - Patch request')]
-    public function testEditComment($id, $url, $input, $result) {
-        $response = $this->userRequest()
-            ->patch("/api/v1/comment/$id", $input);
-
-        $this->assertStatus($response, 200);
-        $getResponse = $this->userRequest()
-            ->get("/api/v1/comment/resource/$url");
-
-        $this->assertStatus($getResponse, 200);
-        $content = json_decode($getResponse->getContent());
-        $getResponse->assertJson($result);
-
-        /**
-         * As the target comment is not always the first element in the array
-         * we need to find the index of the target comment in the array
-         * the requirement for this is, that every item has a created_at
-         * set otherwise this will fail.
-         */
-        $idx = 0;
-        while(!isset($result[$idx]["created_at"])) {
-            $idx ++;
-            if($idx > 10) throw new Exception("Out Of Range");
-        }
-
-        $updatedAt = Carbon::parse($content[$idx]->updated_at);
-        $this->assertTrue(
-            $updatedAt->diffInSeconds(Carbon::now()) < 5,
-            "The 'updated_at' value is not withing 5s of the current time"
-        );
-    }
-
-    public static function patchProvider() {
-        return [
-            "Change Comment On Entity" => [
-                1,
-                "1?r=entity",
-                [
-                    "content" => "Patched content"
-                ],
-                [
-                    [
-                        "content" => "Patched content",
-                        "created_at" => "2017-12-20T09:47:35.000000Z"
-                    ]
-                ]
+dataset('patchProvider', function () {
+    return [
+        "Change Comment On Entity" => [
+            1,
+            "1?r=entity",
+            [
+                "content" => "Patched content"
             ],
-            "Change Comment On Attribute Value" => [
-                5,
-                "1?r=attribute_value&aid=15",
+            [
                 [
-                    "content" => "Patched content"
-                ],
-                [
-                    [],
-                    [
-                        "content" => "Patched content",
-                        "created_at" => "2017-12-20T09:53:35.000000Z"
-                    ]
+                    "content" => "Patched content",
+                    "created_at" => "2017-12-20T09:47:35.000000Z"
                 ]
             ]
-        ];
-    }
+        ],
+        "Change Comment On Attribute Value" => [
+            5,
+            "1?r=attribute_value&aid=15",
+            [
+                "content" => "Patched content"
+            ],
+            [
+                [],
+                [
+                    "content" => "Patched content",
+                    "created_at" => "2017-12-20T09:53:35.000000Z"
+                ]
+            ]
+        ]
+    ];
+});
 
-    // ==========================================
-    //              [[ DELETE ]]
-    // ==========================================
+test('delete comment', function ($id, $targetCount) {
+    $response = $this->userRequest()
+        ->delete('/api/v1/comment/' . $id);
 
-    #[DataProvider('deleteProvider')]
-    #[TestDox('DELETE /api/v1/comment/{id} - Delete request')]
-    public function testDeleteComment($id, $targetCount)
-    {
-        $response = $this->userRequest()
-            ->delete('/api/v1/comment/' . $id);
+    $response->assertStatus(204);
+    $cnt = Comment::withoutTrashed()->count();
+    expect($cnt)->toEqual($targetCount);
+})->with('deleteProvider');
 
-        $response->assertStatus(204);
-        $cnt = Comment::withoutTrashed()->count();
-        $this->assertEquals($targetCount, $cnt);
-    }
+dataset('deleteProvider', function () {
+    return [
+        "Delete Entity Comment" => [3, 5],
+        "Delete Attribute Value Comment" => [6, 5],
+        "Delete Entity Comment Which Was Replied To" => [1, 4],
+        "Delete AV Comment Which Was Replied To" => [4, 4]
+    ];
+});
 
-    public static function deleteProvider() {
-        return [
-            "Delete Entity Comment" => [3, 5],
-            "Delete Attribute Value Comment" => [6, 5],
-            "Delete Entity Comment Which Was Replied To" => [1, 4],
-            "Delete AV Comment Which Was Replied To" => [4, 4]
-        ];
-    }
+test('without permission', function ($permission) {
+    (new ResponseTester($this))->testMissingPermission($permission);
+})->with('permissions');
 
-    // ==========================================
-    //      [[ ADDITIONAL DATA PROVIDERS ]]
-    // ==========================================
+test('exceptions', function ($permission) {
+    (new ResponseTester($this))->testExceptions($permission);
+})->with('exceptions');
 
-    #[DataProvider('permissions')]
-    #[TestDox('[[PROVIDER]] Routes Without Permissions')]
-    public function testWithoutPermission($permission) {
-        (new ResponseTester($this))->testMissingPermission($permission);
-    }
+test('unprocessable', function ($permission, $errors) {
+    $response = $this->userRequest()
+    ->json($permission->getMethod(), $permission->getUrl(), $permission->getData());
 
-    #[DataProvider('exceptions')]
-    #[TestDox('[[PROVIDER]] Exceptions With Permissions')]
-    public function testExceptions($permission) {
-        (new ResponseTester($this))->testExceptions($permission);
-    }
+    $this->assertStatus($response, 422);
+    $response->assertJson([
+        'errors' => $errors
+    ]);
+})->with('unprocessable');
 
-    #[DataProvider('unprocessable')]
-    #[TestDox('[[PROVIDER]] Unprocessable Entities')]
-    public function testUnprocessable($permission, $errors) {
-        $response = $this->userRequest()
-        ->json($permission->getMethod(), $permission->getUrl(), $permission->getData());
+dataset('permissions', function () {
+    return [
+        "GET    /api/v1/comment/resource/1?r=entity"                    => Permission::for("get",   "/api/v1/comment/resource/1?r=entity",                  "You do not have the permission to get comments"),
+        "GET    /api/v1/comment/resource/8?r=attribute_value&aid=5"     => Permission::for("get",   "/api/v1/comment/resource/8?r=attribute_value&aid=5",   "You do not have the permission to get comments"),
+        "POST   /api/v1/comment"                                        => Permission::for("post",  "/api/v1/comment",                                      "You do not have the permission to add comments", self::$testComment),
+        "PATCH  /api/v1/comment/1"                                      => Permission::for("patch", "/api/v1/comment/1",                                    "You do not have the permission to edit a comment", self::$testComment),
+        "DELETE /api/v1/comment/1"                                      => Permission::for("delete","/api/v1/comment/1",                                      "You do not have the permission to delete a comment"),
+    ];
+});
 
-        $this->assertStatus($response, 422);
-        $response->assertJson([
-            'errors' => $errors
-        ]);
-    }
+//TODO:: Test certainties
+dataset('exceptions', function () {
+    return [
+        "GET    /api/v1/comment/resource/99?r=entity -> invalid entity"                         => Permission::for("get",   "/api/v1/comment/resource/99?r=entity",                     "This entity does not exist"),
+        "GET    /api/v1/comment/resource/99?r=attribute_value&aid=5 -> invalid entity"          => Permission::for("get",   "/api/v1/comment/resource/99?r=attribute_value&aid=5",      "This attribute value does not exist"),
+        "GET    /api/v1/comment/resource/8?r=attribute_value&aid=99 -> invalid attribute"       => Permission::for("get",   "/api/v1/comment/resource/8?r=attribute_value&aid=99",      "This attribute value does not exist"),
+        "GET    /api/v1/comment/resource/1?r=attribute_value&aid=17 -> no attribute value"      => Permission::for("get",   "/api/v1/comment/resource/1?r=attribute_value&aid=17",      "This attribute value does not exist"),
+         // DISCUSS: I would expect a comment to fail if it is empty. But due to the nature of
+        //          the comments being intertwined with the certainty system, this is currently not possible.
+        // "POST   /api/v1/comment -> empty content"                                               => Permission::for("post",  "/api/v1/comment",                                          "The resource_id field is required.", ['content' => '', 'resource_id' => 1, 'resource_type' => 'entity']),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
+        "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
+        "DELETE /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("delete","/api/v1/comment/99",                                       "This comment does not exist"),
+    ];
+});
 
-    public static $testComment =  ['content' => 'Test Comment'];
-
-    public static function permissions() {
-        return [
-            "GET    /api/v1/comment/resource/1?r=entity"                    => Permission::for("get",   "/api/v1/comment/resource/1?r=entity",                  "You do not have the permission to get comments"),
-            "GET    /api/v1/comment/resource/8?r=attribute_value&aid=5"     => Permission::for("get",   "/api/v1/comment/resource/8?r=attribute_value&aid=5",   "You do not have the permission to get comments"),
-            "POST   /api/v1/comment"                                        => Permission::for("post",  "/api/v1/comment",                                      "You do not have the permission to add comments", self::$testComment),
-            "PATCH  /api/v1/comment/1"                                      => Permission::for("patch", "/api/v1/comment/1",                                    "You do not have the permission to edit a comment", self::$testComment),
-            "DELETE /api/v1/comment/1"                                      => Permission::for("delete","/api/v1/comment/1",                                      "You do not have the permission to delete a comment"),
-        ];
-    }
-
-    //TODO:: Test certainties
-    public static function exceptions() {
-        return [
-            "GET    /api/v1/comment/resource/99?r=entity -> invalid entity"                         => Permission::for("get",   "/api/v1/comment/resource/99?r=entity",                     "This entity does not exist"),
-            "GET    /api/v1/comment/resource/99?r=attribute_value&aid=5 -> invalid entity"          => Permission::for("get",   "/api/v1/comment/resource/99?r=attribute_value&aid=5",      "This attribute value does not exist"),
-            "GET    /api/v1/comment/resource/8?r=attribute_value&aid=99 -> invalid attribute"       => Permission::for("get",   "/api/v1/comment/resource/8?r=attribute_value&aid=99",      "This attribute value does not exist"),
-            "GET    /api/v1/comment/resource/1?r=attribute_value&aid=17 -> no attribute value"      => Permission::for("get",   "/api/v1/comment/resource/1?r=attribute_value&aid=17",      "This attribute value does not exist"),
-             // DISCUSS: I would expect a comment to fail if it is empty. But due to the nature of
-            //          the comments being intertwined with the certainty system, this is currently not possible.
-            // "POST   /api/v1/comment -> empty content"                                               => Permission::for("post",  "/api/v1/comment",                                          "The resource_id field is required.", ['content' => '', 'resource_id' => 1, 'resource_type' => 'entity']),
-            "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
-            "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
-            "PATCH  /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("patch", "/api/v1/comment/99",                                       "This comment does not exist", self::$testComment),
-            "DELETE /api/v1/comment/99 -> comment does not exist"                                   => Permission::for("delete","/api/v1/comment/99",                                       "This comment does not exist"),
-        ];
-    }
-
-    public static function unprocessable() {
-        return [
-            "POST   /api/v1/comment -> missing resource_id & _type"                                 => [new Permission("post",  "/api/v1/comment","", ['content' => 'content']), ["resource_id" => ["The resource id field is required."], "resource_type" => ["The resource type field is required."]]],
-            "POST   /api/v1/comment -> missing resource_id"                                       => [new Permission("post",  "/api/v1/comment","", ['content' => 'content', 'resource_id' => 1]),  [ "resource_type" => ["The resource type field is required."]]],
-            "POST   /api/v1/comment -> missing resource_type"                                         => [new Permission("post",  "/api/v1/comment","", ['content' => 'content', 'resource_type' => 'entity']),  ["resource_id" => ["The resource id field is required."]]],
-        ];
-    }
-}
+dataset('unprocessable', function () {
+    return [
+        "POST   /api/v1/comment -> missing resource_id & _type"                                 => [new Permission("post",  "/api/v1/comment","", ['content' => 'content']), ["resource_id" => ["The resource id field is required."], "resource_type" => ["The resource type field is required."]]],
+        "POST   /api/v1/comment -> missing resource_id"                                       => [new Permission("post",  "/api/v1/comment","", ['content' => 'content', 'resource_id' => 1]),  [ "resource_type" => ["The resource type field is required."]]],
+        "POST   /api/v1/comment -> missing resource_type"                                         => [new Permission("post",  "/api/v1/comment","", ['content' => 'content', 'resource_type' => 'entity']),  ["resource_id" => ["The resource id field is required."]]],
+    ];
+});

--- a/tests/Feature/ApiDataImporterTest.php
+++ b/tests/Feature/ApiDataImporterTest.php
@@ -1,151 +1,98 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Entity;
-use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 
-class ApiDataImporterTest extends TestCase {
-    /**
-     *
-     * Utilities
-     *
-     */
-    private function createDefaultCSVFile($delimiter = ",", $hasHeaderRow = true) {
-        $columns = [
-            ['Yamato', 'Site A\\\\Befund 1\\\\Inv. 1234', 'yellow', 'lee;steve;dave'],
-            ['大和', '', '黃色的', '王;伟祺;平安'],
-            ['やまと', 'Site A', 'きいろい', "ひまり;まゆみ;ユイ"],
-            ['ياماتو', 'Site B', 'أصفر', "عَلِي;يُوْسِف;حَسَن"],
-            ['Site A', '', 'Updated', 'Alternative Site']
-        ];
 
-        if($hasHeaderRow) {
-            array_unshift($columns, ['name', 'parent', 'Notizen', 'Alternativer Name']);
+/**
+ *
+ * Utilities
+ *
+ */
+function createDefaultCSVFile($delimiter = ",", $hasHeaderRow = true)
+{
+    $columns = [
+        ['Yamato', 'Site A\\\\Befund 1\\\\Inv. 1234', 'yellow', 'lee;steve;dave'],
+        ['大和', '', '黃色的', '王;伟祺;平安'],
+        ['やまと', 'Site A', 'きいろい', "ひまり;まゆみ;ユイ"],
+        ['ياماتو', 'Site B', 'أصفر', "عَلِي;يُوْسِف;حَسَن"],
+        ['Site A', '', 'Updated', 'Alternative Site']
+    ];
+
+    if($hasHeaderRow) {
+        array_unshift($columns, ['name', 'parent', 'Notizen', 'Alternativer Name']);
+    }
+
+    return createCSVFile($columns, $delimiter);
+}
+
+function createDimensionsCSVFile($delimiter = ",", $hasHeaderRow = true)
+{
+    $columns = [
+        ['imported', 'Site A', '1;2;3;cm'],
+    ];
+
+    if($hasHeaderRow) {
+        array_unshift($columns, ['name', 'parent', 'Abmessungen']);
+    }
+
+    return createCSVFile($columns, $delimiter);
+}
+
+function createCSVFile(array $tableData, $delimiter = ",")
+{
+    $content = '';
+    if(!empty($tableData)) {
+        foreach($tableData as $row) {
+            // Cells need to be escaped, as some cells may contain elements that collide with the delimiter
+            // e.g. lists are separated by semicolons
+            $escapeAllRows = array_map(fn ($cell) => "\"$cell\"", $row);
+            $content .= implode($delimiter, $escapeAllRows) . "\n";
         }
-
-        return $this->createCSVFile($columns, $delimiter);
     }
 
-    private function createDimensionsCSVFile($delimiter = ",", $hasHeaderRow = true) {
-        $columns = [
-            ['imported', 'Site A', '1;2;3;cm'],
-        ];
+    return UploadedFile::fake()->createWithContent('data.csv', $content);
+}
 
-        if($hasHeaderRow) {
-            array_unshift($columns, ['name', 'parent', 'Abmessungen']);
-        }
+function getData(?string $name = 'name', int $entityTypeId = 3, array $attributes = [], ?string $parentColumn = null)
+{
+    return json_encode([
+        "name_column" => $name,
+        "parent_column" => $parentColumn,
+        "entity_type_id" => $entityTypeId,
+        "attributes" => $attributes,
+    ]);
+}
 
-        return $this->createCSVFile($columns, $delimiter);
-    }
+function getDimensionsData()
+{
+    return getData(parentColumn: 'parent', entityTypeId: 6, attributes: [
+        9 => "Abmessungen",
+    ]);
+}
 
-    private function createCSVFile(array $tableData, $delimiter = ",") {
-        $content = '';
-        if(!empty($tableData)) {
-            foreach($tableData as $row) {
-                // Cells need to be escaped, as some cells may contain elements that collide with the delimiter
-                // e.g. lists are separated by semicolons
-                $escapeAllRows = array_map(fn ($cell) => "\"$cell\"", $row);
-                $content .= implode($delimiter, $escapeAllRows) . "\n";
-            }
-        }
+function getMetaData(string $delimiter = ",", bool $hasHeaderRow = true)
+{
+    return json_encode([
+        'delimiter' => $delimiter,
+        'has_header_row' => $hasHeaderRow,
+        'encoding' => 'UTF-8'
+    ]);
+}
 
-        return UploadedFile::fake()->createWithContent('data.csv', $content);
-    }
+test('validation empty file', function () {
+    $file = createCSVFile([]);
+    $metadata = getMetaData();
 
-    private function getData(?string $name = 'name', int $entityTypeId = 3, array $attributes = [], ?string $parentColumn = null) {
-        return json_encode([
-            "name_column" => $name,
-            "parent_column" => $parentColumn,
-            "entity_type_id" => $entityTypeId,
-            "attributes" => $attributes,
-        ]);
-    }
-
-    private function getDimensionsData() {
-        return $this->getData(
-            parentColumn: 'parent',
-            entityTypeId: 6,
-            attributes: [
-                9 => "Abmessungen",
-            ]
-        );
-    }
-
-    private function getMetaData(string $delimiter = ",", bool $hasHeaderRow = true) {
-        return json_encode([
-            'delimiter' => $delimiter,
-            'has_header_row' => $hasHeaderRow,
-            'encoding' => 'UTF-8'
-        ]);
-    }
-
-    /**
-     * We run the tests two times. Once with a header row and once without.
-     */
-
-    /**
-     *
-     * TESTS WITH NAMED HEADERS
-     *
-     */
-
-    public function testValidationEmptyFile() {
-        $file = $this->createCSVFile([]);
-        $metadata = $this->getMetaData();
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(hasHeaderRow: false),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [
-                    "No rows to import"
-                ],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationEmptyWithHeaders() {
-        $file = $this->createCSVFile([['name', 'parent', 'type']]);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [
-                    "No rows to import"
-                ],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationNamesColumnMissingError() {
-        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
-
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: ''),
-            'metadata' => $this->getMetaData(),
-        ])->assertStatus(200);
-
-        $response->assertJson([
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(),
+        'metadata' => getMetaData(hasHeaderRow: false),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
             "errors" => [
-                "Required column is missing: name_column"
+                "No rows to import"
             ],
             "summary" => [
                 "create" => 0,
@@ -153,20 +100,20 @@ class ApiDataImporterTest extends TestCase {
                 "conflict" => 1
             ]
         ]);
-    }
+});
 
-    public function testValidationNamesColumnNullError() {
-        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
+test('validation empty with headers', function () {
+    $file = createCSVFile([['name', 'parent', 'type']]);
 
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: null),
-            'metadata' => $this->getMetaData(),
-        ])->assertStatus(200);
-
-        $response->assertJson([
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
             "errors" => [
-                "Required column is missing: name_column"
+                "No rows to import"
             ],
             "summary" => [
                 "create" => 0,
@@ -174,519 +121,517 @@ class ApiDataImporterTest extends TestCase {
                 "conflict" => 1
             ]
         ]);
-    }
+});
 
-    public function testValidationWithAllNamesSetCorrectly() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
+test('validation names column missing error', function () {
+    $file = createCSVFile([['other'], [''], ['other 2']]);
+
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: ''),
+        'metadata' => getMetaData(),
+    ])->assertStatus(200);
+
+    $response->assertJson([
+        "errors" => [
+            "Required column is missing: name_column"
+        ],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation names column null error', function () {
+    $file = createCSVFile([['other'], [''], ['other 2']]);
+
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: null),
+        'metadata' => getMetaData(),
+    ])->assertStatus(200);
+
+    $response->assertJson([
+        "errors" => [
+            "Required column is missing: name_column"
+        ],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation with all names set correctly', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation with invalid type id', function () {
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(entityTypeId: -1),
+        'metadata' => getMetaData(),
+    ])->assertStatus(200);
+
+    $response->assertJson([
+        'errors' => ['The entity type does not exist: -1'],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation invalid file', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => null,
+        'data' => getData(),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(422)
+        ->assertJson([
+            "message" => "The file field is required.",
+            "errors" => [
+                "file" => [
+                    "The file field is required."
                 ]
-            ]);
-    }
+            ]
+        ]);
+});
 
-    public function testValidationWithInvalidTypeId() {
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(entityTypeId: -1),
-            'metadata' => $this->getMetaData(),
-        ])->assertStatus(200);
-
-        $response->assertJson([
-            'errors' => ['The entity type does not exist: -1'],
+test('validation incorrect delimiter', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(';'),
+        'data' => getData(),
+        'metadata' => getMetaData(delimiter: ','),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => ["The column for the name does not exist: name"],
             "summary" => [
                 "create" => 0,
                 "update" => 0,
                 "conflict" => 1
             ]
         ]);
-    }
+});
 
-    public function testValidationInvalidFile() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => null,
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(422)
-            ->assertJson([
-                "message" => "The file field is required.",
-                "errors" => [
-                    "file" => [
-                        "The file field is required."
-                    ]
-                ]
-            ]);
-    }
-
-    public function testValidationIncorrectDelimiter() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(';'),
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(delimiter: ','),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => ["The column for the name does not exist: name"],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationCorrectDelimiter() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(';'),
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(delimiter: ';'),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationWithParentColumn() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(parentColumn: 'parent'),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);;
-    }
-
-    public function testValidationWithParentColumnChildTypeNotAllowed() {
-        $file = $this->createCSVFile([
-            ['name', 'parent', 'Notizen'],
-            ['parent not allowed', 'Site A\\\\Befund 1\\\\Inv. 31', '6 is parent of 3']
+test('validation correct delimiter', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(';'),
+        'data' => getData(),
+        'metadata' => getMetaData(delimiter: ';'),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
         ]);
+});
 
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(parentColumn: 'parent'),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['[2] The relationship between entity types is not allowed: Stone -> Site'],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-    
-    public function testValidationErrorOnNonTopEntityAsTop(){
-            $file = $this->createCSVFile([
-                ['name', 'parent', 'Notizen'],
-                ['Feature #1', '', 'Feature is not a top level entity.']
-            ]);
-            
-            $this->userRequest()->post('/api/v1/entity/import/validate', [
-                'file' => $file,
-                'data' => $this->getData(parentColumn: 'parent', entityTypeId: 4), 
-                'metadata' => $this->getMetaData(),
-            ])
-                ->assertStatus(200)
-                ->assertJson([
-                    'errors' => ['[2] The relationship between entity types is not allowed: TOP -> Feature'],
-                    "summary" => [
-                        "create" => 0,
-                        "update" => 0,
-                        "conflict" => 1
-                    ]
-                ]);
-    }
-
-    public function testValidationWithParentColumnTopLevelElementAlreadyExists() {
-        $file = $this->createCSVFile([
-            ['name', 'parent', 'Notizen'],
-            ['Site A', '', '']
+test('validation with parent column', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(parentColumn: 'parent'),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
         ]);
+});
 
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(parentColumn: 'parent'),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
+test('validation with parent column child type not allowed', function () {
+    $file = createCSVFile([
+        ['name', 'parent', 'Notizen'],
+        ['parent not allowed', 'Site A\\\\Befund 1\\\\Inv. 31', '6 is parent of 3']
+    ]);
 
-    public function testValidationWithParentColumnSubElementAlreadyExists() {
-        $file = $this->createCSVFile([
-            ['name', 'parent', 'Notizen'],
-            ['Fund 12', 'Site B', 'Fund 12 does already exist at this location.']
-        ]);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(parentColumn: 'parent'),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributes() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(attributes: [
-                8 => "Notizen",
-                15 => "Alternativer Name"
-            ]),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributesInvalidColumnName() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(attributes: [
-                8 => "nots",
-                15 => "alts"
-            ]),
-            'metadata' => $this->getMetaData(),
-        ])->assertJson([
-            'errors' => ["The attribute columns do not exist: nots, alts"],
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(parentColumn: 'parent'),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['[2] The relationship between entity types is not allowed: Stone -> Site'],
             "summary" => [
                 "create" => 0,
                 "update" => 0,
                 "conflict" => 1
             ]
         ]);
-    }
+});
 
-    public function testValidationOfAttributesInvalidAttributeId() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(attributes: [
-                -1 => "Notizen",
-                -1 => "Alternativer Name"
-            ]),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['The attribute id does not exist: -1'],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
+test('validation error on non top entity as top', function () {
+    $file = createCSVFile([
+        ['name', 'parent', 'Notizen'],
+        ['Feature #1', '', 'Feature is not a top level entity.']
+    ]);
 
-    public function testValidationOfAttributesInvalidAttributeIdAndInvalidColumnName() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(attributes: [
-                -1 => "nots",
-            ]),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [
-                    'The attribute id does not exist: -1',
-                    'The attribute columns do not exist: nots',
-                ],
-                'summary' => [
-                    'create' => 0,
-                    'update' => 0,
-                    'conflict' => 2
-                ]
-            ]);
-    }
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(parentColumn: 'parent', entityTypeId: 4), 
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['[2] The relationship between entity types is not allowed: TOP -> Feature'],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+});
 
-    public function testValidationOfAttributeValueSucceeds() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createCSVFile([
-                ['name', 'parent', 'Abmessungen'],
-                ['good', 'Site A', '1;2;3;cm'],
-            ]),
-            'data' => $this->getData(
-                parentColumn: 'parent',
-                entityTypeId: 6,
-                attributes: [
-                    9 => "Abmessungen",
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                'summary' => [
-                    'create' => 1,
-                    'update' => 0,
-                    'conflict' => 0
-                ]
-            ]);
-    }
+test('validation with parent column top level element already exists', function () {
+    $file = createCSVFile([
+        ['name', 'parent', 'Notizen'],
+        ['Site A', '', '']
+    ]);
 
-    public function testValidationOfAttributeValueFails() {
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createCSVFile([
-                ['name', 'parent', 'Abmessungen'],
-                ['bad',  'Site A', '1,2,3,cm'],
-            ]),
-            'data' => $this->getData(
-                parentColumn: 'parent',
-                entityTypeId: 6,
-                attributes: [
-                    9 => "Abmessungen",
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['[2] Attribute could not be imported: {{Abmessungen}} => {{1,2,3,cm}}'],
-                'summary' => [
-                    'create' => 1,
-                    'update' => 0,
-                    'conflict' => 1,
-                ]
-            ]);
-    }
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(parentColumn: 'parent'),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 0,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
 
-    public function testValidationFailsWithMismatchingColumns() {
-        $headerRow = ["name", "parent", "Notes", "Description"];
-        $headerRowString = implode(',', $headerRow);
-        $headerCount = count($headerRow);
-        $dataRow = ["Site A", "", "updated"];
-        $dataRowString = implode(',', $dataRow);
-        $dataCount = count($dataRow);
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createCSVFile([
-                $headerRow,
-                $dataRow,
-            ]),
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(200);
+test('validation with parent column sub element already exists', function () {
+    $file = createCSVFile([
+        ['name', 'parent', 'Notizen'],
+        ['Fund 12', 'Site B', 'Fund 12 does already exist at this location.']
+    ]);
 
-        $response->assertJson([
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(parentColumn: 'parent'),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 0,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation of attributes', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            8 => "Notizen",
+            15 => "Alternativer Name"
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation of attributes invalid column name', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            8 => "nots",
+            15 => "alts"
+        ]),
+        'metadata' => getMetaData(),
+    ])->assertJson([
+        'errors' => ["The attribute columns do not exist: nots, alts"],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation of attributes invalid attribute id', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            -1 => "Notizen",
+            -1 => "Alternativer Name"
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['The attribute id does not exist: -1'],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+});
+
+test('validation of attributes invalid attribute id and invalid column name', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            -1 => "nots",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
             'errors' => [
-                "Column count of current row '{$dataRowString}' ({$dataCount} columns) does not match column count in header row '{$headerRowString}' ({$headerCount} columns)."
+                'The attribute id does not exist: -1',
+                'The attribute columns do not exist: nots',
             ],
+            'summary' => [
+                'create' => 0,
+                'update' => 0,
+                'conflict' => 2
+            ]
         ]);
-    }
+});
 
-    public function testValidationWithDuplicateColumnMapping(){
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(
-                attributes: [
-                    13 => "Notizen", // Notizen
-                    19 => "Notizen", // Aufbewahrung
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ]);
-        $response->assertStatus(200);
-
-        $response->assertJson([
+test('validation of attribute value succeeds', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createCSVFile([
+            ['name', 'parent', 'Abmessungen'],
+            ['good', 'Site A', '1;2;3;cm'],
+        ]),
+        'data' => getData(parentColumn: 'parent', entityTypeId: 6, attributes: [
+            9 => "Abmessungen",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
             'errors' => [],
             'summary' => [
-                'create' => 4,
-                'update' => 1,
+                'create' => 1,
+                'update' => 0,
                 'conflict' => 0
             ]
         ]);
-    }
+});
 
-    public function testDataImportSuccess() {
-        $response = $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createDimensionsCSVFile(),
-            'data' => $this->getDimensionsData(),
-            'metadata' => $this->getMetaData(),
-        ]);
-
-        if($response->status() !== 201) {
-            $response->assertJson([
-                'error' => 'any'
-            ]);
-        }
-        $response->assertStatus(201);
-
-        $entityId = null;
-        try {
-            $entityId = Entity::getFromPath('Site A\\\\imported');
-        } catch(\Exception $e) {
-            $this->fail('Entity not found');
-        }
-
-        $this->assertNotNull($entityId);
-        $entity = Entity::find($entityId);
-        $this->assertNotNull($entity);
-
-        $this->assertEquals('imported', $entity->name);
-        $entityData = $entity->getData();
-        $this->assertEquals(json_decode('{"B":1,"H":2,"T":3,"unit":"cm"}'), $entityData[9]->value);
-    }
-
-    public function testDataImportFailsOnEmptyFile() {
-        $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createCSVFile([]),
-            'data' => $this->getData(),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(400)
-            ->assertJson([
-                'error' => 'No rows to import'
-            ]);
-    }
-
-    public function testDataImportCanCreateAttribute() {
-        $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createCSVFile([["name", "parent", "Notizen"], ["Site A", "", "updated"]]),
-            'data' => $this->getData(
-                attributes: [
-                    8 => "Notizen",
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(201);
-
-        $entityId = Entity::getFromPath('Site A');
-        $data = Entity::find($entityId)->getData();
-        $this->assertEquals('updated', $data[8]->value);
-    }
-
-    public function testDataImportCanUpdateAttribute() {
-        $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createCSVFile([["name", "parent", "Alternativer Name"], ["Site A", "", "alt name;alias"]]),
-            'data' => $this->getData(
-                attributes: [
-                    15 => "Alternativer Name",
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(201);
-
-        $entityId = Entity::getFromPath('Site A');
-        $data = Entity::find($entityId)->getData();
-        $this->assertEquals(["alt name", "alias"], $data[15]->value);
-    }
-
-    public function testDataImportFailsWithIncompatibleMapping() {
-        $response = $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createCSVFile([["name", "parent", "Notizen"], ["Site A", "", "updated"]]),
-            'data' => $this->getData(
-                attributes: [
-                    99 => "Notizen",
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(400);
-
-        $response->assertJson([
-            'error' => 'The attribute id does not exist: 99',
-            'data' => [
-                'count' => -1,
-                'entry' => null,
-                'on' => -1,
-                'on_index' => -1,
-                'on_value' => null,
-                'on_name' => null
+test('validation of attribute value fails', function () {
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createCSVFile([
+            ['name', 'parent', 'Abmessungen'],
+            ['bad',  'Site A', '1,2,3,cm'],
+        ]),
+        'data' => getData(parentColumn: 'parent', entityTypeId: 6, attributes: [
+            9 => "Abmessungen",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['[2] Attribute could not be imported: {{Abmessungen}} => {{1,2,3,cm}}'],
+            'summary' => [
+                'create' => 1,
+                'update' => 0,
+                'conflict' => 1,
             ]
         ]);
-    }
+});
 
-    /**
-    *
-    * TESTS WITH NO HEADERS
-    *
-    */
+test('validation fails with mismatching columns', function () {
+    $headerRow = ["name", "parent", "Notes", "Description"];
+    $headerRowString = implode(',', $headerRow);
+    $headerCount = count($headerRow);
+    $dataRow = ["Site A", "", "updated"];
+    $dataRowString = implode(',', $dataRow);
+    $dataCount = count($dataRow);
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createCSVFile([
+            $headerRow,
+            $dataRow,
+        ]),
+        'data' => getData(),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(200);
 
-    public function testValidationEmptyFileNoHeaders() {
-        $file = $this->createCSVFile([]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
+    $response->assertJson([
+        'errors' => [
+            "Column count of current row '{$dataRowString}' ({$dataCount} columns) does not match column count in header row '{$headerRowString}' ({$headerCount} columns)."
+        ],
+    ]);
+});
 
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [
-                    "No rows to import"
-                ],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
+test('validation with duplicate column mapping', function () {
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            13 => "Notizen", // Notizen
+            19 => "Notizen", // Aufbewahrung
+        ]),
+        'metadata' => getMetaData(),
+    ]);
+    $response->assertStatus(200);
 
-    public function testValidationNamesColumnMissingErrorNoHeaders() {
-        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
+    $response->assertJson([
+        'errors' => [],
+        'summary' => [
+            'create' => 4,
+            'update' => 1,
+            'conflict' => 0
+        ]
+    ]);
+});
 
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: '#4'),
-            'metadata' => $metadata,
-        ])->assertStatus(200);
+test('data import success', function () {
+    $response = $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createDimensionsCSVFile(),
+        'data' => getDimensionsData(),
+        'metadata' => getMetaData(),
+    ]);
 
+    if($response->status() !== 201) {
         $response->assertJson([
+            'error' => 'any'
+        ]);
+    }
+    $response->assertStatus(201);
+
+    $entityId = null;
+    try {
+        $entityId = Entity::getFromPath('Site A\\\\imported');
+    } catch(\Exception $e) {
+        $this->fail('Entity not found');
+    }
+
+    expect($entityId)->not->toBeNull();
+    $entity = Entity::find($entityId);
+    expect($entity)->not->toBeNull();
+
+    expect($entity->name)->toEqual('imported');
+    $entityData = getData();
+    expect($entityData[9]->value)->toEqual(json_decode('{"B":1,"H":2,"T":3,"unit":"cm"}'));
+});
+
+test('data import fails on empty file', function () {
+    $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createCSVFile([]),
+        'data' => getData(),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(400)
+        ->assertJson([
+            'error' => 'No rows to import'
+        ]);
+});
+
+test('data import can create attribute', function () {
+    $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createCSVFile([["name", "parent", "Notizen"], ["Site A", "", "updated"]]),
+        'data' => getData(attributes: [
+            8 => "Notizen",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(201);
+
+    $entityId = Entity::getFromPath('Site A');
+    $data = getData();
+    expect($data[8]->value)->toEqual('updated');
+});
+
+test('data import can update attribute', function () {
+    $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createCSVFile([["name", "parent", "Alternativer Name"], ["Site A", "", "alt name;alias"]]),
+        'data' => getData(attributes: [
+            15 => "Alternativer Name",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(201);
+
+    $entityId = Entity::getFromPath('Site A');
+    $data = getData();
+    expect($data[15]->value)->toEqual(["alt name", "alias"]);
+});
+
+test('data import fails with incompatible mapping', function () {
+    $response = $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createCSVFile([["name", "parent", "Notizen"], ["Site A", "", "updated"]]),
+        'data' => getData(attributes: [
+            99 => "Notizen",
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(400);
+
+    $response->assertJson([
+        'error' => 'The attribute id does not exist: 99',
+        'data' => [
+            'count' => -1,
+            'entry' => null,
+            'on' => -1,
+            'on_index' => -1,
+            'on_value' => null,
+            'on_name' => null
+        ]
+    ]);
+});
+
+test('validation empty file no headers', function () {
+    $file = createCSVFile([]);
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
             "errors" => [
-                "The column for the name does not exist: #4"
+                "No rows to import"
             ],
             "summary" => [
                 "create" => 0,
@@ -694,373 +639,374 @@ class ApiDataImporterTest extends TestCase {
                 "conflict" => 1
             ]
         ]);
-    }
+});
 
-    public function testValidationNamesColumnNullErrorNoHeaders() {
-        $file = $this->createCSVFile([['other'], [''], ['other 2']]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
+test('validation names column missing error no headers', function () {
+    $file = createCSVFile([['other'], [''], ['other 2']]);
+    $metadata = getMetaData(hasHeaderRow: false);
 
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: null),
-            'metadata' => $metadata,
-        ])->assertStatus(200);
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: '#4'),
+        'metadata' => $metadata,
+    ])->assertStatus(200);
 
-        $response->assertJson([
+    $response->assertJson([
+        "errors" => [
+            "The column for the name does not exist: #4"
+        ],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation names column null error no headers', function () {
+    $file = createCSVFile([['other'], [''], ['other 2']]);
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: null),
+        'metadata' => $metadata,
+    ])->assertStatus(200);
+
+    $response->assertJson([
+        "errors" => [
+            "Required column is missing: name_column"
+        ],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation with all names set correctly no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: '#1'),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation with invalid type id no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", entityTypeId: -1),
+        'metadata' => $metadata,
+    ])->assertStatus(200);
+
+    $response->assertJson([
+        'errors' => ['The entity type does not exist: -1'],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation invalid file no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => null,
+        'data' => getData(name: "#1"),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(422)
+        ->assertJson([
+            "message" => "The file field is required.",
             "errors" => [
-                "Required column is missing: name_column"
+                "file" => [
+                    "The file field is required."
+                ]
+            ]
+        ]);
+});
+
+test('validation incorrect delimiter no headers', function () {
+    $metadata = getMetaData(delimiter: ',', hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
+        'data' => getData(),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => ["The column for the name does not exist: name"],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+});
+
+test('validation correct delimiter no headers', function () {
+    $metadata = getMetaData(delimiter: ';', hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
+        'data' => getData(name: "#1"),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation with parent column no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", parentColumn: '#2'),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            "errors" => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation with parent column child type not allowed no headers', function () {
+    $file = createCSVFile([
+        ['parent not allowed', 'Site A\\\\Befund 1\\\\Inv. 31', '6 is parent of 3']
+    ]);
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: "#1", parentColumn: '#2'),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['[1] The relationship between entity types is not allowed: Stone -> Site'],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+});
+
+test('validation with parent column top level element already exists no headers', function () {
+    $file = createCSVFile([
+        ['Site A', '', '']
+    ]);
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: "#1", parentColumn: '#2'),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 0,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation with parent column sub element already exists no headers', function () {
+    $file = createCSVFile([
+        ['Fund 12', 'Site B', 'Fund 12 does already exist at this location.']
+    ]);
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => $file,
+        'data' => getData(name: "#1", parentColumn: '#2'),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 0,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation of attributes no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", attributes: [
+        8 => "#3",
+        15 => "#4"
+    ]),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            "summary" => [
+                "create" => 4,
+                "update" => 1,
+                "conflict" => 0
+            ]
+        ]);
+});
+
+test('validation of attributes invalid column name no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", attributes: [
+        8 => "#10",
+        15 => "#11"
+    ]),
+        'metadata' => $metadata,
+    ])->assertJson([
+        'errors' => ["The attribute columns do not exist: #10, #11"],
+        "summary" => [
+            "create" => 0,
+            "update" => 0,
+            "conflict" => 1
+        ]
+    ]);
+});
+
+test('validation of attributes invalid attribute id no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", attributes: [
+        -1 => "#3",
+        -1 => "#4"
+    ]),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['The attribute id does not exist: -1'],
+            "summary" => [
+                "create" => 0,
+                "update" => 0,
+                "conflict" => 1
+            ]
+        ]);
+});
+
+test('validation of attributes invalid attribute id and invalid column name no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
+
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createDefaultCSVFile(hasHeaderRow: false),
+        'data' => getData(name: "#1", attributes: [
+        -1 => "#11",
+    ]),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [
+                'The attribute id does not exist: -1',
+                'The attribute columns do not exist: #11',
             ],
-            "summary" => [
-                "create" => 0,
-                "update" => 0,
-                "conflict" => 1
+            'summary' => [
+                'create' => 0,
+                'update' => 0,
+                'conflict' => 2
             ]
         ]);
-    }
+});
 
-    public function testValidationWithAllNamesSetCorrectlyNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
+test('validation of attribute value succeeds no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
 
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(name: '#1'),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationWithInvalidTypeIdNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $response = $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(name: "#1", entityTypeId: -1),
-            'metadata' => $metadata,
-        ])->assertStatus(200);
-
-        $response->assertJson([
-            'errors' => ['The entity type does not exist: -1'],
-            "summary" => [
-                "create" => 0,
-                "update" => 0,
-                "conflict" => 1
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createCSVFile([
+            ['good', 'Site A', '1;2;3;cm'],
+        ]),
+        'data' => getData(name: "#1", parentColumn: '#2', entityTypeId: 6, attributes: [
+            9 => "#3",
+        ]),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => [],
+            'summary' => [
+                'create' => 1,
+                'update' => 0,
+                'conflict' => 0
             ]
         ]);
-    }
+});
 
-    public function testValidationInvalidFileNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
+test('validation of attribute value fails no headers', function () {
+    $metadata = getMetaData(hasHeaderRow: false);
 
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => null,
-            'data' => $this->getData(name: "#1"),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(422)
-            ->assertJson([
-                "message" => "The file field is required.",
-                "errors" => [
-                    "file" => [
-                        "The file field is required."
-                    ]
-                ]
-            ]);
-    }
-
-    public function testValidationIncorrectDelimiterNoHeaders() {
-        $metadata = $this->getMetaData(delimiter: ',', hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
-            'data' => $this->getData(),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => ["The column for the name does not exist: name"],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationCorrectDelimiterNoHeaders() {
-        $metadata = $this->getMetaData(delimiter: ';', hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false, delimiter:';'),
-            'data' => $this->getData(name: "#1"),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationWithParentColumnNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(name: "#1", parentColumn: '#2'),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                "errors" => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationWithParentColumnChildTypeNotAllowedNoHeaders() {
-        $file = $this->createCSVFile([
-            ['parent not allowed', 'Site A\\\\Befund 1\\\\Inv. 31', '6 is parent of 3']
-        ]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: "#1", parentColumn: '#2'),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['[1] The relationship between entity types is not allowed: Stone -> Site'],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationWithParentColumnTopLevelElementAlreadyExistsNoHeaders() {
-        $file = $this->createCSVFile([
-            ['Site A', '', '']
-        ]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: "#1", parentColumn: '#2'),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationWithParentColumnSubElementAlreadyExistsNoHeaders() {
-        $file = $this->createCSVFile([
-            ['Fund 12', 'Site B', 'Fund 12 does already exist at this location.']
-        ]);
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $file,
-            'data' => $this->getData(name: "#1", parentColumn: '#2'),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributesNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(
-                name: "#1",
-                attributes: [
-                8 => "#3",
-                15 => "#4"
-            ]),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                "summary" => [
-                    "create" => 4,
-                    "update" => 1,
-                    "conflict" => 0
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributesInvalidColumnNameNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(
-                name: "#1",
-                attributes: [
-                8 => "#10",
-                15 => "#11"
-            ]),
-            'metadata' => $metadata,
-        ])->assertJson([
-            'errors' => ["The attribute columns do not exist: #10, #11"],
-            "summary" => [
-                "create" => 0,
-                "update" => 0,
-                "conflict" => 1
+    $this->userRequest()->post('/api/v1/entity/import/validate', [
+        'file' => createCSVFile([
+            ['bad',  'Site A', '1,2,3,cm'],
+        ]),
+        'data' => getData(name: "#1", parentColumn: '#2', entityTypeId: 6, attributes: [
+            9 => "#3",
+        ]),
+        'metadata' => $metadata,
+    ])
+        ->assertStatus(200)
+        ->assertJson([
+            'errors' => ['[1] Attribute could not be imported: {{#3}} => {{1,2,3,cm}}'],
+            'summary' => [
+                'create' => 1,
+                'update' => 0,
+                'conflict' => 1,
             ]
         ]);
-    }
+});
 
-    public function testValidationOfAttributesInvalidAttributeIdNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(
-                name: "#1",
-                attributes: [
-                -1 => "#3",
-                -1 => "#4"
-            ]),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['The attribute id does not exist: -1'],
-                "summary" => [
-                    "create" => 0,
-                    "update" => 0,
-                    "conflict" => 1
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributesInvalidAttributeIdAndInvalidColumnNameNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createDefaultCSVFile(hasHeaderRow: false),
-            'data' => $this->getData(
-                name: "#1",
-                attributes: [
-                -1 => "#11",
-            ]),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [
-                    'The attribute id does not exist: -1',
-                    'The attribute columns do not exist: #11',
-                ],
-                'summary' => [
-                    'create' => 0,
-                    'update' => 0,
-                    'conflict' => 2
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributeValueSucceedsNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createCSVFile([
-                ['good', 'Site A', '1;2;3;cm'],
-            ]),
-            'data' => $this->getData(
-                name: "#1",
-                parentColumn: '#2',
-                entityTypeId: 6,
-                attributes: [
-                    9 => "#3",
-                ]
-            ),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => [],
-                'summary' => [
-                    'create' => 1,
-                    'update' => 0,
-                    'conflict' => 0
-                ]
-            ]);
-    }
-
-    public function testValidationOfAttributeValueFailsNoHeaders() {
-        $metadata = $this->getMetaData(hasHeaderRow: false);
-
-        $this->userRequest()->post('/api/v1/entity/import/validate', [
-            'file' => $this->createCSVFile([
-                ['bad',  'Site A', '1,2,3,cm'],
-            ]),
-            'data' => $this->getData(
-                name: "#1",
-                parentColumn: '#2',
-                entityTypeId: 6,
-                attributes: [
-                    9 => "#3",
-                ]
-            ),
-            'metadata' => $metadata,
-        ])
-            ->assertStatus(200)
-            ->assertJson([
-                'errors' => ['[1] Attribute could not be imported: {{#3}} => {{1,2,3,cm}}'],
-                'summary' => [
-                    'create' => 1,
-                    'update' => 0,
-                    'conflict' => 1,
-                ]
-            ]);
-    }
-
-    public function testDataImportFailsWithDuplicateColumnMapping(){
-        $response = $this->userRequest()->post('/api/v1/entity/import', [
-            'file' => $this->createDefaultCSVFile(),
-            'data' => $this->getData(
-                attributes: [
-                    13 => "Notizen", // Notizen
-                    19 => "Notizen", // Aufbewahrung
-                ]
-            ),
-            'metadata' => $this->getMetaData(),
-        ])
-            ->assertStatus(201);
-    }
-}
+test('data import fails with duplicate column mapping', function () {
+    $response = $this->userRequest()->post('/api/v1/entity/import', [
+        'file' => createDefaultCSVFile(),
+        'data' => getData(attributes: [
+            13 => "Notizen", // Notizen
+            19 => "Notizen", // Aufbewahrung
+        ]),
+        'metadata' => getMetaData(),
+    ])
+        ->assertStatus(201);
+});

--- a/tests/Feature/ApiDataImporterTest.php
+++ b/tests/Feature/ApiDataImporterTest.php
@@ -550,7 +550,7 @@ test('data import success', function () {
     expect($entity)->not->toBeNull();
 
     expect($entity->name)->toEqual('imported');
-    $entityData = getData();
+    $entityData = $entity->getData();
     expect($entityData[9]->value)->toEqual(json_decode('{"B":1,"H":2,"T":3,"unit":"cm"}'));
 });
 
@@ -577,7 +577,7 @@ test('data import can create attribute', function () {
         ->assertStatus(201);
 
     $entityId = Entity::getFromPath('Site A');
-    $data = getData();
+    $data = Entity::find($entityId)->getData();
     expect($data[8]->value)->toEqual('updated');
 });
 
@@ -592,7 +592,7 @@ test('data import can update attribute', function () {
         ->assertStatus(201);
 
     $entityId = Entity::getFromPath('Site A');
-    $data = getData();
+    $data = Entity::find($entityId)->getData();
     expect($data[15]->value)->toEqual(["alt name", "alias"]);
 });
 

--- a/tests/Feature/ApiEditorTest.php
+++ b/tests/Feature/ApiEditorTest.php
@@ -1,9 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
-use Tests\TestCase;
-
 use App\Attribute;
 use App\AvailableLayer;
 use App\AttributeValue;
@@ -17,772 +13,783 @@ use Tests\Permission;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiEditorTest extends TestCase
-{
-    // Testing GET requests
 
-    #[TestDox('GET /api/v1/editor/dm/entity_type/occurrence_count/{id}  -  Get number of occurrences of an entity type (id=5)')]
-    public function testEntityOccurCountEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/entity_type/occurrence_count/5');
+test('entity occur count endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/entity_type/occurrence_count/5');
 
-        $this->assertStatus($response, 200);
-        $response->assertSimilarJson([3]);
-    }
+    $this->assertStatus($response, 200);
+    $response->assertSimilarJson([3]);
+});
 
-    #[TestDox('GET /api/v1/editor/dm/attribute/occurrence_count/{id}  -  Get number of occurrences of an attribute (id=9)')]
-    public function testAttributeOccurCountEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/attribute/occurrence_count/9');
+test('attribute occur count endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/attribute/occurrence_count/9');
 
-        $this->assertStatus($response, 200);
-        $response->assertSimilarJson([4]);
-    }
+    $this->assertStatus($response, 200);
+    $response->assertSimilarJson([4]);
+});
 
-    #[TestDox('GET /api/v1/editor/dm/attribute/occurrence_count/{attribute_id}/{entity_id}  -  Get number of occurrences of an attribute (id=9) on an entity (id=5)')]
-    public function testAttributeOfEntityTypeOccurCountEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/attribute/occurrence_count/9/5');
+test('attribute of entity type occur count endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/attribute/occurrence_count/9/5');
 
-        $this->assertStatus($response, 200);
-        $response->assertSimilarJson([3]);
-    }
+    $this->assertStatus($response, 200);
+    $response->assertSimilarJson([3]);
+});
 
-    #[TestDox('GET /api/v1/editor/dm/entity_type/top  -  Get top-level entities')]
-    public function testTopEntityTypeCountEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/entity_type/top');
+test('top entity type count endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/entity_type/top');
 
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'thesaurus_url',
-                'is_root',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        $response->assertSimilarJson([
-            [
-                'id' => 3,
-                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911',
-                'is_root' => true,
-                'created_at' => '2017-12-20T10:03:06.000000Z',
-                'updated_at' => '2017-12-20T10:03:06.000000Z',
-                'color' => '#FF0000',
-            ],
-            [
-                'id' => 7,
-                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/lagerstatte#20171220165727',
-                'is_root' => true,
-                'created_at' => '2017-12-20T16:57:41.000000Z',
-                'updated_at' => '2017-12-20T16:57:41.000000Z',
-                'color' => '#0000FF',
-            ]
-        ]);
-    }
-
-    /**
-     * @ GET /api/v1/editor/dm/attribute - Get all attributes
-    */
-    public function testGetAttributeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/attribute');
-
-
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(21, 'attributes');
-        $response->assertJsonStructure([
-            'attributes' => [
-                '*' => [
-                    'id',
-                    'thesaurus_url',
-                    'datatype',
-                    'text',
-                    'thesaurus_root_url',
-                    'parent_id',
-                    'created_at',
-                    'updated_at',
-                    'recursive',
-                    'root_attribute_id',
-                    'is_system',
-                    'multiple',
-                    'restrictions',
-                    'metadata',
-                    'entity_types_count',
-                ]
-            ]
-        ]);
-        $response->assertJson(fn(AssertableJson $json) =>
-            $json
-                ->has('attributes')
-                ->has('attributes.1', fn($json) =>
-                    $json
-                        ->where('id', 2)
-                        ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437')
-                        ->where( 'datatype', 'percentage')
-                        ->where('thesaurus_root_url', NULL)
-                        ->where('created_at', '2017-12-20T10:07:45.000000Z')
-                        ->where('updated_at', '2017-12-20T10:07:45.000000Z')
-                        ->where('parent_id', NULL)
-                        ->where('text', NULL)
-                        ->where('recursive', true)
-                        ->where('root_attribute_id', NULL)
-                        ->where('is_system', false)
-                        ->where('multiple', false)
-                        ->where('restrictions', NULL)
-                        ->where('metadata', NULL)
-                        ->where('entity_types_count', 1)
-                )
-                // This was originally an array keyed by index. But the backend changed
-                // to use the id as key. Idk if this is a good idea. [SO]
-                ->has('attributes.4.columns.6', fn($json) =>
-                    $json
-                        ->where('id', 6)
-                        ->where('thesaurus_url',  'https://spacialist.escience.uni-tuebingen.de/<user-project>/gefassposition#20171220105434')
-                        ->where('datatype',  'string-sc')
-                        ->where('thesaurus_root_url',  'https://spacialist.escience.uni-tuebingen.de/<user-project>/gefassposition#20171220105434')
-                        ->where('created_at',  '2017-12-20T10:56:32.000000Z')
-                        ->where('updated_at',  '2017-12-20T10:56:32.000000Z')
-                        ->where('parent_id',  5)
-                        ->where('text',  NULL)
-                        ->where('recursive',  true)
-                        ->where('root_attribute_id', NULL)
-                        ->where('is_system', false)
-                        ->where('multiple', false)
-                        ->where('restrictions', NULL)
-                        ->where('metadata', NULL)
-                )
-                ->has('attributes.4.columns.7', fn($json) =>
-                    $json
-                        ->where('id', 7)
-                        ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440')
-                        ->where('datatype', 'string-sc')
-                        ->where('thesaurus_root_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440')
-                        ->where('created_at', '2017-12-20T10:56:32.000000Z')
-                        ->where('updated_at', '2017-12-20T10:56:32.000000Z')
-                        ->where('parent_id', 5)
-                        ->where('text', NULL)
-                        ->where('recursive', true)
-                        ->where('root_attribute_id', NULL)
-                        ->where('is_system', false)
-                        ->where('multiple', false)
-                        ->where('restrictions', NULL)
-                        ->where('metadata', NULL)
-                )
-                ->has('attributes.4.columns.8', fn($json) =>
-                    $json
-                        ->where('id', 8)
-                        ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/notizen#20171220105603')
-                        ->where('datatype', 'string')
-                        ->where('thesaurus_root_url', NULL)
-                        ->where('created_at', '2017-12-20T10:56:32.000000Z')
-                        ->where('updated_at', '2017-12-20T10:56:32.000000Z')
-                        ->where('parent_id', 5)
-                        ->where('text', NULL)
-                        ->where('recursive', true)
-                        ->where('root_attribute_id', NULL)
-                        ->where('is_system', false)
-                        ->where('multiple', false)
-                        ->where('restrictions', NULL)
-                        ->where('metadata', NULL)
-                    )
-                ->has('selections')
-        );
-    }
-
-    #[TestDox('GET /api/v1/editor/dm/attribute_types - Get all attribute types')]
-    public function testGetAttributeTypesEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/dm/attribute_types');
-
-        $attributeTypes = [
-            "boolean"       => true,
-            "date"          => true,
-            "daterange"     => true,
-            "dimension"     => false,
-            "double"        => true,
-            "string-mc"     => true,
-            "string-sc"     => true,
-            "entity"        => true,
-            "entity-mc"     => true,
-            "epoch"         => false,
-            "geography"     => true,
-            "iconclass"     => true,
-            "integer"       => true,
-            "list"          => false,
-            "percentage"    => false,
-            "richtext"      => false,
-            "rism"          => true,
-            "serial"        => false,
-            "sql"           => false,
-            "string"        => true,
-            "stringf"       => false,
-            "table"         => false,
-            "timeperiod"    => true,
-            "userlist"      => true,
-            "url"           => true,
-            "si-unit"       => true,
-        ];
-
-        $this->assertStatus($response, 200);
-        $response->assertJsonCount(count($attributeTypes));
-        $response->assertJsonStructure([
-            '*' => [
-                'datatype'
-            ]
-        ]);
-        $resultArray = [];
-        foreach($attributeTypes as $datatype => $in_table) {
-            $resultArray[] = ['datatype' => $datatype, 'in_table' => $in_table];
-        }
-
-        $response->assertSimilarJson($resultArray);
-    }
-
-    #[TestDox('GET /api/v1/editor/entity_type/{id} - Get enety type (id=3) including sub entity types')]
-    public function testGetEntityTypeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/editor/entity_type/3');
-
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure([
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        [
             'id',
             'thesaurus_url',
             'is_root',
             'created_at',
-            'updated_at',
-            'sub_entity_types'
-        ]);
-        $response->assertJsonFragment([
+            'updated_at'
+        ]
+    ]);
+    $response->assertSimilarJson([
+        [
             'id' => 3,
             'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911',
             'is_root' => true,
             'created_at' => '2017-12-20T10:03:06.000000Z',
-            'updated_at' => '2017-12-20T10:03:06.000000Z'
-        ]);
+            'updated_at' => '2017-12-20T10:03:06.000000Z',
+            'color' => '#FF0000',
+        ],
+        [
+            'id' => 7,
+            'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/lagerstatte#20171220165727',
+            'is_root' => true,
+            'created_at' => '2017-12-20T16:57:41.000000Z',
+            'updated_at' => '2017-12-20T16:57:41.000000Z',
+            'color' => '#0000FF',
+        ]
+    ]);
+});
 
-        $content = json_decode($response->getContent());
-        $subs = $content->sub_entity_types;
-        $this->assertEquals(3, $subs[0]->id);
-        $this->assertEquals(4, $subs[1]->id);
-        $this->assertEquals(5, $subs[2]->id);
-        $this->assertEquals(6, $subs[3]->id);
-        $this->assertEquals(7, $subs[4]->id);
+test('get attribute endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/attribute');
+
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(21, 'attributes');
+    $response->assertJsonStructure([
+        'attributes' => [
+            '*' => [
+                'id',
+                'thesaurus_url',
+                'datatype',
+                'text',
+                'thesaurus_root_url',
+                'parent_id',
+                'created_at',
+                'updated_at',
+                'recursive',
+                'root_attribute_id',
+                'is_system',
+                'multiple',
+                'restrictions',
+                'metadata',
+                'entity_types_count',
+            ]
+        ]
+    ]);
+    $response->assertJson(fn(AssertableJson $json) =>
+        $json
+            ->has('attributes')
+            ->has('attributes.1', fn($json) =>
+                $json
+                    ->where('id', 2)
+                    ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437')
+                    ->where( 'datatype', 'percentage')
+                    ->where('thesaurus_root_url', NULL)
+                    ->where('created_at', '2017-12-20T10:07:45.000000Z')
+                    ->where('updated_at', '2017-12-20T10:07:45.000000Z')
+                    ->where('parent_id', NULL)
+                    ->where('text', NULL)
+                    ->where('recursive', true)
+                    ->where('root_attribute_id', NULL)
+                    ->where('is_system', false)
+                    ->where('multiple', false)
+                    ->where('restrictions', NULL)
+                    ->where('metadata', NULL)
+                    ->where('entity_types_count', 1)
+            )
+            // This was originally an array keyed by index. But the backend changed
+            // to use the id as key. Idk if this is a good idea. [SO]
+            ->has('attributes.4.columns.6', fn($json) =>
+                $json
+                    ->where('id', 6)
+                    ->where('thesaurus_url',  'https://spacialist.escience.uni-tuebingen.de/<user-project>/gefassposition#20171220105434')
+                    ->where('datatype',  'string-sc')
+                    ->where('thesaurus_root_url',  'https://spacialist.escience.uni-tuebingen.de/<user-project>/gefassposition#20171220105434')
+                    ->where('created_at',  '2017-12-20T10:56:32.000000Z')
+                    ->where('updated_at',  '2017-12-20T10:56:32.000000Z')
+                    ->where('parent_id',  5)
+                    ->where('text',  NULL)
+                    ->where('recursive',  true)
+                    ->where('root_attribute_id', NULL)
+                    ->where('is_system', false)
+                    ->where('multiple', false)
+                    ->where('restrictions', NULL)
+                    ->where('metadata', NULL)
+            )
+            ->has('attributes.4.columns.7', fn($json) =>
+                $json
+                    ->where('id', 7)
+                    ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440')
+                    ->where('datatype', 'string-sc')
+                    ->where('thesaurus_root_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440')
+                    ->where('created_at', '2017-12-20T10:56:32.000000Z')
+                    ->where('updated_at', '2017-12-20T10:56:32.000000Z')
+                    ->where('parent_id', 5)
+                    ->where('text', NULL)
+                    ->where('recursive', true)
+                    ->where('root_attribute_id', NULL)
+                    ->where('is_system', false)
+                    ->where('multiple', false)
+                    ->where('restrictions', NULL)
+                    ->where('metadata', NULL)
+            )
+            ->has('attributes.4.columns.8', fn($json) =>
+                $json
+                    ->where('id', 8)
+                    ->where('thesaurus_url', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/notizen#20171220105603')
+                    ->where('datatype', 'string')
+                    ->where('thesaurus_root_url', NULL)
+                    ->where('created_at', '2017-12-20T10:56:32.000000Z')
+                    ->where('updated_at', '2017-12-20T10:56:32.000000Z')
+                    ->where('parent_id', 5)
+                    ->where('text', NULL)
+                    ->where('recursive', true)
+                    ->where('root_attribute_id', NULL)
+                    ->where('is_system', false)
+                    ->where('multiple', false)
+                    ->where('restrictions', NULL)
+                    ->where('metadata', NULL)
+                )
+            ->has('selections')
+    );
+});
+
+test('get attribute types endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/dm/attribute_types');
+
+    $attributeTypes = [
+        "boolean"       => true,
+        "date"          => true,
+        "daterange"     => true,
+        "dimension"     => false,
+        "double"        => true,
+        "string-mc"     => true,
+        "string-sc"     => true,
+        "entity"        => true,
+        "entity-mc"     => true,
+        "epoch"         => false,
+        "geography"     => true,
+        "iconclass"     => true,
+        "integer"       => true,
+        "list"          => false,
+        "percentage"    => false,
+        "richtext"      => false,
+        "rism"          => true,
+        "serial"        => false,
+        "sql"           => false,
+        "string"        => true,
+        "stringf"       => false,
+        "table"         => false,
+        "timeperiod"    => true,
+        "userlist"      => true,
+        "url"           => true,
+        "si-unit"       => true,
+    ];
+
+    $this->assertStatus($response, 200);
+    $response->assertJsonCount(count($attributeTypes));
+    $response->assertJsonStructure([
+        '*' => [
+            'datatype'
+        ]
+    ]);
+    $resultArray = [];
+    foreach($attributeTypes as $datatype => $in_table) {
+        $resultArray[] = ['datatype' => $datatype, 'in_table' => $in_table];
     }
 
-    // TODO: This seems to be deprecated, the endpoint does not exist anymore.
-    //
-    // /**
-    //  * @testdox GET /api/v1/editor/entity_type/{id}/attribute  -  Test getting attributes of an entity type (id=4) including dropdown menu selections and dependencies.
-    //  */
-    // public function testGetEntityTypeAttributesEndpoint()
-    // {
-    //     // Get an attribute (attribute_id=14) of the entity type to be tested (4);
-    //     $ea = EntityAttribute::find(9);
-    //     $ea->depends_on = '{"17": {"value": "placeholder", "operator": "=", "dependant": "14"}}';
-    //     $ea->save();
+    $response->assertSimilarJson($resultArray);
+});
 
-    //     $response = $this->userRequest()
-    //         ->get('/api/v1/editor/entity_type/4/attribute');
+test('get entity type endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/editor/entity_type/3');
 
-    //     $this->assertStatus($response, 200);
-    //     $response->assertJsonCount(3);
-    //     $response->assertJsonStructure([
-    //         'attributes' => [
-    //             [
-    //                 'id',
-    //                 'entity_type_id',
-    //                 'attribute_id',
-    //                 'position',
-    //                 'created_at',
-    //                 'updated_at'
-    //             ]
-    //         ],
-    //         'selections' => [
-    //             '*' => [
-    //                 [
-    //                     'broader_id',
-    //                     'narrower_id',
-    //                     'id',
-    //                     'concept_url',
-    //                     'concept_scheme',
-    //                     'is_top_concept',
-    //                     'user_id',
-    //                     'created_at',
-    //                     'updated_at'
-    //                 ]
-    //             ]
-    //         ],
-    //         'dependencies' => [
-    //             '*' => [
-    //                 [
-    //                     'value',
-    //                     'operator',
-    //                     'dependant'
-    //                 ]
-    //             ]
-    //         ]
-    //     ]);
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure([
+        'id',
+        'thesaurus_url',
+        'is_root',
+        'created_at',
+        'updated_at',
+        'sub_entity_types'
+    ]);
+    $response->assertJsonFragment([
+        'id' => 3,
+        'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911',
+        'is_root' => true,
+        'created_at' => '2017-12-20T10:03:06.000000Z',
+        'updated_at' => '2017-12-20T10:03:06.000000Z'
+    ]);
 
-    //     $content = json_decode($response->getContent());
-    //     $sels = $content->selections->{17};
-    //     $deps = $content->dependencies->{17};
-    //     $this->assertEquals(59, $sels[0]->id);
-    //     $this->assertEquals(60, $sels[1]->id);
-    //     $this->assertEquals(61, $sels[2]->id);
-    //     $this->assertEquals(14, $deps[0]->dependant);
-    //     $this->assertEquals('=', $deps[0]->operator);
-    //     $this->assertEquals('placeholder', $deps[0]->value);
-    // }
+    $content = json_decode($response->getContent());
+    $subs = $content->sub_entity_types;
+    expect($subs[0]->id)->toEqual(3);
+    expect($subs[1]->id)->toEqual(4);
+    expect($subs[2]->id)->toEqual(5);
+    expect($subs[3]->id)->toEqual(6);
+    expect($subs[4]->id)->toEqual(7);
+});
 
-    // TODO:: Deprecated (?)
-    //
-    // /**
-    //  * Test getting entries of a dropdown attribute (id=14).
-    //  *
-    //  * @return void
-    //  */
-    // public function testGetAttributeSelectionEndpoint()
-    // {
-    //     $response = $this->userRequest()
-    //         ->get('/api/v1/editor/attribute/14/selection');
+test('add entity type endpoint', function () {
+    $concept = ThConcept::first();
 
-    //     $this->assertStatus($response, 200);
-    //     $response->assertJsonCount(3);
-    //     $response->assertJson([
-    //         ['id' => 52],
-    //         ['id' => 53],
-    //         ['id' => 54],
-    //     ]);
-    // }
+    $response = $this->userRequest()
+        ->post('/api/v1/editor/dm/entity_type', [
+            'concept_url' => $concept->concept_url,
+            'is_root' => true,
+            'geometry_type' => 'Any'
+        ]);
 
-    // Testing POST requests
+    $entityType = EntityType::latest()->first();
 
-    #[TestDox('POST /api/v1/editor/dm/entity_type  -  Add a new entity type')]
-    public function testAddEntityTypeEndpoint()
-    {
-        $concept = ThConcept::first();
+    $this->assertStatus($response, 201);
+    $response->assertJsonStructure([
+        'id',
+        'thesaurus_url',
+        'is_root',
+        'created_at',
+        'updated_at',
+        'color',
+    ]);
 
-        $response = $this->userRequest()
-            ->post('/api/v1/editor/dm/entity_type', [
-                'concept_url' => $concept->concept_url,
-                'is_root' => true,
-                'geometry_type' => 'Any'
-            ]);
+    $response->assertJson(fn(AssertableJson $json) =>
+        $json
+            ->has('id')
+            ->has('thesaurus_url')
+            ->has('is_root')
+            ->has('created_at')
+            ->has('updated_at')
+            ->has('color')
+            ->where('id', $entityType->id)
+            ->where('thesaurus_url', $concept->concept_url)
+            ->where('is_root', true)
+            ->where('created_at', $entityType->created_at->toJSON())
+            ->where('updated_at', $entityType->updated_at->toJSON())
+            ->where('color', $entityType->color)
+    );
 
-        $entityType = EntityType::latest()->first();
+    // DISCUSS: Is this relevant anymore?
+    // $entityTypeLayer = AvailableLayer::latest()->first();
+    // $this->assertEquals($entityType->id, $entityTypeLayer->entity_type_id);
+    // $layMax = AvailableLayer::where('is_overlay', true)->max('position');
+    // $this->assertEquals($layMax+1, $entityTypeLayer->position);
+});
 
-        $this->assertStatus($response, 201);
-        $response->assertJsonStructure([
+test('add attribute endpoint', function () {
+    $concept = ThConcept::first();
+    $response = $this->userRequest()
+        ->post('/api/v1/editor/dm/attribute', [
+            'label_id' => $concept->id,
+            'datatype' => 'string-sc',
+            'root_id' => $concept->id,
+            'recursive' => false
+        ]);
+
+    $attribute = Attribute::orderBy('id', 'desc')->first();
+    $this->assertStatus($response, 201);
+    $response->assertJsonStructure([
+        'attribute' => [
             'id',
             'thesaurus_url',
-            'is_root',
+            'datatype',
+            'text',
+            'thesaurus_root_url',
+            'parent_id',
             'created_at',
             'updated_at',
-            'color',
-        ]);
+            'recursive',
+            'root_attribute_id'
+        ],
+        'selection'
+    ]);
 
-        $response->assertJson(fn(AssertableJson $json) =>
-            $json
-                ->has('id')
-                ->has('thesaurus_url')
-                ->has('is_root')
-                ->has('created_at')
-                ->has('updated_at')
-                ->has('color')
-                ->where('id', $entityType->id)
-                ->where('thesaurus_url', $concept->concept_url)
-                ->where('is_root', true)
-                ->where('created_at', $entityType->created_at->toJSON())
-                ->where('updated_at', $entityType->updated_at->toJSON())
-                ->where('color', $entityType->color)
-        );
+    $response->assertJson(fn(AssertableJson $json) =>
+        $json
+            ->has('attribute', fn($json) =>
+                $json
+                    ->has("id")
+                    ->has('thesaurus_url')
+                    ->has('datatype')
+                    ->has('text')
+                    ->has('thesaurus_root_url')
+                    ->has('parent_id')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->has('recursive')
+                    ->has('root_attribute_id')
+                    ->has('is_system')
+                    ->has('multiple')
+                    ->has('restrictions')
+                    ->has('metadata')
+                    ->has('columns')
+                    ->where('thesaurus_url', $concept->concept_url)
+                    ->where('datatype', 'string-sc')
+                    ->where('text', null)
+                    ->where('thesaurus_root_url', $concept->concept_url)
+                    ->where('parent_id', null)
+                    ->where('created_at', $attribute->created_at->toJSON())
+                    ->where('updated_at', $attribute->updated_at->toJSON())
+                    ->where('recursive', false)
+                    ->where('root_attribute_id', null)
+                    ->where('is_system', false)
+                    ->where('multiple', false)
+                    ->where('restrictions', null)
+                    ->where('metadata', null)
+                    ->where('columns', [])
+            )
+            ->has('selection.0', fn($json) =>
+                $json
+                    ->has('id')
+                    ->has('concept_scheme')
+                    ->has('concept_url')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->has('is_top_concept')
+                    ->has('narrower_id')
+                    ->has('broader_id')
+                    ->has('user_id')
+                    ->where('id', 48)
+            )
+            ->has('selection.1', fn($json) =>
+                $json
+                    ->has('id')
+                    ->has('concept_scheme')
+                    ->has('concept_url')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->has('is_top_concept')
+                    ->has('narrower_id')
+                    ->has('broader_id')
+                    ->has('user_id')
+                    ->where('id', 62)
+            )
+    );
+});
 
-        // DISCUSS: Is this relevant anymore?
-        // $entityTypeLayer = AvailableLayer::latest()->first();
-        // $this->assertEquals($entityType->id, $entityTypeLayer->entity_type_id);
-
-        // $layMax = AvailableLayer::where('is_overlay', true)->max('position');
-        // $this->assertEquals($layMax+1, $entityTypeLayer->position);
-    }
-
-    // TODO check if necessary to replace old set relation logic with new logic in EditorController::patchEntityType
-    // /**
-    // * @testdox POST /api/v1/editor/dm/{id}/relation  -  Modify entity type relations
-    // */
-    // public function testModifyingEntityTypeRelation() {
-    //     $id = 4;
-    //     $response = $this->userRequest()
-    //         ->post("/api/v1/editor/dm/$id/relation", [
-    //             'is_root' => false,
-    //             'sub_entity_types' => [
-    //                 3, 6, 7
-    //             ]
-    //         ]);
-    // }
-
-    // /**
-    // * @testdox POST /api/v1/editor/dm/{id}/relation  -  Modify entity type relations
-    // */
-    // public function testModifyingEntityTypeRelation() {
-    //     $id = 4;
-    //     $response = $this->userRequest()
-    //         ->post("/api/v1/editor/dm/$id/relation", [
-    //             'is_root' => false,
-    //             'sub_entity_types' => [
-    //                 3, 6, 7
-    //             ]
-    //         ]);
-
-    //     $this->assertStatus($response, 204);
-
-    //     $entityType = EntityType::find($id)->load('sub_entity_types');
-    //     $this->assertTrue(!$entityType->is_root);
-    //     $this->assertArraySubset([
-    //         ['id' => 3],
-    //         ['id' => 6],
-    //         ['id' => 7]
-    //     ], $entityType->sub_entity_types->toArray());
-    // }
-
-    #[TestDox('POST /api/v1/editor/dm/attribute  -  Test adding a new entity type and modifying it\'s relations afterwards.')]
-    public function testAddAttributeEndpoint()
-    {
-        $concept = ThConcept::first();
-        $response = $this->userRequest()
-            ->post('/api/v1/editor/dm/attribute', [
-                'label_id' => $concept->id,
-                'datatype' => 'string-sc',
-                'root_id' => $concept->id,
-                'recursive' => false
-            ]);
-
-        $attribute = Attribute::orderBy('id', 'desc')->first();
-        $this->assertStatus($response, 201);
-        $response->assertJsonStructure([
-            'attribute' => [
-                'id',
-                'thesaurus_url',
-                'datatype',
-                'text',
-                'thesaurus_root_url',
-                'parent_id',
-                'created_at',
-                'updated_at',
-                'recursive',
-                'root_attribute_id'
-            ],
-            'selection'
-        ]);
-
-        $response->assertJson(fn(AssertableJson $json) =>
-            $json
-                ->has('attribute', fn($json) =>
-                    $json
-                        ->has("id")
-                        ->has('thesaurus_url')
-                        ->has('datatype')
-                        ->has('text')
-                        ->has('thesaurus_root_url')
-                        ->has('parent_id')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->has('recursive')
-                        ->has('root_attribute_id')
-                        ->has('is_system')
-                        ->has('multiple')
-                        ->has('restrictions')
-                        ->has('metadata')
-                        ->has('columns')
-                        ->where('thesaurus_url', $concept->concept_url)
-                        ->where('datatype', 'string-sc')
-                        ->where('text', null)
-                        ->where('thesaurus_root_url', $concept->concept_url)
-                        ->where('parent_id', null)
-                        ->where('created_at', $attribute->created_at->toJSON())
-                        ->where('updated_at', $attribute->updated_at->toJSON())
-                        ->where('recursive', false)
-                        ->where('root_attribute_id', null)
-                        ->where('is_system', false)
-                        ->where('multiple', false)
-                        ->where('restrictions', null)
-                        ->where('metadata', null)
-                        ->where('columns', [])
-                )
-                ->has('selection.0', fn($json) =>
-                    $json
-                        ->has('id')
-                        ->has('concept_scheme')
-                        ->has('concept_url')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->has('is_top_concept')
-                        ->has('narrower_id')
-                        ->has('broader_id')
-                        ->has('user_id')
-                        ->where('id', 48)
-                )
-                ->has('selection.1', fn($json) =>
-                    $json
-                        ->has('id')
-                        ->has('concept_scheme')
-                        ->has('concept_url')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->has('is_top_concept')
-                        ->has('narrower_id')
-                        ->has('broader_id')
-                        ->has('user_id')
-                        ->where('id', 62)
-                )
-        );
-    }
-
-    #[TestDox('POST /api/v1/editor/dm/entity_type/{id}/attribute  -  Adding attributes to an entity type (id=3).')]
-    public function testAddAttributeToEntityTypeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->post('/api/v1/editor/dm/entity_type/3/attribute', [
-                'attribute_id' => 2,
-                'position' => 1
-            ]);
-
-        $this->assertStatus($response, 201);
-        $response->assertJsonStructure([
-            'id',
-            'entity_type_id',
-            'attribute_id',
-            'position',
-            'depends_on',
-            'created_at',
-            'updated_at',
-            'attribute' => [
-                'id',
-                'thesaurus_url',
-                'datatype',
-                'text',
-                'thesaurus_root_url',
-                'parent_id',
-                'created_at',
-                'updated_at',
-                'recursive',
-                'root_attribute_id'
-            ]
-        ]);
-        $response->assertJson([
-            'entity_type_id' => 3,
+test('add attribute to entity type endpoint', function () {
+    $response = $this->userRequest()
+        ->post('/api/v1/editor/dm/entity_type/3/attribute', [
             'attribute_id' => 2,
-            'position' => 1,
-            'depends_on' => null,
-            'attribute' => [
-                'id' => 2,
-                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437',
-                'datatype' => 'percentage',
-                'text' => null,
-                'thesaurus_root_url' => null,
-                'parent_id' => null,
-                'recursive' => true,
-                'root_attribute_id' => null
-            ]
+            'position' => 1
         ]);
 
-        $response = $this->userRequest()
-            ->post('/api/v1/editor/dm/entity_type/3/attribute', [
-                'attribute_id' => 3
-            ]);
-        $this->assertStatus($response, 201);
-        $response->assertJsonStructure([
-            'id',
-            'entity_type_id',
-            'attribute_id',
-            'position',
-            'depends_on',
-            'created_at',
-            'updated_at',
-            'attribute' => [
-                'id',
-                'thesaurus_url',
-                'datatype',
-                'text',
-                'thesaurus_root_url',
-                'parent_id',
-                'created_at',
-                'updated_at',
-                'recursive',
-                'root_attribute_id'
-            ]
-        ]);
-        $response->assertJson([
-            'entity_type_id' => 3,
-            'attribute_id' => 3,
-            'position' => 9,
-            'depends_on' => null,
-            'attribute' => [
-                'id' => 3,
-                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/farbe#20171220100506',
-                'datatype' => 'string-mc',
-                'text' => null,
-                'thesaurus_root_url' => null,
-                'parent_id' => null,
-                'recursive' => true,
-                'root_attribute_id' => null
-            ]
-        ]);
-    }
-
-    #[TestDox('POST /api/v1/editor/dm/entity_type/{id}/duplicate  -  Duplicating an entity type (id=3).')]
-    public function testDuplicateEntityTypeEndpoint()
-    {
-        $entityType = EntityType::find(3)->load('sub_entity_types');
-        $layMax = AvailableLayer::where('is_overlay', true)->max('position');
-        $response = $this->userRequest()
-            ->post('/api/v1/editor/dm/entity_type/3/duplicate');
-
-        $newEntityType = EntityType::latest()->first();
-
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure([
+    $this->assertStatus($response, 201);
+    $response->assertJsonStructure([
+        'id',
+        'entity_type_id',
+        'attribute_id',
+        'position',
+        'depends_on',
+        'created_at',
+        'updated_at',
+        'attribute' => [
             'id',
             'thesaurus_url',
-            'is_root',
+            'datatype',
+            'text',
+            'thesaurus_root_url',
+            'parent_id',
             'created_at',
             'updated_at',
-            'sub_entity_types'
+            'recursive',
+            'root_attribute_id'
+        ]
+    ]);
+    $response->assertJson([
+        'entity_type_id' => 3,
+        'attribute_id' => 2,
+        'position' => 1,
+        'depends_on' => null,
+        'attribute' => [
+            'id' => 2,
+            'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437',
+            'datatype' => 'percentage',
+            'text' => null,
+            'thesaurus_root_url' => null,
+            'parent_id' => null,
+            'recursive' => true,
+            'root_attribute_id' => null
+        ]
+    ]);
+
+    $response = $this->userRequest()
+        ->post('/api/v1/editor/dm/entity_type/3/attribute', [
+            'attribute_id' => 3
         ]);
-        $response->assertJson([
-            'id' => $newEntityType->id,
-            'thesaurus_url' => $entityType->thesaurus_url,
-            'is_root' => $entityType->is_root,
-            'created_at' => $newEntityType->created_at->toJSON(),
-            'updated_at' => $newEntityType->updated_at->toJSON()
+    $this->assertStatus($response, 201);
+    $response->assertJsonStructure([
+        'id',
+        'entity_type_id',
+        'attribute_id',
+        'position',
+        'depends_on',
+        'created_at',
+        'updated_at',
+        'attribute' => [
+            'id',
+            'thesaurus_url',
+            'datatype',
+            'text',
+            'thesaurus_root_url',
+            'parent_id',
+            'created_at',
+            'updated_at',
+            'recursive',
+            'root_attribute_id'
+        ]
+    ]);
+    $response->assertJson([
+        'entity_type_id' => 3,
+        'attribute_id' => 3,
+        'position' => 9,
+        'depends_on' => null,
+        'attribute' => [
+            'id' => 3,
+            'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/farbe#20171220100506',
+            'datatype' => 'string-mc',
+            'text' => null,
+            'thesaurus_root_url' => null,
+            'parent_id' => null,
+            'recursive' => true,
+            'root_attribute_id' => null
+        ]
+    ]);
+});
+
+test('duplicate entity type endpoint', function () {
+    $entityType = EntityType::find(3)->load('sub_entity_types');
+    $layMax = AvailableLayer::where('is_overlay', true)->max('position');
+    $response = $this->userRequest()
+        ->post('/api/v1/editor/dm/entity_type/3/duplicate');
+
+    $newEntityType = EntityType::latest()->first();
+
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure([
+        'id',
+        'thesaurus_url',
+        'is_root',
+        'created_at',
+        'updated_at',
+        'sub_entity_types'
+    ]);
+    $response->assertJson([
+        'id' => $newEntityType->id,
+        'thesaurus_url' => $entityType->thesaurus_url,
+        'is_root' => $entityType->is_root,
+        'created_at' => $newEntityType->created_at->toJSON(),
+        'updated_at' => $newEntityType->updated_at->toJSON()
+    ]);
+
+    $content = json_decode($response->getContent());
+    $etSubTypeIds = $entityType->sub_entity_types->pluck('id');
+    expect(count($content->sub_entity_types))->toEqual(count($etSubTypeIds));
+});
+
+test('edit entity type endpoint', function () {
+    $entityType = EntityType::find(3);
+    expect($entityType->thesaurus_url)->toEqual('https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911');
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/3', [
+            'data' => [
+                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437'
+            ]
         ]);
 
-        $content = json_decode($response->getContent());
-        $etSubTypeIds = $entityType->sub_entity_types->pluck('id');
-        $this->assertEquals(count($etSubTypeIds), count($content->sub_entity_types));
-    }
+    $this->assertStatus($response, 200);
 
-    #[TestDox('PATCH /api/v1/editor/dm/entity_type/{id}  -  Editing an entity type (id=3).')]
-    public function testEditEntityTypeEndpoint()
-    {
-        $entityType = EntityType::find(3);
-        $this->assertEquals('https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911', $entityType->thesaurus_url);
+    $entityType = EntityType::find(3);
+    expect($entityType->thesaurus_url)->toEqual('https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437');
+});
 
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/3', [
-                'data' => [
-                    'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437'
-                ]
-            ]);
-
-        $this->assertStatus($response, 200);
-
-        $entityType = EntityType::find(3);
-        $this->assertEquals('https://spacialist.escience.uni-tuebingen.de/<user-project>/erhaltung#20171220100437', $entityType->thesaurus_url);
-    }
-
-    #[TestDox('PATCH /api/v1/editor/dm/entity_type/{id}/attribute/{aid}/position  -   Test reordering attributes of an entity type (id=4).')]
-    public function testRoorderEntityTypeAttributesEndpoint()
-    {
-        $entityType = EntityType::find(3)->load('attributes');
-        foreach($entityType->attributes as $a) {
-            if($a->attribute_id == 14) {
-                $this->assertEquals(1, $a->pivot->position);
-            } else if($a->attribute_id == 16) {
-                $this->assertEquals(2, $a->pivot->position);
-            } else if($a->attribute_id == 17) {
-                $this->assertEquals(3, $a->pivot->position);
-            } else if($a->attribute_id == 10) {
-                $this->assertEquals(4, $a->pivot->position);
-            } else if($a->attribute_id == 13) {
-                $this->assertEquals(5, $a->pivot->position);
-            }
-        }
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/position', [
-                'position' => 4
-            ]);
-
-        $this->assertStatus($response, 204);
-
-        $entityType = EntityType::find(3)->load('attributes');
-        foreach($entityType->attributes as $a) {
-            if($a->attribute_id == 14) {
-                $this->assertEquals(4, $a->pivot->position);
-            } else if($a->attribute_id == 16) {
-                $this->assertEquals(1, $a->pivot->position);
-            } else if($a->attribute_id == 17) {
-                $this->assertEquals(2, $a->pivot->position);
-            } else if($a->attribute_id == 10) {
-                $this->assertEquals(3, $a->pivot->position);
-            } else if($a->attribute_id == 13) {
-                $this->assertEquals(5, $a->pivot->position);
-            }
-        }
-
-        // Testing again with higher position
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/4/attribute/13/position', [
-                'position' => 1
-            ]);
-
-        $this->assertStatus($response, 204);
-
-        $entityType = EntityType::find(3)->load('attributes');
-        foreach($entityType->attributes as $a) {
-            if($a->attribute_id == 14) {
-                $this->assertEquals(5, $a->pivot->position);
-            } else if($a->attribute_id == 16) {
-                $this->assertEquals(2, $a->pivot->position);
-            } else if($a->attribute_id == 17) {
-                $this->assertEquals(3, $a->pivot->position);
-            } else if($a->attribute_id == 10) {
-                $this->assertEquals(4, $a->pivot->position);
-            } else if($a->attribute_id == 13) {
-                $this->assertEquals(1, $a->pivot->position);
-            }
-        }
-
-        // Testing again with same position (nothing should happen)
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/position', [
-                'position' => 4
-            ]);
-
-        $this->assertStatus($response, 204);
-
-        $entityType = EntityType::find(3)->load('attributes');
-        foreach($entityType->attributes as $a) {
-            if($a->attribute_id == 14) {
-                $this->assertEquals(4, $a->pivot->position);
-            } else if($a->attribute_id == 16) {
-                $this->assertEquals(1, $a->pivot->position);
-            } else if($a->attribute_id == 17) {
-                $this->assertEquals(2, $a->pivot->position);
-            } else if($a->attribute_id == 10) {
-                $this->assertEquals(3, $a->pivot->position);
-            } else if($a->attribute_id == 13) {
-                $this->assertEquals(5, $a->pivot->position);
-            }
+test('roorder entity type attributes endpoint', function () {
+    $entityType = EntityType::find(3)->load('attributes');
+    foreach($entityType->attributes as $a) {
+        if($a->attribute_id == 14) {
+            expect($a->pivot->position)->toEqual(1);
+        } else if($a->attribute_id == 16) {
+            expect($a->pivot->position)->toEqual(2);
+        } else if($a->attribute_id == 17) {
+            expect($a->pivot->position)->toEqual(3);
+        } else if($a->attribute_id == 10) {
+            expect($a->pivot->position)->toEqual(4);
+        } else if($a->attribute_id == 13) {
+            expect($a->pivot->position)->toEqual(5);
         }
     }
 
-    #[TestDox('PATCH /api/v1/editor/dm/entity_type/{id}/attribute/{aid}/dependency  -   Test adding dependency to an attribute of an entity type (id=4).')]
-    public function testAddDependencyToEntiyTypeAttributeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/dependency', [
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/position', [
+            'position' => 4
+        ]);
+
+    $this->assertStatus($response, 204);
+
+    $entityType = EntityType::find(3)->load('attributes');
+    foreach($entityType->attributes as $a) {
+        if($a->attribute_id == 14) {
+            expect($a->pivot->position)->toEqual(4);
+        } else if($a->attribute_id == 16) {
+            expect($a->pivot->position)->toEqual(1);
+        } else if($a->attribute_id == 17) {
+            expect($a->pivot->position)->toEqual(2);
+        } else if($a->attribute_id == 10) {
+            expect($a->pivot->position)->toEqual(3);
+        } else if($a->attribute_id == 13) {
+            expect($a->pivot->position)->toEqual(5);
+        }
+    }
+
+    // Testing again with higher position
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/4/attribute/13/position', [
+            'position' => 1
+        ]);
+
+    $this->assertStatus($response, 204);
+
+    $entityType = EntityType::find(3)->load('attributes');
+    foreach($entityType->attributes as $a) {
+        if($a->attribute_id == 14) {
+            expect($a->pivot->position)->toEqual(5);
+        } else if($a->attribute_id == 16) {
+            expect($a->pivot->position)->toEqual(2);
+        } else if($a->attribute_id == 17) {
+            expect($a->pivot->position)->toEqual(3);
+        } else if($a->attribute_id == 10) {
+            expect($a->pivot->position)->toEqual(4);
+        } else if($a->attribute_id == 13) {
+            expect($a->pivot->position)->toEqual(1);
+        }
+    }
+
+    // Testing again with same position (nothing should happen)
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/position', [
+            'position' => 4
+        ]);
+
+    $this->assertStatus($response, 204);
+
+    $entityType = EntityType::find(3)->load('attributes');
+    foreach($entityType->attributes as $a) {
+        if($a->attribute_id == 14) {
+            expect($a->pivot->position)->toEqual(4);
+        } else if($a->attribute_id == 16) {
+            expect($a->pivot->position)->toEqual(1);
+        } else if($a->attribute_id == 17) {
+            expect($a->pivot->position)->toEqual(2);
+        } else if($a->attribute_id == 10) {
+            expect($a->pivot->position)->toEqual(3);
+        } else if($a->attribute_id == 13) {
+            expect($a->pivot->position)->toEqual(5);
+        }
+    }
+});
+
+test('add dependency to entiy type attribute endpoint', function () {
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/dependency', [
+            'data' => [
+                'or' => false,
+                'groups' => [
+                    [
+                        'or' => true,
+                        'rules' => [
+                            [
+                                'attribute' => 13,
+                                'operator' => '=',
+                                'value' => 'Test Value'
+                            ],
+                        ],
+                    ]
+                ],
+            ],
+        ]);
+
+    $this->assertStatus($response, 200);
+
+    $entityAttribute = EntityAttribute::for(4, 14);
+    expect($entityAttribute)->toHaveKey('depends_on');
+    expect($entityAttribute->depends_on)->toEqual([
+        'or' => false,
+        'groups' => [
+            [
+                'or' => true,
+                'rules' => [
+                    [
+                        'operator' => '=',
+                        'value' => 'Test Value',
+                        'on' => 13,
+                    ],
+                ],
+            ]
+        ],
+    ]);
+});
+
+test('add empty dependency to entiy type attribute endpoint', function () {
+    $response = $this->userRequest()
+        ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/dependency', [
+            'data' => [
+                'or' => false,
+                'groups' => [],
+            ],
+        ]);
+
+    $this->assertStatus($response, 200);
+
+    $entityAttribute = EntityAttribute::for(4, 14);
+    expect($entityAttribute->depends_on)->toBeNull();
+});
+
+test('delete entity type endpoint', function () {
+    $etCnt = EntityType::count();
+    expect($etCnt)->toEqual(5);
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(29);
+    $eCnt = Entity::count();
+    expect($eCnt)->toEqual(8);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(31);
+
+    $response = $this->userRequest()
+        ->delete('/api/v1/editor/dm/entity_type/4');
+
+    $this->assertStatus($response, 204);
+
+    $etCnt = EntityType::count();
+    expect($etCnt)->toEqual(4);
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(23);
+    $eCnt = Entity::count();
+    expect($eCnt)->toEqual(4);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(11);
+});
+
+test('delete attribute endpoint', function () {
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(29);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(31);
+    $aCnt = Attribute::count();
+    expect($aCnt)->toEqual(24);
+
+    $response = $this->userRequest()
+        ->delete('/api/v1/editor/dm/attribute/12');
+
+    $this->assertStatus($response, 204);
+
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(27);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(27);
+    $aCnt = Attribute::count();
+    expect($aCnt)->toEqual(23);
+});
+
+test('delete attribute from entity type endpoint', function () {
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(29);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(31);
+    $entityType = EntityType::find(5)->load('attributes');
+
+    $oldPositions = [12, 9, 11, 2, 3, 5, 19, 4, 13];
+    foreach($entityType->attributes as $entityType) {
+        foreach($oldPositions as $index => $position) {
+            if($entityType->id == $position) {
+                expect($entityType->pivot->position)->toEqual($index+1);
+                break;
+            }
+        }
+    }
+
+    $entityAttribute = EntityAttribute::for(5, 11);
+    $response = $this->userRequest()
+        ->delete("/api/v1/editor/dm/entity_type/attribute/$entityAttribute->id");
+
+    $this->assertStatus($response, 204);
+
+    $eaCnt = EntityAttribute::count();
+    expect($eaCnt)->toEqual(28);
+    $avCnt = AttributeValue::count();
+    expect($avCnt)->toEqual(28);
+    $entityType = EntityType::find(5)->load('attributes');
+    $newPositions = [12, 9, 2, 3, 5, 19, 4, 13];
+    foreach($entityType->attributes as $entityType) {
+        foreach($newPositions as $index => $position) {
+            if($entityType->id == $position) {
+                expect($entityType->pivot->position)->toEqual($index+1);
+                break;
+            }
+        }
+    }
+});
+
+test('without permission', function ($permission) {
+    (new ResponseTester($this))->testMissingPermission($permission);
+})->with('permissionsProvider');
+
+test('exceptions', function ($permission) {
+    (new ResponseTester($this))->testExceptions($permission);
+})->with('exceptionsProvider');
+
+dataset('permissionsProvider', function () {
+    return [
+        'permission to get entity type'                        => Permission::for("get", "/api/v1/editor/entity_type/1",           "You do not have the permission to get an entity type's data"),
+        'permission to view entity data on top entity types'   => Permission::for("get", "/api/v1/editor/dm/entity_type/top",      "You do not have the permission to view entity data"),
+        'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/dm/attribute",           "You do not have the permission to view entity data"),
+        'permission to create entity type'                     => Permission::for("post", "/api/v1/editor/dm/entity_type",        "You do not have the permission to create a new entity type"),
+        // TODO check if necessary to replace old set relation logic with new logic in EditorController::patchEntityType
+        // 'permission to modify entity relations'                => Permission::for("post", "/api/v1/editor/dm/1/relation",     "You do not have the permission to modify entity relations"),
+        'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/entity_type/1/attribute", "You do not have the permission to view entity data"),
+        'permission to view entity data on top entity types'   => Permission::for("get", "/api/v1/editor/dm/entity_type/top",      "You do not have the permission to view entity data"),
+        'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/dm/attribute",           "You do not have the permission to view entity data"),
+        'permission to create entity type'                     => Permission::for("post", "/api/v1/editor/dm/entity_type",        "You do not have the permission to create a new entity type"),
+        'permission to add attributes'                         => Permission::for("post", "/api/v1/editor/dm/attribute",          "You do not have the permission to add attributes",[
+                'label_id' => 1,
+                'datatype' => 'string-sc',
+                'root_id' => 1,
+                'recursive' => false
+        ]),
+        'permission to add attributes to an entity type'    => Permission::for("post", "/api/v1/editor/dm/entity_type/1/attribute", "You do not have the permission to add attributes to an entity type"),
+        'permission to duplicate an entity type'            => Permission::for("post", "/api/v1/editor/dm/entity_type/1/duplicate", "You do not have the permission to duplicate an entity type"),
+        'permission to modify entity-type'                  => Permission::for("patch", "/api/v1/editor/dm/entity_type/1", "You do not have the permission to modify entity-type",[
+            'data' => [
+                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911'
+            ]
+        ]),
+        'permission to reorder attributes'                     => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/1/position", "You do not have the permission to reorder attributes"),
+        'permission to add/modify attribute dependencies'      => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/1/dependency", "You do not have the permission to add/modify attribute dependencies", [
                 'data' => [
                     'or' => false,
                     'groups' => [
@@ -790,290 +797,106 @@ class ApiEditorTest extends TestCase
                             'or' => true,
                             'rules' => [
                                 [
-                                    'attribute' => 13,
+                                    'attribute' => 15,
                                     'operator' => '=',
-                                    'value' => 'Test Value'
+                                    'value' => 'NoValue',
                                 ],
                             ],
                         ]
                     ],
                 ],
-            ]);
+            ]),
+        'permission to edit metadata of an attribute'                    => Permission::for("patch", "/api/v1/editor/dm/entity_type/attribute/1/metadata", "You do not have the permission to edit attribute names"),
+        'permission to delete entity types'                    => Permission::for("delete", "/api/v1/editor/dm/entity_type/1", "You do not have the permission to delete entity types"),
+        'permission to delete attributes'                      => Permission::for("delete", "/api/v1/editor/dm/attribute/1", "You do not have the permission to delete attributes"),
+        'permission to remove attributes from entity types'    => Permission::for("delete", "/api/v1/editor/dm/entity_type/attribute/19", "You do not have the permission to remove attributes from entity types"),
+    ];
+});
 
-        $this->assertStatus($response, 200);
+dataset('exceptionsProvider', function () {
+    $entityDoesNotExist = "This entity-type does not exist";
+    $entityAttributeNotFound = "Entity Attribute not found";
+    $attributeDoesNotExist = "This attribute does not exist";
+    $attributeAlreadyAdded = "This attribute already exists on this entity-type";
 
-        $entityAttribute = EntityAttribute::for(4, 14);
-        $this->assertArrayHasKey('depends_on', $entityAttribute);
-        $this->assertEquals([
-            'or' => false,
-            'groups' => [
-                [
-                    'or' => true,
-                    'rules' => [
-                        [
-                            'operator' => '=',
-                            'value' => 'Test Value',
-                            'on' => 13,
-                        ],
-                    ],
-                ]
-            ],
-        ], $entityAttribute->depends_on);
-    }
-
-    #[TestDox('PATCH /api/v1/editor/dm/entity_type/{id}/attribute/{aid}/dependency  -   Test adding dependency without data to an attribute of an entity type (id=4).')]
-    public function testAddEmptyDependencyToEntiyTypeAttributeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->patch('/api/v1/editor/dm/entity_type/4/attribute/14/dependency', [
+    return [
+        'exception on get entity type'                         => Permission::for("get", "/api/v1/editor/entity_type/99", $entityDoesNotExist),
+        'exception on view entity data'                        => Permission::for("post", "/api/v1/editor/dm/entity_type/99/attribute", $entityDoesNotExist,[
+            'attribute_id' => 2,
+            'position' => 1
+        ]),
+        // TODO check if necessary to replace old set relation logic with new logic in EditorController::patchEntityType
+        // 'exception on modify entity relations'                 => Permission::for("post", "/api/v1/editor/dm/99/relation", $entityDoesNotExist),
+        'exception on add attributes to an entity type'        => Permission::for("post", "/api/v1/editor/dm/entity_type/99/attribute", $entityDoesNotExist,[
+            'attribute_id' => 2,
+            'position' => 1
+        ]),
+        'exception on add already added attribute'             => Permission::for("post", "/api/v1/editor/dm/entity_type/3/attribute", $attributeAlreadyAdded,[
+            'attribute_id' => 15,
+            'position' => 1
+        ]),
+        'exception on duplicate an entity type'                => Permission::for("post", "/api/v1/editor/dm/entity_type/99/duplicate", $entityDoesNotExist),
+        'exception on modify entity-type'                      => Permission::for("patch", "/api/v1/editor/dm/entity_type/99", $entityDoesNotExist,[
+            'data' => [
+                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911'
+            ]
+        ]),
+        'exception on reorder attributes'                      => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/99/position", $entityAttributeNotFound, [
+            'position' => 1
+        ]),
+        'exception on add/modify attribute dependencies'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/99/dependency", $entityAttributeNotFound, [
                 'data' => [
                     'or' => false,
-                    'groups' => [],
-                ],
-            ]);
-
-        $this->assertStatus($response, 200);
-
-        $entityAttribute = EntityAttribute::for(4, 14);
-        $this->assertNull($entityAttribute->depends_on);
-    }
-
-    #[TestDox('DELETE /api/v1/editor/dm/entity_type/{id}  -   Test deleting an entity type (id=4).')]
-    public function testDeleteEntityTypeEndpoint()
-    {
-        $etCnt = EntityType::count();
-        $this->assertEquals(5, $etCnt);
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(29, $eaCnt);
-        $eCnt = Entity::count();
-        $this->assertEquals(8, $eCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(31, $avCnt);
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/editor/dm/entity_type/4');
-
-        $this->assertStatus($response, 204);
-
-        $etCnt = EntityType::count();
-        $this->assertEquals(4, $etCnt);
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(23, $eaCnt);
-        $eCnt = Entity::count();
-        $this->assertEquals(4, $eCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(11, $avCnt);
-    }
-
-     #[TestDox('DELETE /api/v1/editor/dm/attribute/{id}  -  Test deleting an attribute (id=12).')]
-    public function testDeleteAttributeEndpoint()
-    {
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(29, $eaCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(31, $avCnt);
-        $aCnt = Attribute::count();
-        $this->assertEquals(24, $aCnt);
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/editor/dm/attribute/12');
-
-        $this->assertStatus($response, 204);
-
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(27, $eaCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(27, $avCnt);
-        $aCnt = Attribute::count();
-        $this->assertEquals(23, $aCnt);
-    }
-
-     #[TestDox('DELETE /api/v1/editor/dm/entity_type/{id}/attribute/{aid}  -  Test deleting an attribute (id=11) from an entity type (id=5).')]
-    public function testDeleteAttributeFromEntityTypeEndpoint()
-    {
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(29, $eaCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(31, $avCnt);
-        $entityType = EntityType::find(5)->load('attributes');
-
-        $oldPositions = [12, 9, 11, 2, 3, 5, 19, 4, 13];
-        foreach($entityType->attributes as $entityType) {
-            foreach($oldPositions as $index => $position) {
-                if($entityType->id == $position) {
-                    $this->assertEquals($index+1, $entityType->pivot->position);
-                    break;
-                }
-            }
-        }
-
-        $entityAttribute = EntityAttribute::for(5, 11);
-        $response = $this->userRequest()
-            ->delete("/api/v1/editor/dm/entity_type/attribute/$entityAttribute->id");
-
-        $this->assertStatus($response, 204);
-
-        $eaCnt = EntityAttribute::count();
-        $this->assertEquals(28, $eaCnt);
-        $avCnt = AttributeValue::count();
-        $this->assertEquals(28, $avCnt);
-        $entityType = EntityType::find(5)->load('attributes');
-        $newPositions = [12, 9, 2, 3, 5, 19, 4, 13];
-        foreach($entityType->attributes as $entityType) {
-            foreach($newPositions as $index => $position) {
-                if($entityType->id == $position) {
-                    $this->assertEquals($index+1, $entityType->pivot->position);
-                    break;
-                }
-            }
-        }
-    }
-
-    #[DataProvider('permissionsProvider')]
-    public function testWithoutPermission($permission) {
-        (new ResponseTester($this))->testMissingPermission($permission);
-    }
-
-    #[DataProvider('exceptionsProvider')]
-    public function testExceptions($permission) {
-        (new ResponseTester($this))->testExceptions($permission);
-    }
-
-    public static function permissionsProvider() {
-        return [
-            'permission to get entity type'                        => Permission::for("get", "/api/v1/editor/entity_type/1",           "You do not have the permission to get an entity type's data"),
-            'permission to view entity data on top entity types'   => Permission::for("get", "/api/v1/editor/dm/entity_type/top",      "You do not have the permission to view entity data"),
-            'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/dm/attribute",           "You do not have the permission to view entity data"),
-            'permission to create entity type'                     => Permission::for("post", "/api/v1/editor/dm/entity_type",        "You do not have the permission to create a new entity type"),
-            // TODO check if necessary to replace old set relation logic with new logic in EditorController::patchEntityType
-            // 'permission to modify entity relations'                => Permission::for("post", "/api/v1/editor/dm/1/relation",     "You do not have the permission to modify entity relations"),
-            'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/entity_type/1/attribute", "You do not have the permission to view entity data"),
-            'permission to view entity data on top entity types'   => Permission::for("get", "/api/v1/editor/dm/entity_type/top",      "You do not have the permission to view entity data"),
-            'permission to view entity data'                       => Permission::for("get", "/api/v1/editor/dm/attribute",           "You do not have the permission to view entity data"),
-            'permission to create entity type'                     => Permission::for("post", "/api/v1/editor/dm/entity_type",        "You do not have the permission to create a new entity type"),
-            'permission to add attributes'                         => Permission::for("post", "/api/v1/editor/dm/attribute",          "You do not have the permission to add attributes",[
-                    'label_id' => 1,
-                    'datatype' => 'string-sc',
-                    'root_id' => 1,
-                    'recursive' => false
-            ]),
-            'permission to add attributes to an entity type'    => Permission::for("post", "/api/v1/editor/dm/entity_type/1/attribute", "You do not have the permission to add attributes to an entity type"),
-            'permission to duplicate an entity type'            => Permission::for("post", "/api/v1/editor/dm/entity_type/1/duplicate", "You do not have the permission to duplicate an entity type"),
-            'permission to modify entity-type'                  => Permission::for("patch", "/api/v1/editor/dm/entity_type/1", "You do not have the permission to modify entity-type",[
-                'data' => [
-                    'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911'
-                ]
-            ]),
-            'permission to reorder attributes'                     => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/1/position", "You do not have the permission to reorder attributes"),
-            'permission to add/modify attribute dependencies'      => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/1/dependency", "You do not have the permission to add/modify attribute dependencies", [
-                    'data' => [
-                        'or' => false,
-                        'groups' => [
-                            [
-                                'or' => true,
-                                'rules' => [
-                                    [
-                                        'attribute' => 15,
-                                        'operator' => '=',
-                                        'value' => 'NoValue',
-                                    ],
+                    'groups' => [
+                        [
+                            'or' => true,
+                            'rules' => [
+                                [
+                                    'attribute' => 15,
+                                    'operator' => '=',
+                                    'value' => 'NoValue',
                                 ],
-                            ]
-                        ],
+                            ],
+                        ]
                     ],
-                ]),
-            'permission to edit metadata of an attribute'                    => Permission::for("patch", "/api/v1/editor/dm/entity_type/attribute/1/metadata", "You do not have the permission to edit attribute names"),
-            'permission to delete entity types'                    => Permission::for("delete", "/api/v1/editor/dm/entity_type/1", "You do not have the permission to delete entity types"),
-            'permission to delete attributes'                      => Permission::for("delete", "/api/v1/editor/dm/attribute/1", "You do not have the permission to delete attributes"),
-            'permission to remove attributes from entity types'    => Permission::for("delete", "/api/v1/editor/dm/entity_type/attribute/19", "You do not have the permission to remove attributes from entity types"),
-        ];
-    }
-
-    public static function exceptionsProvider() {
-        $entityDoesNotExist = "This entity-type does not exist";
-        $entityAttributeNotFound = "Entity Attribute not found";
-        $attributeDoesNotExist = "This attribute does not exist";
-        $attributeAlreadyAdded = "This attribute already exists on this entity-type";
-
-        return [
-            'exception on get entity type'                         => Permission::for("get", "/api/v1/editor/entity_type/99", $entityDoesNotExist),
-            'exception on view entity data'                        => Permission::for("post", "/api/v1/editor/dm/entity_type/99/attribute", $entityDoesNotExist,[
-                'attribute_id' => 2,
-                'position' => 1
-            ]),
-            // TODO check if necessary to replace old set relation logic with new logic in EditorController::patchEntityType
-            // 'exception on modify entity relations'                 => Permission::for("post", "/api/v1/editor/dm/99/relation", $entityDoesNotExist),
-            'exception on add attributes to an entity type'        => Permission::for("post", "/api/v1/editor/dm/entity_type/99/attribute", $entityDoesNotExist,[
-                'attribute_id' => 2,
-                'position' => 1
-            ]),
-            'exception on add already added attribute'             => Permission::for("post", "/api/v1/editor/dm/entity_type/3/attribute", $attributeAlreadyAdded,[
-                'attribute_id' => 15,
-                'position' => 1
-            ]),
-            'exception on duplicate an entity type'                => Permission::for("post", "/api/v1/editor/dm/entity_type/99/duplicate", $entityDoesNotExist),
-            'exception on modify entity-type'                      => Permission::for("patch", "/api/v1/editor/dm/entity_type/99", $entityDoesNotExist,[
-                'data' => [
-                    'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/fundstelle#20171220094911'
                 ]
             ]),
-            'exception on reorder attributes'                      => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/99/position", $entityAttributeNotFound, [
-                'position' => 1
+        'exception on add/modify attribute dependencies with wrong reference'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/3/attribute/15/dependency", 'Entity attribute does not exist', [
+                'data' => [
+                    'or' => false,
+                    'groups' => [
+                        [
+                            'or' => true,
+                            'rules' => [
+                                [
+                                    'attribute' => 99,
+                                    'operator' => '=',
+                                    'value' => 'NoValue',
+                                ],
+                            ],
+                        ]
+                    ],
+                ]
             ]),
-            'exception on add/modify attribute dependencies'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/1/attribute/99/dependency", $entityAttributeNotFound, [
-                    'data' => [
-                        'or' => false,
-                        'groups' => [
-                            [
-                                'or' => true,
-                                'rules' => [
-                                    [
-                                        'attribute' => 15,
-                                        'operator' => '=',
-                                        'value' => 'NoValue',
-                                    ],
+        'exception on add/modify attribute dependencies with operator mismatch'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/3/attribute/15/dependency", 'Operator mismatch', [
+                'data' => [
+                    'or' => false,
+                    'groups' => [
+                        [
+                            'or' => true,
+                            'rules' => [
+                                [
+                                    'attribute' => 15,
+                                    'operator' => 'INVALID',
+                                    'value' => 'NoValue',
                                 ],
-                            ]
-                        ],
-                    ]
-                ]),
-            'exception on add/modify attribute dependencies with wrong reference'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/3/attribute/15/dependency", 'Entity attribute does not exist', [
-                    'data' => [
-                        'or' => false,
-                        'groups' => [
-                            [
-                                'or' => true,
-                                'rules' => [
-                                    [
-                                        'attribute' => 99,
-                                        'operator' => '=',
-                                        'value' => 'NoValue',
-                                    ],
-                                ],
-                            ]
-                        ],
-                    ]
-                ]),
-            'exception on add/modify attribute dependencies with operator mismatch'       => Permission::for("patch", "/api/v1/editor/dm/entity_type/3/attribute/15/dependency", 'Operator mismatch', [
-                    'data' => [
-                        'or' => false,
-                        'groups' => [
-                            [
-                                'or' => true,
-                                'rules' => [
-                                    [
-                                        'attribute' => 15,
-                                        'operator' => 'INVALID',
-                                        'value' => 'NoValue',
-                                    ],
-                                ],
-                            ]
-                        ],
-                    ]
-                ]),
-            'exception on delete entity types'                     => Permission::for("delete", "/api/v1/editor/dm/entity_type/99", $entityDoesNotExist),
-            'exception on delete attributes'                       => Permission::for("delete", "/api/v1/editor/dm/attribute/99", $attributeDoesNotExist),
-            'exception on remove attributes from entity types'     => Permission::for("delete", "/api/v1/editor/dm/entity_type/attribute/99", $entityAttributeNotFound),
-        ];
-    }
-}
+                            ],
+                        ]
+                    ],
+                ]
+            ]),
+        'exception on delete entity types'                     => Permission::for("delete", "/api/v1/editor/dm/entity_type/99", $entityDoesNotExist),
+        'exception on delete attributes'                       => Permission::for("delete", "/api/v1/editor/dm/attribute/99", $attributeDoesNotExist),
+        'exception on remove attributes from entity types'     => Permission::for("delete", "/api/v1/editor/dm/entity_type/attribute/99", $entityAttributeNotFound),
+    ];
+});

--- a/tests/Feature/ApiEditorTest.php
+++ b/tests/Feature/ApiEditorTest.php
@@ -11,7 +11,6 @@ use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\ResponseTester;
 use Tests\Permission;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 test('entity occur count endpoint', function () {

--- a/tests/Feature/ApiEntityTest.php
+++ b/tests/Feature/ApiEntityTest.php
@@ -8,7 +8,6 @@ use App\User;
 use Tests\Permission;
 use Tests\ResponseTester;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 test('top entity endpoint', function () {

--- a/tests/Feature/ApiEntityTest.php
+++ b/tests/Feature/ApiEntityTest.php
@@ -1,775 +1,701 @@
 <?php
 
-namespace Tests\Feature;
-
 use Carbon\Carbon;
 
 use App\AttributeValue;
 use App\Entity;
 use App\User;
-use Tests\TestCase;
 use Tests\Permission;
 use Tests\ResponseTester;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiEntityTest extends TestCase
-{
-    // ==========================================
-    //              [[ GET ]]
-    // ==========================================
 
-    #[TestDox('GET    /api/v1/entity  -  Get all top entities.')]
-    public function testTopEntityEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/top');
+test('top entity endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/top');
 
-        $response->assertJsonCount(3);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'name',
-                'entity_type_id',
-                'root_entity_id',
-                'rank',
-                'user_id',
-                'created_at',
-                'updated_at',
-            ]
-        ]);
-    }
+    $response->assertJsonCount(3);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'name',
+            'entity_type_id',
+            'root_entity_id',
+            'rank',
+            'user_id',
+            'created_at',
+            'updated_at',
+        ]
+    ]);
+});
 
-    #[TestDox('GET    /api/v1/entity/{id}  -  Get entity (id=1).')]
-    public function testEntityEndpointtestEntityEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/1');
+test('entity endpointtest entity endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/1');
 
-        $response->assertSimilarJson([
+    $response->assertSimilarJson([
+        'id' => 1,
+        'name' => 'Site A',
+        'entity_type_id' => 3,
+        'root_entity_id' => null,
+        'rank' => 1,
+        'user_id' => 1,
+        'user' => [
             'id' => 1,
-            'name' => 'Site A',
-            'entity_type_id' => 3,
-            'root_entity_id' => null,
+            'name' => "Admin",
+            'nickname' => "admin",
+            'email' => "admin@localhost",
+            'created_at' => "2017-12-20T09:47:36.000000Z",
+            'updated_at' => "2017-12-20T09:47:36.000000Z",
+            'deleted_at' => null,
+            'avatar' => null,
+            'metadata' => null,
+            'login_attempts' => null,
+        ],
+        'created_at' => '2017-12-20T17:10:34.000000Z',
+        'updated_at' => '2017-12-31T16:10:56.000000Z',
+        'parentIds' => [1],
+        'parentNames' => ['Site A'],
+        'comments_count' => 3,
+        'metadata' => [],
+        'attributeLinks' => [],
+    ]);
+});
+
+test('entity endpoint id', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/2');
+
+    $response->assertJson([
+        'id' => 2,
+    ]);
+});
+
+test('entity wrong id endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/-1');
+
+    $response->assertStatus(404);
+});
+
+test('entity type data endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/entity_type/3/data/15');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        '*' => [
+            'id',
+            'entity_id',
+            'attribute_id',
+            'value',
+            'user_id',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
+    $response->assertJson([
+        1 => [
+            'value' => ['Fundstelle A']
+        ],
+        7 => [
+            'value' => ['Kirchberg']
+        ],
+    ]);
+});
+
+test('entity data endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/1/data');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(1);
+    $response->assertJsonStructure([
+        15 => [
+            'id',
+            'entity_id',
+            'attribute_id',
+            'value',
+            'user_id',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
+    $response->assertJson([
+        15 => [
+            'value' => ['Fundstelle A']
+        ]
+    ]);
+});
+
+test('entity data with wrong id endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/99/data');
+
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'This entity does not exist'
+    ]);
+});
+
+test('entity data with attribute endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/1/data/15');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(1);
+    $response->assertJsonStructure([
+        15 => [
+            'id',
+            'entity_id',
+            'attribute_id',
+            'value',
+            'user_id',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
+    $response->assertJson([
+        15 => [
+            'value' => ['Fundstelle A']
+        ]
+    ]);
+});
+
+test('entity data with wrong attribute endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/1/data/99');
+
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'This attribute does not exist'
+    ]);
+});
+
+test('entity export endpoint', function () {
+    Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/3/export');
+
+    $response->assertDownload('export_inv1234_20250101123000.csv');
+    $response->assertStatus(200);
+});
+
+test('entity parent metadata get id endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/5/parent/metadata?ids');
+
+    $response->assertJsonCount(3);
+    $response->assertSimilarJson([
+        5, 2, 1
+    ]);
+});
+
+test('entity parent metadata endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/5/parent/metadata');
+
+    $response->assertJsonCount(3);
+    $response->assertSimilarJson([
+        'parentIds' => [5, 2, 1],
+        'parentNames' => ['Inv. 31', 'Befund 1', 'Site A'],
+        'attributeLinks' => [
+            [
+                "attribute_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/lagerstatte#20171220165727",
+                "entity_type_id" => 3,
+                "id" => 7,
+                "name" => "Site B",
+                "path" => ["Site B"],
+            ]
+        ],
+    ]);
+});
+
+test('entity parent endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/byParent/2');
+
+    $response->assertJsonCount(3);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'name',
+            'entity_type_id',
+            'root_entity_id',
+            'rank',
+            'user_id',
+            'created_at',
+            'updated_at',
+        ]
+    ]);
+    $response->assertJson([
+        ['id' => 3],
+        ['id' => 4],
+        ['id' => 5],
+    ]);
+});
+
+test('new entity endpoint', function () {
+    $cnt = Entity::count();
+    expect(8)->toEqual($cnt);
+
+    $response = $this->userRequest()
+    ->post('/api/v1/entity', [
+        'name' => 'Unit-Test Entity I',
+        'entity_type_id' => 3,
+        'root_entity_id' => 1
+    ]);
+
+    $response->assertStatus(201);
+    $response->assertJsonStructure([
+        'id',
+        'name',
+        'entity_type_id',
+        'root_entity_id',
+        'rank',
+        'user_id',
+        'created_at',
+        'updated_at',
+        'parentIds'
+    ]);
+    $response->assertJson([
+        'name' => 'Unit-Test Entity I',
+        'entity_type_id' => 3,
+        'root_entity_id' => 1,
+        'rank' => 2,
+    ]);
+
+    $cnt = Entity::count();
+    expect(9)->toEqual($cnt);
+});
+
+test('new root entity endpoint', function () {
+    $cnt = Entity::count();
+    expect(8)->toEqual($cnt);
+
+    $response = $this->userRequest()
+    ->post('/api/v1/entity', [
+        'name' => 'Unit-Test Entity I',
+        'entity_type_id' => 3,
+    ]);
+
+    $response->assertStatus(201);
+    $response->assertJsonStructure([
+        'id',
+        'name',
+        'entity_type_id',
+        'root_entity_id',
+        'rank',
+        'user_id',
+        'created_at',
+        'updated_at',
+        'parentIds'
+    ]);
+    $response->assertJson([
+        'name' => 'Unit-Test Entity I',
+        'entity_type_id' => 3,
+        'root_entity_id' => null,
+        'rank' => 4,
+    ]);
+
+    $cnt = Entity::count();
+    expect(9)->toEqual($cnt);
+});
+
+test('patch attributes endpoint', function () {
+    $entity = Entity::with('attributes')->find(4);
+
+    foreach($entity->attributes as $attr) {
+        if($attr->id == 11) {
+            expect($attr->pivot->int_val)->toEqual(10);
+        }
+        else if($attr->id == 9) {
+            $val = json_decode($attr->pivot->json_val);
+            expect($val->B)->toEqual(45);
+            expect($val->H)->toEqual(40);
+            expect($val->unit)->toEqual('cm');
+        }
+    }
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/entity/4/attributes', [
+            [
+                'params' => [
+                    'id' => 39,
+                    'aid' => 9,
+                    'cid' => 4
+                ],
+                'op' => 'remove'
+            ],
+            [
+                'params' => [
+                    'id' => 37,
+                    'aid' => 11,
+                    'cid' => 4
+                ],
+                'op' => 'replace',
+                'value' => 2
+            ],
+            [
+                'params' => [
+                    'aid' => 19,
+                    'cid' => 4
+                ],
+                'op' => 'add',
+                'value' => 'Test'
+            ]
+        ]);
+
+    $response->assertStatus(200);
+    $response->assertJson( fn($json) =>
+        $json
+            ->has('entity', fn($entityJson) =>
+                $entityJson
+                    ->has('id')
+                    ->has('name')
+                    ->has('entity_type_id')
+                    ->has('root_entity_id')
+                    ->has('rank')
+                    ->has('user_id')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->has('parentIds')
+                    ->etc()
+            )
+            ->has('added_attributes.19', fn($addedAttrJson) =>
+                $addedAttrJson
+                    ->has('id')
+                    ->has('entity_id')
+                    ->has('attribute_id')
+                    ->has('certainty')
+                    ->has('user_id')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->etc()
+            )
+            ->has('removed_attributes.9', fn($removedAttrJson) =>
+                $removedAttrJson
+                    ->has('id')
+                    ->has('entity_id')
+                    ->has('attribute_id')
+                    ->has('certainty')
+                    ->has('user_id')
+                    ->has('created_at')
+                    ->has('updated_at')
+                    ->etc()
+            )
+    );
+
+    $entity = Entity::with('attributes')->find(4);
+    foreach($entity->attributes as $attr) {
+        if($attr->id == 37) {
+            expect($attr->value)->toEqual(2);
+        }
+        else if($attr->id == 39) {
+            expect(false)->toBeTrue();
+        } else if($attr->attribute_id == 19) {
+            expect($attr->value)->toEqual('Test');
+        }
+    }
+});
+
+test('patch wrong attributes endpoint', function () {
+    $entity = Entity::with('attributes')->find(2);
+
+    foreach($entity->attributes as $attr) {
+        if($attr->id == 17) {
+            $val = json_decode($attr->pivot->json_val);
+            expect($val->start)->toEqual(340);
+            expect($val->end)->toEqual(300);
+            expect($val->startLabel)->toEqual('bc');
+            expect($val->endLabel)->toEqual('bc');
+        }
+    }
+
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/2/attributes', [
+        [
+            'params' => [
+                'id' => 62,
+                'aid' => 17,
+                'cid' => 2
+            ],
+            'op' => 'replace',
+            'value' => [
+                'startLabel' => 'ad',
+                'endLabel' => 'bc',
+                'start' => 400,
+                'end' => 150,
+                'epoch' => [
+                    'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
+                ]
+            ]
+        ],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertSimilarJson([
+        'error' => 'Start date of a time period must not be after it\'s end date'
+    ]);
+
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/2/attributes', [
+        [
+            'params' => [
+                'id' => 62,
+                'aid' => 17,
+                'cid' => 2
+            ],
+            'op' => 'replace',
+            'value' => [
+                'startLabel' => 'ad',
+                'endLabel' => 'ad',
+                'start' => 400,
+                'end' => 150,
+                'epoch' => [
+                    'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
+                ]
+            ]
+        ],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertSimilarJson([
+        'error' => 'Start date of a time period must not be after it\'s end date'
+    ]);
+
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/2/attributes', [
+        [
+            'params' => [
+                'id' => 62,
+                'aid' => 17,
+                'cid' => 2
+            ],
+            'op' => 'replace',
+            'value' => [
+                'startLabel' => 'bc',
+                'endLabel' => 'bc',
+                'start' => 100,
+                'end' => 150,
+                'epoch' => [
+                    'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
+                ]
+            ]
+        ],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertSimilarJson([
+        'error' => 'Start date of a time period must not be after it\'s end date'
+    ]);
+
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/2/attributes', [
+        [
+            'params' => [
+                'id' => 62,
+                'aid' => 17,
+                'cid' => 2
+            ],
+            'op' => 'replace',
+            'value' => [
+                'startLabel' => 'bc',
+                'endLabel' => 'bc',
+                'start' => 400,
+                'end' => 300,
+                'epoch' => [
+                    'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
+                ]
+            ]
+        ],
+    ]);
+
+    $response->assertStatus(200);
+
+    $entity = Entity::with('attributes')->find(2);
+    foreach($entity->attributes as $attr) {
+        if($attr->id == 17) {
+            $val = json_decode($attr->pivot->json_val);
+            expect($val->start)->toEqual(400);
+            expect($val->end)->toEqual(300);
+            expect($val->startLabel)->toEqual('bc');
+            expect($val->endLabel)->toEqual('bc');
+        }
+    }
+});
+
+test('patch rename entity endpoint', function () {
+    $entity = Entity::find(1);
+    expect($entity->name)->toEqual('Site A');
+
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/1/name', [
+        'name' => 'Site A_renamed'
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'id',
+        'name',
+        'entity_type_id',
+        'root_entity_id',
+        'rank',
+        'user_id',
+        'created_at',
+        'updated_at',
+        'user',
+    ]);
+
+    $entity = Entity::find(1);
+    expect($entity->name)->toEqual('Site A_renamed');
+});
+
+test('patch move entity endpoint', function () {
+    $siteA = Entity::find(1);
+    expect($siteA->name)->toEqual('Site A');
+    expect($siteA->root_entity_id)->toBeNull();
+
+    $siteB = Entity::find(7);
+    expect($siteB->name)->toEqual('Site B');
+    expect($siteB->root_entity_id)->toBeNull();
+    expect($siteB->rank)->toEqual(2);
+
+    $find12 = Entity::find(8);
+    expect($find12->name)->toEqual('Fund 12');
+    expect($find12->rank)->toEqual(1);
+    expect($find12->root_entity_id)->toEqual(7);
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/entity/1/rank', [
             'rank' => 1,
-            'user_id' => 1,
-            'user' => [
-                'id' => 1,
-                'name' => "Admin",
-                'nickname' => "admin",
-                'email' => "admin@localhost",
-                'created_at' => "2017-12-20T09:47:36.000000Z",
-                'updated_at' => "2017-12-20T09:47:36.000000Z",
-                'deleted_at' => null,
-                'avatar' => null,
-                'metadata' => null,
-                'login_attempts' => null,
-            ],
-            'created_at' => '2017-12-20T17:10:34.000000Z',
-            'updated_at' => '2017-12-31T16:10:56.000000Z',
-            'parentIds' => [1],
-            'parentNames' => ['Site A'],
-            'comments_count' => 3,
-            'metadata' => [],
-            'attributeLinks' => [],
+            'parent_id' => 7
         ]);
-    }
 
-    #[TestDox('GET    /api/v1/entity/{id}  -  Get entity (id=2).')]
-    public function testEntityEndpointId()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/2');
+    $response->assertStatus(204);
 
-        $response->assertJson([
-            'id' => 2,
-        ]);
-    }
+    $siteA = Entity::find(1);
+    $siteB = Entity::find(7);
+    $find12 = Entity::find(8);
 
-    #[TestDox('GET    /api/v1/entity/{id}  -  Get non-existing entity.')]
-    public function testEntityWrongIdEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/-1');
+    // Changed values
+    expect($siteA->root_entity_id)->toEqual(7);
+    expect($siteA->rank)->toEqual(1);
 
-        $response->assertStatus(404);
-    }
+    // Same values
+    expect($siteB->rank)->toEqual(1);
+    expect($siteB->root_entity_id)->toEqual(null);
+    expect($find12->root_entity_id)->toEqual(7);
+    expect($find12->rank)->toEqual(2);
+});
 
-    #[TestDox('GET    /api/v1/entity/entity_type/{entity_id}/data/{attribute_id}  -  Get attribute values (id=15) of an entity-type (id=3).')]
-    public function testEntityTypeDataEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/entity_type/3/data/15');
+test('move exceptions', function (int $entity, int | null $newParentEntity, int $statusCode = 400) {
+    $response = $this->userRequest()
+    ->patch("/api/v1/entity/$entity/rank", [
+        'rank' => 1,
+        'parent_id' => $newParentEntity
+    ]);
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            '*' => [
-                'id',
-                'entity_id',
-                'attribute_id',
-                'value',
-                'user_id',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        $response->assertJson([
-            1 => [
-                'value' => ['Fundstelle A']
-            ],
-            7 => [
-                'value' => ['Kirchberg']
-            ],
-        ]);
-    }
+    $response->assertStatus($statusCode);
+})->with('moveExceptionsProvider');
 
-     #[TestDox('GET    /api/v1/entity/{id}/data  -  Get data of an entity (id=1).')]
-    public function testEntityDataEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/1/data');
+dataset('moveExceptionsProvider', function () {
+    return [
+        "invalid entity type to top" => [8, null],
+        "invalid entity type to incompatible parent" => [7, 2],
+        "invalid entity type to child" => [1, 2],
+        "invalid entity type to self" => [8, 8],
+        "move to non-existing entity" => [8, 99999, 422],
+    ];
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(1);
-        $response->assertJsonStructure([
-            15 => [
-                'id',
-                'entity_id',
-                'attribute_id',
-                'value',
-                'user_id',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        $response->assertJson([
-            15 => [
-                'value' => ['Fundstelle A']
-            ]
-        ]);
-    }
+test('delete entity without sub entities', function () {
+    $cnt = Entity::count();
+    expect(8)->toEqual($cnt);
 
-     #[TestDox('GET    /api/v1/entity/{id}/data  -  Get data of a non-existing entity.')]
-    public function testEntityDataWithWrongIdEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/99/data');
+    $response = $this->userRequest()
+        ->delete('/api/v1/entity/8');
 
-        $response->assertStatus(400);
-        $response->assertSimilarJson([
-            'error' => 'This entity does not exist'
-        ]);
-    }
+    $response->assertStatus(204);
 
-    #[TestDox('GET    /api/v1/entity/{id}/data/{aid}  -  Get data of an attribute (id=15) of an entity (id=1).')]
-    public function testEntityDataWithAttributeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/1/data/15');
+    $cnt = Entity::count();
+    expect(7)->toEqual($cnt);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(1);
-        $response->assertJsonStructure([
-            15 => [
-                'id',
-                'entity_id',
-                'attribute_id',
-                'value',
-                'user_id',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        $response->assertJson([
-            15 => [
-                'value' => ['Fundstelle A']
-            ]
-        ]);
-    }
+test('delete entity endpoint', function () {
+    $cnt = Entity::count();
+    expect(8)->toEqual($cnt);
 
-     #[TestDox('GET    /api/v1/entity/{id}/data/{aid}  -  Get data of a non-existing attribute (id=99) of an entity (id=1).')]
-    public function testEntityDataWithWrongAttributeEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/1/data/99');
+    $response = $this->userRequest()
+        ->delete('/api/v1/entity/1');
 
-        $response->assertStatus(400);
-        $response->assertSimilarJson([
-            'error' => 'This attribute does not exist'
-        ]);
-    }
+    $response->assertStatus(204);
 
-    #[TestDox('GET    /api/v1/entity/{id}/export  -  Get entity and all children of an entity as csv/zip (id=3).')]
-    public function testEntityExportEndpoint()
-    {
-        Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/3/export');
+    $cnt = Entity::count();
+    expect(3)->toEqual($cnt);
+});
 
-        $response->assertDownload('export_inv1234_20250101123000.csv');
-        $response->assertStatus(200);
-    }
+test('delete entity wrong id endpoint', function () {
+    $response = $this->userRequest()
+    ->delete('/api/v1/entity/99');
 
-    #[TestDox('GET    /api/v1/entity/{id}/parent/metadata  -  Get all parentIds of an entity (id=5).')]
-    public function testEntityParentMetadataGetIdEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/5/parent/metadata?ids');
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'This entity does not exist'
+    ]);
+});
 
-        $response->assertJsonCount(3);
-        $response->assertSimilarJson([
-            5, 2, 1
-        ]);
-    }
+test('without permission', function ($permission) {
+    (new ResponseTester($this))->testMissingPermission($permission);
+})->with('permissions');
 
-    #[TestDox('GET    /api/v1/entity/{id}/parent/metadata  -  Get all parent metadata of an entity (id=5).')]
-    public function testEntityParentMetadataEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/5/parent/metadata');
+test('succeed with permission', function ($permission) {
+    (new ResponseTester($this))->testExceptions($permission);
+})->with('exceptions');
 
-        $response->assertJsonCount(3);
-        $response->assertSimilarJson([
-            'parentIds' => [5, 2, 1],
-            'parentNames' => ['Inv. 31', 'Befund 1', 'Site A'],
-            'attributeLinks' => [
-                [
-                    "attribute_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/lagerstatte#20171220165727",
-                    "entity_type_id" => 3,
-                    "id" => 7,
-                    "name" => "Site B",
-                    "path" => ["Site B"],
-                ]
-            ],
-        ]);
-    }
+dataset('permissions', function () {
+    return [
+        "GET    /api/v1/entity/top"                    => Permission::for("get", "/api/v1/entity/top", "You do not have the permission to get entities"),
+        "GET    /api/v1/entity/1"                      => Permission::for("get", "/api/v1/entity/1", "You do not have the permission to get a specific entity"),
+        "GET    /api/v1/entity/entity_type/3/data/14"  => Permission::for("get", "/api/v1/entity/entity_type/3/data/14", "You do not have the permission to get an entity's data"),
+        "GET    /api/v1/entity/1/data/14"              => Permission::for("get", "/api/v1/entity/1/data/14", "You do not have the permission to get an entity's data"),
+        "GET    /api/v1/entity/1/export"            => Permission::for("get", "/api/v1/entity/1/export", "You do not have the permission to export an entity tree"),
+        "GET    /api/v1/entity/1/parent/metadata"            => Permission::for("get", "/api/v1/entity/1/parent/metadata", "You do not have the permission to get an entity's parent id's"),
+        "POST   /api/v1/entity"                        => Permission::for("post", "/api/v1/entity", "You do not have the permission to add a new entity"),
+        "PATCH  /api/v1/entity/1/attributes"           => Permission::for("patch", "/api/v1/entity/1/attributes", "You do not have the permission to modify an entity's data"),
+        "PATCH  /api/v1/entity/1/attribute/13"         => Permission::for("patch", "/api/v1/entity/1/attribute/13", "You do not have the permission to modify an entity's data"),
+        "PATCH  /api/v1/entity/1/name"                 => Permission::for("patch", "/api/v1/entity/1/name", "You do not have the permission to modify an entity's data"),
+        "PATCH  /api/v1/entity/1/rank"                 => Permission::for("patch", "/api/v1/entity/1/rank", "You do not have the permission to modify an entity"),
+        "DELETE /api/v1/entity/1"                      => Permission::for("delete", "/api/v1/entity/1", "You do not have the permission to delete an entity"),
+    ];
+});
 
-    #[TestDox('GET    /api/v1/entity/byParent/{id}  -  Get all sub-entities/children of an entity (id=2).')]
-    public function testEntityParentEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/byParent/2');
-
-        $response->assertJsonCount(3);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'name',
-                'entity_type_id',
-                'root_entity_id',
-                'rank',
-                'user_id',
-                'created_at',
-                'updated_at',
-            ]
-        ]);
-        $response->assertJson([
-            ['id' => 3],
-            ['id' => 4],
-            ['id' => 5],
-        ]);
-    }
-
-    // ==========================================
-    //              [[ POST ]]
-    // ==========================================
-
-    #[TestDox('POST   /api/v1/entity  -  Add a new entity.')]
-    public function testNewEntityEndpoint()
-    {
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 8);
-
-        $response = $this->userRequest()
-        ->post('/api/v1/entity', [
-            'name' => 'Unit-Test Entity I',
+dataset('exceptions', function () {
+    return [
+        "GET    /api/v1/entity/99" => Permission::for("get", "/api/v1/entity/99", "This entity does not exist"),
+        "GET    /api/v1/entity/entity_type/99/data/14" => Permission::for("get", "/api/v1/entity/entity_type/99/data/14", "This entity type does not exist"),
+        "GET    /api/v1/entity/entity_type/3/data/99" => Permission::for("get", "/api/v1/entity/entity_type/3/data/99", "This attribute does not exist"),
+        "GET    /api/v1/entity/99/data" => Permission::for("get", "/api/v1/entity/99/data", "This entity does not exist"),
+        "GET    /api/v1/entity/99/export" => Permission::for("get", "/api/v1/entity/99/export", "This entity does not exist"),
+        "POST   /api/v1/entity" => Permission::for("post", "/api/v1/entity", "This type is not an allowed sub-type.", [
+            'name' => 'Test Entity',
             'entity_type_id' => 3,
-            'root_entity_id' => 1
-        ]);
-
-        $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'id',
-            'name',
-            'entity_type_id',
-            'root_entity_id',
-            'rank',
-            'user_id',
-            'created_at',
-            'updated_at',
-            'parentIds'
-        ]);
-        $response->assertJson([
-            'name' => 'Unit-Test Entity I',
-            'entity_type_id' => 3,
-            'root_entity_id' => 1,
-            'rank' => 2,
-        ]);
-
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 9);
-    }
-
-    #[TestDox('POST   /api/v1/entity  -  Add a new root entity.')]
-    public function testNewRootEntityEndpoint()
-    {
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 8);
-
-        $response = $this->userRequest()
-        ->post('/api/v1/entity', [
-            'name' => 'Unit-Test Entity I',
-            'entity_type_id' => 3,
-        ]);
-
-        $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'id',
-            'name',
-            'entity_type_id',
-            'root_entity_id',
-            'rank',
-            'user_id',
-            'created_at',
-            'updated_at',
-            'parentIds'
-        ]);
-        $response->assertJson([
-            'name' => 'Unit-Test Entity I',
-            'entity_type_id' => 3,
-            'root_entity_id' => null,
-            'rank' => 4,
-        ]);
-
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 9);
-    }
-
-    // ==========================================
-    //              [[ PATCH ]]
-    // ==========================================
-
-    #[TestDox('PATCH  /api/v1/entity/{entity_id}/attributes  -  Test modifying [remove, replace, add] attributes of an entity (id=4).')]
-    public function testPatchAttributesEndpoint()
-    {
-        $entity = Entity::with('attributes')->find(4);
-
-        foreach($entity->attributes as $attr) {
-            if($attr->id == 11) {
-                $this->assertEquals(10, $attr->pivot->int_val);
-            }
-            else if($attr->id == 9) {
-                $val = json_decode($attr->pivot->json_val);
-                $this->assertEquals(45, $val->B);
-                $this->assertEquals(40, $val->H);
-                $this->assertEquals('cm', $val->unit);
-            }
-        }
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/entity/4/attributes', [
-                [
-                    'params' => [
-                        'id' => 39,
-                        'aid' => 9,
-                        'cid' => 4
-                    ],
-                    'op' => 'remove'
-                ],
-                [
-                    'params' => [
-                        'id' => 37,
-                        'aid' => 11,
-                        'cid' => 4
-                    ],
-                    'op' => 'replace',
-                    'value' => 2
-                ],
-                [
-                    'params' => [
-                        'aid' => 19,
-                        'cid' => 4
-                    ],
-                    'op' => 'add',
-                    'value' => 'Test'
-                ]
-            ]);
-
-        $response->assertStatus(200);
-        $response->assertJson( fn($json) =>
-            $json
-                ->has('entity', fn($entityJson) =>
-                    $entityJson
-                        ->has('id')
-                        ->has('name')
-                        ->has('entity_type_id')
-                        ->has('root_entity_id')
-                        ->has('rank')
-                        ->has('user_id')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->has('parentIds')
-                        ->etc()
-                )
-                ->has('added_attributes.19', fn($addedAttrJson) =>
-                    $addedAttrJson
-                        ->has('id')
-                        ->has('entity_id')
-                        ->has('attribute_id')
-                        ->has('certainty')
-                        ->has('user_id')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->etc()
-                )
-                ->has('removed_attributes.9', fn($removedAttrJson) =>
-                    $removedAttrJson
-                        ->has('id')
-                        ->has('entity_id')
-                        ->has('attribute_id')
-                        ->has('certainty')
-                        ->has('user_id')
-                        ->has('created_at')
-                        ->has('updated_at')
-                        ->etc()
-                )
-        );
-
-        $entity = Entity::with('attributes')->find(4);
-        foreach($entity->attributes as $attr) {
-            if($attr->id == 37) {
-                $this->assertEquals(2, $attr->value);
-            }
-            else if($attr->id == 39) {
-                $this->assertTrue(false);
-            } else if($attr->attribute_id == 19) {
-                $this->assertEquals('Test', $attr->value);
-            }
-        }
-    }
-
-    #[TestDox('PATCH  /api/v1/entity/{entity_id}/attributes  -  Test setting wrong values for epoch attribute of an entity (id=2).')]
-    public function testPatchWrongAttributesEndpoint()
-    {
-        $entity = Entity::with('attributes')->find(2);
-
-        foreach($entity->attributes as $attr) {
-            if($attr->id == 17) {
-                $val = json_decode($attr->pivot->json_val);
-                $this->assertEquals(340, $val->start);
-                $this->assertEquals(300, $val->end);
-                $this->assertEquals('bc', $val->startLabel);
-                $this->assertEquals('bc', $val->endLabel);
-            }
-        }
-
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/2/attributes', [
-            [
-                'params' => [
-                    'id' => 62,
-                    'aid' => 17,
-                    'cid' => 2
-                ],
-                'op' => 'replace',
-                'value' => [
-                    'startLabel' => 'ad',
-                    'endLabel' => 'bc',
-                    'start' => 400,
-                    'end' => 150,
-                    'epoch' => [
-                        'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
-                    ]
-                ]
-            ],
-        ]);
-
-        $response->assertStatus(422);
-        $response->assertSimilarJson([
-            'error' => 'Start date of a time period must not be after it\'s end date'
-        ]);
-
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/2/attributes', [
-            [
-                'params' => [
-                    'id' => 62,
-                    'aid' => 17,
-                    'cid' => 2
-                ],
-                'op' => 'replace',
-                'value' => [
-                    'startLabel' => 'ad',
-                    'endLabel' => 'ad',
-                    'start' => 400,
-                    'end' => 150,
-                    'epoch' => [
-                        'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
-                    ]
-                ]
-            ],
-        ]);
-
-        $response->assertStatus(422);
-        $response->assertSimilarJson([
-            'error' => 'Start date of a time period must not be after it\'s end date'
-        ]);
-
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/2/attributes', [
-            [
-                'params' => [
-                    'id' => 62,
-                    'aid' => 17,
-                    'cid' => 2
-                ],
-                'op' => 'replace',
-                'value' => [
-                    'startLabel' => 'bc',
-                    'endLabel' => 'bc',
-                    'start' => 100,
-                    'end' => 150,
-                    'epoch' => [
-                        'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
-                    ]
-                ]
-            ],
-        ]);
-
-        $response->assertStatus(422);
-        $response->assertSimilarJson([
-            'error' => 'Start date of a time period must not be after it\'s end date'
-        ]);
-
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/2/attributes', [
-            [
-                'params' => [
-                    'id' => 62,
-                    'aid' => 17,
-                    'cid' => 2
-                ],
-                'op' => 'replace',
-                'value' => [
-                    'startLabel' => 'bc',
-                    'endLabel' => 'bc',
-                    'start' => 400,
-                    'end' => 300,
-                    'epoch' => [
-                        'concept_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eisenzeit#20171220165409'
-                    ]
-                ]
-            ],
-        ]);
-
-        $response->assertStatus(200);
-
-        $entity = Entity::with('attributes')->find(2);
-        foreach($entity->attributes as $attr) {
-            if($attr->id == 17) {
-                $val = json_decode($attr->pivot->json_val);
-                $this->assertEquals(400, $val->start);
-                $this->assertEquals(300, $val->end);
-                $this->assertEquals('bc', $val->startLabel);
-                $this->assertEquals('bc', $val->endLabel);
-            }
-        }
-    }
-
-    #[TestDox('PATCH  /api/v1/entity/{entity_id}/name  -  Test renaming an entity (id=1)  -  Site A => Site A_renamed.')]
-    public function testPatchRenameEntityEndpoint()
-    {
-        $entity = Entity::find(1);
-        $this->assertEquals('Site A', $entity->name);
-
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/1/name', [
-            'name' => 'Site A_renamed'
-        ]);
-
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'id',
-            'name',
-            'entity_type_id',
-            'root_entity_id',
-            'rank',
-            'user_id',
-            'created_at',
-            'updated_at',
-            'user',
-        ]);
-
-        $entity = Entity::find(1);
-        $this->assertEquals('Site A_renamed', $entity->name);
-    }
-
-    #[TestDox('PATCH  /api/v1/entity/{entity_id}/rank  -  Move an entity (id=1) from one parent (id=7) to another entity (id=8).')]
-    public function testPatchMoveEntityEndpoint()
-    {
-        $siteA = Entity::find(1);
-        $this->assertEquals('Site A', $siteA->name);
-        $this->assertNull($siteA->root_entity_id);
-
-        $siteB = Entity::find(7);
-        $this->assertEquals('Site B', $siteB->name);
-        $this->assertNull($siteB->root_entity_id);
-        $this->assertEquals(2, $siteB->rank);
-
-        $find12 = Entity::find(8);
-        $this->assertEquals('Fund 12', $find12->name);
-        $this->assertEquals(1, $find12->rank);
-        $this->assertEquals(7, $find12->root_entity_id);
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/entity/1/rank', [
-                'rank' => 1,
-                'parent_id' => 7
-            ]);
-
-        $response->assertStatus(204);
-
-        $siteA = Entity::find(1);
-        $siteB = Entity::find(7);
-        $find12 = Entity::find(8);
-        // Changed values
-        $this->assertEquals(7, $siteA->root_entity_id);
-        $this->assertEquals(1, $siteA->rank);
-
-        // Same values
-        $this->assertEquals(1, $siteB->rank);
-        $this->assertEquals(null, $siteB->root_entity_id);
-        $this->assertEquals(7, $find12->root_entity_id);
-        $this->assertEquals(2, $find12->rank);
-    }
-
-    #[DataProvider('moveExceptionsProvider')]
-    #[TestDox('PATCH  /api/v1/entity/{entity_id}/rank  -  Move entities exception')]
-    function testMoveExceptions(int $entity,int | null $newParentEntity, int $statusCode = 400) {
-            $response = $this->userRequest()
-            ->patch("/api/v1/entity/$entity/rank", [
-                'rank' => 1,
-                'parent_id' => $newParentEntity
-            ]);
-
-            $response->assertStatus($statusCode);
-    }
-
-    public static function moveExceptionsProvider(): array{
-        return [
-            "invalid entity type to top" => [8, null],
-            "invalid entity type to incompatible parent" => [7, 2],
-            "invalid entity type to child" => [1, 2],
-            "invalid entity type to self" => [8, 8],
-            "move to non-existing entity" => [8, 99999, 422],
-        ];
-    }
-
-    // ==========================================
-    //              [[ DELETE ]]
-    // ==========================================
-
-    #[TestDox('DELETE /api/v1/entity/{entity_id}  -  Delete an entity (id=8) with no sub-entities.')]
-    public function testDeleteEntityWithoutSubEntities()
-    {
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 8);
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/entity/8');
-
-        $response->assertStatus(204);
-
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 7);
-    }
-
-    #[TestDox('DELETE /api/v1/entity/{entity_id}  -  Delete an entity (id=1) and all it\'s sub-entities.')]
-    public function testDeleteEntityEndpoint()
-    {
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 8);
-
-        $response = $this->userRequest()
-            ->delete('/api/v1/entity/1');
-
-        $response->assertStatus(204);
-
-        $cnt = Entity::count();
-        $this->assertEquals($cnt, 3);
-    }
-
-    #[TestDox('DELETE /api/v1/entity/{entity_id}  -  Delete a non-existing entity.')]
-    public function testDeleteEntityWrongIdEndpoint()
-    {
-        $response = $this->userRequest()
-        ->delete('/api/v1/entity/99');
-
-        $response->assertStatus(400);
-        $response->assertSimilarJson([
-            'error' => 'This entity does not exist'
-        ]);
-    }
-
-    // ==========================================
-    //      [[ ADDITIONAL DATA PROVIDERS ]]
-    // ==========================================
-
-    #[DataProvider('permissions')]
-    #[TestDox('[[PROVIDER]] Routes Without Permissions')]
-    public function testWithoutPermission($permission) {
-        (new ResponseTester($this))->testMissingPermission($permission);
-    }
-
-    #[DataProvider('exceptions')]
-    #[TestDox('[[PROVIDER]] Exceptions With Permissions')]
-    public function testSucceedWithPermission($permission) {
-        (new ResponseTester($this))->testExceptions($permission);
-    }
-
-    public static function permissions() {
-        return [
-            "GET    /api/v1/entity/top"                    => Permission::for("get", "/api/v1/entity/top", "You do not have the permission to get entities"),
-            "GET    /api/v1/entity/1"                      => Permission::for("get", "/api/v1/entity/1", "You do not have the permission to get a specific entity"),
-            "GET    /api/v1/entity/entity_type/3/data/14"  => Permission::for("get", "/api/v1/entity/entity_type/3/data/14", "You do not have the permission to get an entity's data"),
-            "GET    /api/v1/entity/1/data/14"              => Permission::for("get", "/api/v1/entity/1/data/14", "You do not have the permission to get an entity's data"),
-            "GET    /api/v1/entity/1/export"            => Permission::for("get", "/api/v1/entity/1/export", "You do not have the permission to export an entity tree"),
-            "GET    /api/v1/entity/1/parent/metadata"            => Permission::for("get", "/api/v1/entity/1/parent/metadata", "You do not have the permission to get an entity's parent id's"),
-            "POST   /api/v1/entity"                        => Permission::for("post", "/api/v1/entity", "You do not have the permission to add a new entity"),
-            "PATCH  /api/v1/entity/1/attributes"           => Permission::for("patch", "/api/v1/entity/1/attributes", "You do not have the permission to modify an entity's data"),
-            "PATCH  /api/v1/entity/1/attribute/13"         => Permission::for("patch", "/api/v1/entity/1/attribute/13", "You do not have the permission to modify an entity's data"),
-            "PATCH  /api/v1/entity/1/name"                 => Permission::for("patch", "/api/v1/entity/1/name", "You do not have the permission to modify an entity's data"),
-            "PATCH  /api/v1/entity/1/rank"                 => Permission::for("patch", "/api/v1/entity/1/rank", "You do not have the permission to modify an entity"),
-            "DELETE /api/v1/entity/1"                      => Permission::for("delete", "/api/v1/entity/1", "You do not have the permission to delete an entity"),
-        ];
-    }
-
-    public static function exceptions() {
-        return [
-            "GET    /api/v1/entity/99" => Permission::for("get", "/api/v1/entity/99", "This entity does not exist"),
-            "GET    /api/v1/entity/entity_type/99/data/14" => Permission::for("get", "/api/v1/entity/entity_type/99/data/14", "This entity type does not exist"),
-            "GET    /api/v1/entity/entity_type/3/data/99" => Permission::for("get", "/api/v1/entity/entity_type/3/data/99", "This attribute does not exist"),
-            "GET    /api/v1/entity/99/data" => Permission::for("get", "/api/v1/entity/99/data", "This entity does not exist"),
-            "GET    /api/v1/entity/99/export" => Permission::for("get", "/api/v1/entity/99/export", "This entity does not exist"),
-            "POST   /api/v1/entity" => Permission::for("post", "/api/v1/entity", "This type is not an allowed sub-type.", [
-                'name' => 'Test Entity',
-                'entity_type_id' => 3,
-                'root_entity_id' => 2,
-            ]),
-            "POST   /api/v1/entity" => Permission::for("post", "/api/v1/entity", "This type is not an allowed root-type.", [
-                'name' => 'Test Entity',
-                'entity_type_id' => 4,
-            ]),
-            "PATCH  /api/v1/entity/99/attributes" => Permission::for("patch", "/api/v1/entity/99/attributes", "This entity does not exist"),
-            "PATCH  /api/v1/entity/99/attribute/13" => Permission::for("patch", "/api/v1/entity/99/attribute/13", "This entity does not exist"),
-            "PATCH  /api/v1/entity/1/attribute/99" => Permission::for("patch", "/api/v1/entity/1/attribute/99", "This attribute does not exist"),
-            "PATCH  /api/v1/entity/99/name" => Permission::for("patch", "/api/v1/entity/99/name", "This entity does not exist", [
-                'name' => 'Test'
-            ]),
-            "PATCH  /api/v1/entity/99/rank" => Permission::for("patch", "/api/v1/entity/99/rank", "This entity does not exist", [
-                'rank' => 1,
-            ]),
-        ];
-    }
-}
+            'root_entity_id' => 2,
+        ]),
+        "POST   /api/v1/entity" => Permission::for("post", "/api/v1/entity", "This type is not an allowed root-type.", [
+            'name' => 'Test Entity',
+            'entity_type_id' => 4,
+        ]),
+        "PATCH  /api/v1/entity/99/attributes" => Permission::for("patch", "/api/v1/entity/99/attributes", "This entity does not exist"),
+        "PATCH  /api/v1/entity/99/attribute/13" => Permission::for("patch", "/api/v1/entity/99/attribute/13", "This entity does not exist"),
+        "PATCH  /api/v1/entity/1/attribute/99" => Permission::for("patch", "/api/v1/entity/1/attribute/99", "This attribute does not exist"),
+        "PATCH  /api/v1/entity/99/name" => Permission::for("patch", "/api/v1/entity/99/name", "This entity does not exist", [
+            'name' => 'Test'
+        ]),
+        "PATCH  /api/v1/entity/99/rank" => Permission::for("patch", "/api/v1/entity/99/rank", "This entity does not exist", [
+            'rank' => 1,
+        ]),
+    ];
+});

--- a/tests/Feature/ApiNotificationTest.php
+++ b/tests/Feature/ApiNotificationTest.php
@@ -1,306 +1,257 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Entity;
 use App\Notifications\CommentPosted;
 use App\User;
-use Tests\TestCase;
 use Illuminate\Support\Facades\Hash;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiNotificationTest extends TestCase
+
+function setupData()
 {
-    public static function setupData() {
-        $testUser = new User();
-        $testUser->name = 'Test User';
-        $testUser->nickname = 'testuser';
-        $testUser->email = 'test@localhost';
-        $testUser->password = Hash::make('test');
-        $testUser->save();
-        $testUser->assignRole('admin');
-        $testUser = User::find($testUser->id);
+    $testUser = new User();
+    $testUser->name = 'Test User';
+    $testUser->nickname = 'testuser';
+    $testUser->email = 'test@localhost';
+    $testUser->password = Hash::make('test');
+    $testUser->save();
+    $testUser->assignRole('admin');
+    $testUser = User::find($testUser->id);
 
-        $user = User::find(1);
-        $entity = Entity::first();
+    $user = User::find(1);
+    $entity = Entity::first();
 
-        $entity->addComment([
-            'content' => 'A simple test'
-        ], $user, false, []);
-        $entity->addComment([
-            'content' => 'A simple test from a simple user'
-        ], $testUser, true, []);
-        $entity->load('comments');
+    $entity->addComment([
+        'content' => 'A simple test'
+    ], $user, false, []);
+    $entity->addComment([
+        'content' => 'A simple test from a simple user'
+    ], $testUser, true, []);
+    $entity->load('comments');
 
-        return [
-            'users' => [$user, $testUser],
-            'entity' => $entity,
-        ];
-    }
+    return [
+        'users' => [$user, $testUser],
+        'entity' => $entity,
+    ];
+}
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/comment/resource/{id}?r=entity : Test get Comments for Resource')]
-    public function testResourceComments()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
+test('resource comments', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
 
-        $eid = $entity->id;
-        $response = $this->userRequest()
-            ->get("/api/v1/comment/resource/$eid?r=entity");
-        $response->assertStatus(200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            '*' => [
-                'id',
-                'user_id',
-                'commentable_id',
-                'commentable_type',
-                'reply_to',
-                'content',
-                'metadata',
-                'created_at',
-                'updated_at',
-                'deleted_at',
+    $eid = $entity->id;
+    $response = $this->userRequest()
+        ->get("/api/v1/comment/resource/$eid?r=entity");
+    $response->assertStatus(200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        '*' => [
+            'id',
+            'user_id',
+            'commentable_id',
+            'commentable_type',
+            'reply_to',
+            'content',
+            'metadata',
+            'created_at',
+            'updated_at',
+            'deleted_at',
+        ]
+    ]);
+});
+
+test('comment replies', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
+
+    $eid = $entity->id;
+    $cid = $entity->comments[1]->id;
+    $response = $this->userRequest()
+        ->get("/api/v1/comment/$cid/reply");
+    $response->assertStatus(200);
+    $response->assertJsonCount(0);
+
+    $entity->addComment([
+        'content' => 'A simple reply',
+        'reply_to' => $cid,
+    ], $user, false, []);
+
+    $entity->load('comments');
+    $entity->comments[1]->load('replies');
+    expect(count($entity->comments))->toEqual(2);
+    expect(count($entity->comments[1]->replies))->toEqual(1);
+});
+
+test('add comment', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
+
+    $response = $this->userRequest()
+        ->post("/api/v1/comment", [
+            'resource_type' => 'entity',
+            'resource_id' => $entity->id,
+            'content' => 'This is a test',
+            'metadata' => [
+                'key' => 'value'
             ]
         ]);
-    }
+    $response->assertStatus(201);
+    $response->assertJsonStructure([
+        'id',
+        'user_id',
+        'commentable_id',
+        'commentable_type',
+        'reply_to',
+        'content',
+        'metadata',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+        'author',
+    ]);
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/comment/{id}/reply : Test get replies for comment')]
-    public function testCommentReplies()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
+    $entity->load('comments');
+    expect(count($entity->comments))->toEqual(3);
+    expect($entity->comments[2]->content)->toEqual('This is a test');
+    expect($entity->comments[2]->metadata['key'])->toEqual('value');
+});
 
-        $eid = $entity->id;
-        $cid = $entity->comments[1]->id;
-        $response = $this->userRequest()
-            ->get("/api/v1/comment/$cid/reply");
-        $response->assertStatus(200);
-        $response->assertJsonCount(0);
+test('update comment', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $testUser = $data['users'][1];
+    $entity = $data['entity'];
 
-        $entity->addComment([
-            'content' => 'A simple reply',
-            'reply_to' => $cid,
-        ], $user, false, []);
+    $entity->load('comments');
+    $cid = $entity->comments[0]->id;
 
-        $entity->load('comments');
-        $entity->comments[1]->load('replies');
-        $this->assertEquals(2, count($entity->comments));
-        $this->assertEquals(1, count($entity->comments[1]->replies));
-    }
+    $response = $this->userRequest()
+        ->patch("/api/v1/comment/$cid", [
+            'content' => 'This is still a test',
+        ]);
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure([
+        'id',
+        'user_id',
+        'commentable_id',
+        'commentable_type',
+        'reply_to',
+        'content',
+        'metadata',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ]);
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/comment : Test Add Comment')]
-    public function testAddComment()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
+    $entity->load('comments');
+    expect(count($entity->comments))->toEqual(2);
+    expect($entity->comments[0]->content)->toEqual('This is still a test');
+});
 
-        $response = $this->userRequest()
-            ->post("/api/v1/comment", [
-                'resource_type' => 'entity',
-                'resource_id' => $entity->id,
-                'content' => 'This is a test',
-                'metadata' => [
-                    'key' => 'value'
-                ]
-            ]);
-        $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'id',
-            'user_id',
-            'commentable_id',
-            'commentable_type',
-            'reply_to',
-            'content',
-            'metadata',
-            'created_at',
-            'updated_at',
-            'deleted_at',
-            'author',
+test('mark notification as read', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(1);
+    expect(count($user->unreadNotifications))->toEqual(1);
+
+    $id = $user->unreadNotifications[0]->id;
+
+    $response = $this->userRequest()
+        ->patch("/api/v1/notification/read/$id");
+
+    $response->assertStatus(204);
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(1);
+    expect(count($user->unreadNotifications))->toEqual(0);
+});
+
+test('mark notifications as read', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
+
+    $user->notify(new CommentPosted($entity->comments->last(), [], []));
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(2);
+    expect(count($user->unreadNotifications))->toEqual(2);
+
+    $ids = $user->unreadNotifications->pluck('id')->toArray();
+
+    $response = $this->userRequest()
+        ->patch("/api/v1/notification/read", [
+            'ids' => $ids,
         ]);
 
-        $entity->load('comments');
-        $this->assertEquals(3, count($entity->comments));
-        $this->assertEquals('This is a test', $entity->comments[2]->content);
-        $this->assertEquals('value', $entity->comments[2]->metadata['key']);
-    }
+    $response->assertStatus(204);
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(2);
+    expect(count($user->unreadNotifications))->toEqual(0);
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/comment/{id} : Test Edit Comment')]
-    public function testUpdateComment()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $testUser = $data['users'][1];
-        $entity = $data['entity'];
+test('delete notifications', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
 
-        $entity->load('comments');
-        $cid = $entity->comments[0]->id;
+    $user->notify(new CommentPosted($entity->comments->last(), [], []));
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(2);
+    expect(count($user->unreadNotifications))->toEqual(2);
 
-        $response = $this->userRequest()
-            ->patch("/api/v1/comment/$cid", [
-                'content' => 'This is still a test',
-            ]);
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure([
-            'id',
-            'user_id',
-            'commentable_id',
-            'commentable_type',
-            'reply_to',
-            'content',
-            'metadata',
-            'created_at',
-            'updated_at',
-            'deleted_at',
+    $id = $user->unreadNotifications->first()->id;
+
+    $response = $this->userRequest()
+        ->patch("/api/v1/notification", [
+            'ids' => [$id]
         ]);
 
-        $entity->load('comments');
-        $this->assertEquals(2, count($entity->comments));
-        $this->assertEquals('This is still a test', $entity->comments[0]->content);
-    }
+    $response->assertStatus(204);
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(1);
+    expect(count($user->unreadNotifications))->toEqual(1);
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/notification/read/{id} : Test mark single notification as read')]
-    public function testMarkNotificationAsRead()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
+test('delete notification', function () {
+    $data = setupData();
+    $user = $data['users'][0];
 
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(1, count($user->notifications));
-        $this->assertEquals(1, count($user->unreadNotifications));
+    $user->load('notifications');
+    $user->load('unreadNotifications');
 
-        $id = $user->unreadNotifications[0]->id;
+    $id = $user->unreadNotifications->first()->id;
 
-        $response = $this->userRequest()
-            ->patch("/api/v1/notification/read/$id");
+    $response = $this->userRequest()
+        ->delete("/api/v1/notification/$id");
 
-        $response->assertStatus(204);
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(1, count($user->notifications));
-        $this->assertEquals(0, count($user->unreadNotifications));
-    }
+    $this->assertStatus($response, 204);
+    $user->load('notifications');
+    $user->load('unreadNotifications');
+    expect(count($user->notifications))->toEqual(0);
+    expect(count($user->unreadNotifications))->toEqual(0);
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/notification/read : Test mark array of notifications as read')]
-    public function testMarkNotificationsAsRead()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
+test('delete comment', function () {
+    $data = setupData();
+    $user = $data['users'][0];
+    $entity = $data['entity'];
 
-        $user->notify(new CommentPosted($entity->comments->last(), [], []));
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(2, count($user->notifications));
-        $this->assertEquals(2, count($user->unreadNotifications));
+    $id = $entity->comments->first()->id;
+    $response = $this->userRequest()
+        ->delete("/api/v1/comment/$id");
 
-        $ids = $user->unreadNotifications->pluck('id')->toArray();
-
-        $response = $this->userRequest()
-            ->patch("/api/v1/notification/read", [
-                'ids' => $ids,
-            ]);
-
-        $response->assertStatus(204);
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(2, count($user->notifications));
-        $this->assertEquals(0, count($user->unreadNotifications));
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/notification : Test delete notifications')]
-    public function testDeleteNotifications()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
-
-        $user->notify(new CommentPosted($entity->comments->last(), [], []));
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(2, count($user->notifications));
-        $this->assertEquals(2, count($user->unreadNotifications));
-
-        $id = $user->unreadNotifications->first()->id;
-
-        $response = $this->userRequest()
-            ->patch("/api/v1/notification", [
-                'ids' => [$id]
-            ]);
-
-        $response->assertStatus(204);
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(1, count($user->notifications));
-        $this->assertEquals(1, count($user->unreadNotifications));
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('DELETE /api/v1/notification/{id} : Test delete notification')]
-    public function testDeleteNotification()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-
-        $id = $user->unreadNotifications->first()->id;
-
-        $response = $this->userRequest()
-            ->delete("/api/v1/notification/$id");
-
-        $this->assertStatus($response, 204);
-        $user->load('notifications');
-        $user->load('unreadNotifications');
-        $this->assertEquals(0, count($user->notifications));
-        $this->assertEquals(0, count($user->unreadNotifications));
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('DELETE /api/v1/comment/{id} : Test delete comment')]
-    public function testDeleteComment()
-    {
-        $data = self::setupData();
-        $user = $data['users'][0];
-        $entity = $data['entity'];
-
-        $id = $entity->comments->first()->id;
-        $response = $this->userRequest()
-            ->delete("/api/v1/comment/$id");
-
-        $entity->load('comments');
-        $response->assertStatus(204);
-        $this->assertEquals(2, count($entity->comments));
-        $this->assertEquals(1, count($entity->comments()->withoutTrashed()->get()));
-    }
-}
+    $entity->load('comments');
+    $response->assertStatus(204);
+    expect(count($entity->comments))->toEqual(2);
+    expect(count($entity->comments()->withoutTrashed()->get()))->toEqual(1);
+});

--- a/tests/Feature/ApiNotificationTest.php
+++ b/tests/Feature/ApiNotificationTest.php
@@ -4,7 +4,6 @@ use App\Entity;
 use App\Notifications\CommentPosted;
 use App\User;
 use Illuminate\Support\Facades\Hash;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 function setupData()

--- a/tests/Feature/ApiPreferenceTest.php
+++ b/tests/Feature/ApiPreferenceTest.php
@@ -1,224 +1,191 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Testing\Fluent\AssertableJson;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\TestDox;
 
 use App\User;
 use App\Preference;
 use App\UserPreference;
 
-class ApiPreferenceTest extends TestCase
-{
-    // Testing GET requests
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/preferences : Get System Preferences')]
-    public function testPreferenceEndpoint()
-    {
-        $cnt = UserPreference::count();
-        $this->assertEquals($cnt, 0);
+test('preference endpoint', function () {
+    $cnt = UserPreference::count();
+    expect(0)->toEqual($cnt);
 
-        $fields = [
-            'pref_id' => 1,
-            'user_id' => 1,
-            'value' => '{"language_key":"de"}'
-        ];
-        $up = new UserPreference();
-        foreach($fields as $k => $v) {
-            $up->{$k} = $v;
-        }
-        $up->save();
+    $fields = [
+        'pref_id' => 1,
+        'user_id' => 1,
+        'value' => '{"language_key":"de"}'
+    ];
+    $up = new UserPreference();
+    foreach($fields as $k => $v) {
+        $up->{$k} = $v;
+    }
+    $up->save();
 
-        $cnt = UserPreference::count();
-        $this->assertEquals($cnt, 1);
+    $cnt = UserPreference::count();
+    expect(1)->toEqual($cnt);
 
-        $response = $this->userRequest()
-            ->get('/api/v1/preference');
+    $response = $this->userRequest()
+        ->get('/api/v1/preference');
 
-        $response->assertJsonCount(10);
-        $response->assertJsonStructure([
-            '*' => [
-                'id',
-                'label',
-                'value',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
+    $response->assertJsonCount(10);
+    $response->assertJsonStructure([
+        '*' => [
+            'id',
+            'label',
+            'value',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
 
-        $response->assertJson(fn(AssertableJson $json) =>
-            $json
+    $response->assertJson(fn(AssertableJson $json) =>
+        $json
+            ->etc()
+            ->has('prefs.gui-language', fn(AssertableJson $guiJson) =>
+            $guiJson->where('id', 1)
+                ->where('value', 'en')
                 ->etc()
-                ->has('prefs.gui-language', fn(AssertableJson $guiJson) =>
-                $guiJson->where('id', 1)
-                    ->where('value', 'en')
+        )
+            ->has('prefs.columns', fn(AssertableJson $colJson) =>
+                $colJson->where('id', 2)
+                    ->where('value', [
+                        'left' => 2,
+                        'center' => 5,
+                        'right' => 5,
+                    ])
                     ->etc()
             )
-                ->has('prefs.columns', fn(AssertableJson $colJson) =>
-                    $colJson->where('id', 2)
-                        ->where('value', [
-                            'left' => 2,
-                            'center' => 5,
-                            'right' => 5,
-                        ])
-                        ->etc()
-                )
-                ->has('prefs.show-tooltips', fn(AssertableJson $tooltipJson) =>
-                    $tooltipJson->where('id', 3)
-                        ->where('value', true)
-                        ->etc()
-                )
-                ->has('prefs.tag-root', fn(AssertableJson $tagJson) =>
-                    $tagJson->where('id', 4)
-                        ->where('value', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eigenschaften#20171220100251')
-                        ->etc()
-                )
-                ->has('prefs.link-to-thesaurex', fn(AssertableJson $thJson) =>
-                    $thJson->where('id', 5)
-                        ->where('value', '')
-                        ->etc()
-                )
-                ->has('prefs.project-name', fn(AssertableJson $projectNameJson) =>
-                    $projectNameJson->where('id', 6)
-                        ->where('value', 'Spacialist')
-                        ->etc()
-                )
-                ->has('prefs.project-maintainer', fn(AssertableJson $maintainerJson) =>
-                    $maintainerJson->where('id', 7)
-                        ->where('value', [
-                            'name' => '',
-                            'email' => '',
-                            'public' => false,
-                            'description' => '',
-                        ])
-                        ->etc()
-                )
-                ->has('plugin.map.prefs.map-projection', fn(AssertableJson $mapJson) =>
-                    $mapJson->where('id', 8)
-                        ->where('value', [
-                            'epsg' => '4326'
-                        ])
-                        ->etc()
-                )
-                ->has('prefs.enable-password-reset-link', fn(AssertableJson $pwJson) =>
-                    $pwJson->where('id', 9)
-                        ->where('value', false)
-                        ->etc()
-                )
-                ->has('prefs.color', fn(AssertableJson $colorJson) =>
-                    $colorJson->where('id', 10)
-                        ->where('value', '')
-                        ->etc()
-                )
-        );
-    }
+            ->has('prefs.show-tooltips', fn(AssertableJson $tooltipJson) =>
+                $tooltipJson->where('id', 3)
+                    ->where('value', true)
+                    ->etc()
+            )
+            ->has('prefs.tag-root', fn(AssertableJson $tagJson) =>
+                $tagJson->where('id', 4)
+                    ->where('value', 'https://spacialist.escience.uni-tuebingen.de/<user-project>/eigenschaften#20171220100251')
+                    ->etc()
+            )
+            ->has('prefs.link-to-thesaurex', fn(AssertableJson $thJson) =>
+                $thJson->where('id', 5)
+                    ->where('value', '')
+                    ->etc()
+            )
+            ->has('prefs.project-name', fn(AssertableJson $projectNameJson) =>
+                $projectNameJson->where('id', 6)
+                    ->where('value', 'Spacialist')
+                    ->etc()
+            )
+            ->has('prefs.project-maintainer', fn(AssertableJson $maintainerJson) =>
+                $maintainerJson->where('id', 7)
+                    ->where('value', [
+                        'name' => '',
+                        'email' => '',
+                        'public' => false,
+                        'description' => '',
+                    ])
+                    ->etc()
+            )
+            ->has('plugin.map.prefs.map-projection', fn(AssertableJson $mapJson) =>
+                $mapJson->where('id', 8)
+                    ->where('value', [
+                        'epsg' => '4326'
+                    ])
+                    ->etc()
+            )
+            ->has('prefs.enable-password-reset-link', fn(AssertableJson $pwJson) =>
+                $pwJson->where('id', 9)
+                    ->where('value', false)
+                    ->etc()
+            )
+            ->has('prefs.color', fn(AssertableJson $colorJson) =>
+                $colorJson->where('id', 10)
+                    ->where('value', '')
+                    ->etc()
+            )
+    );
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/preference : Change System Preference')]
-    public function testPatchSystemPreferenceEndpoint()
-    {
-        $data = [
-            'changes' => [
-                [
-                    'user' => false,
-                    'value' => 'Updated Project Name',
-                    'label' => 'prefs.project-name',
-                ],
+test('patch system preference endpoint', function () {
+    $data = [
+        'changes' => [
+            [
+                'user' => false,
+                'value' => 'Updated Project Name',
+                'label' => 'prefs.project-name',
             ],
-        ];
+        ],
+    ];
 
-        $response = $this->userRequest()
-            ->patch('/api/v1/preference', $data);
+    $response = $this->userRequest()
+        ->patch('/api/v1/preference', $data);
 
-        $projectNamePref = Preference::find(6);
-        $this->assertEquals('prefs.project-name', $projectNamePref->label);
-        $this->assertEquals('{"name": "Updated Project Name"}', $projectNamePref->default_value);
-    }
+    $projectNamePref = Preference::find(6);
+    expect($projectNamePref->label)->toEqual('prefs.project-name');
+    expect($projectNamePref->default_value)->toEqual('{"name": "Updated Project Name"}');
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/preference : Change User Preference')]
-    public function testPatchUserPreferenceEndpoint()
-    {
-        $data = [
-            'changes' => [
-                [
-                    'user' => true,
-                    'value' => '{"left": 2, "right": 2, "center": 8}',
-                    'label' => 'prefs.columns',
-                ],
+test('patch user preference endpoint', function () {
+    $data = [
+        'changes' => [
+            [
+                'user' => true,
+                'value' => '{"left": 2, "right": 2, "center": 8}',
+                'label' => 'prefs.columns',
             ],
-        ];
+        ],
+    ];
 
+    $response = $this->userRequest()
+        ->patch('/api/v1/preference', $data);
+
+    $pref = User::with('preferences')->first()->preferences[0];
+    expect($pref->pref_id)->toEqual(2);
+    expect($pref->user_id)->toEqual(1);
+    expect($pref->value)->toEqual('"{\\"left\\": 2, \\"right\\": 2, \\"center\\": 8}"');
+});
+
+test('permissions', function () {
+    User::first()->roles()->detach();
+
+    $calls = [
+        ['url' => '', 'error' => 'You do not have the permission to edit system preferences', 'verb' => 'patch'],
+    ];
+
+    $response = null;
+    foreach($calls as $c) {
         $response = $this->userRequest()
-            ->patch('/api/v1/preference', $data);
-
-        $pref = User::with('preferences')->first()->preferences[0];
-        $this->assertEquals(2, $pref->pref_id);
-        $this->assertEquals(1, $pref->user_id);
-        $this->assertEquals('"{\\"left\\": 2, \\"right\\": 2, \\"center\\": 8}"', $pref->value);
-    }
-
-    // Testing exceptions and permissions
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('Test Permissions')]
-    public function testPermissions()
-    {
-        User::first()->roles()->detach();
-
-        $calls = [
-            ['url' => '', 'error' => 'You do not have the permission to edit system preferences', 'verb' => 'patch'],
-        ];
-
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->json($c['verb'], '/api/v1/preference' . $c['url'], [
-                    'changes' => [
-                        ['label' => 'prefs.columns']
-                    ],
-                ]);
-
-            $response->assertStatus(403);
-            $response->assertSimilarJson([
-                'error' => $c['error']
+            ->json($c['verb'], '/api/v1/preference' . $c['url'], [
+                'changes' => [
+                    ['label' => 'prefs.columns']
+                ],
             ]);
-        }
+
+        $response->assertStatus(403);
+        $response->assertSimilarJson([
+            'error' => $c['error']
+        ]);
     }
-    /**
-	 * @return void
-	 */
-	#[TestDox('Test Exceptions')]
-    public function testExceptions()
-    {
-        $calls = [
-            ['url' => '', 'error' => 'This preference does not exist', 'verb' => 'patch'],
-        ];
+});
 
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->json($c['verb'], '/api/v1/preference' . $c['url'], [
-                    'changes' => [
-                        ['label' => 'prefs.columnsWrongName']
-                    ]
-                ]);
+test('exceptions', function () {
+    $calls = [
+        ['url' => '', 'error' => 'This preference does not exist', 'verb' => 'patch'],
+    ];
 
-            $this->assertStatus($response, 400);
-            $response->assertSimilarJson([
-                'error' => $c['error']
+    $response = null;
+    foreach($calls as $c) {
+        $response = $this->userRequest()
+            ->json($c['verb'], '/api/v1/preference' . $c['url'], [
+                'changes' => [
+                    ['label' => 'prefs.columnsWrongName']
+                ]
             ]);
-        }
+
+        $this->assertStatus($response, 400);
+        $response->assertSimilarJson([
+            'error' => $c['error']
+        ]);
     }
-}
+});

--- a/tests/Feature/ApiPreferenceTest.php
+++ b/tests/Feature/ApiPreferenceTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Testing\Fluent\AssertableJson;
-use PHPUnit\Framework\Attributes\TestDox;
 
 use App\User;
 use App\Preference;

--- a/tests/Feature/ApiReferenceTest.php
+++ b/tests/Feature/ApiReferenceTest.php
@@ -4,7 +4,6 @@ use App\Reference;
 use Tests\Permission;
 use Tests\ResponseTester;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 test('entity references endpoint', function () {

--- a/tests/Feature/ApiReferenceTest.php
+++ b/tests/Feature/ApiReferenceTest.php
@@ -1,241 +1,200 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Reference;
 use Tests\Permission;
 use Tests\ResponseTester;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiReferenceTest extends TestCase
-{
 
-    // ==========================================
-    //                [[ GET ]]
-    // ==========================================
+test('entity references endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/entity/1/reference');
 
-    #[TestDox('GET    /api/v1/entity/{id}/reference  -  Get all references of an entity (id=1).')]
-    public function testEntityReferencesEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/entity/1/reference');
-
-        $response->assertStatus(200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            '*' => [
-                [
-                    'id',
-                    'entity_id',
-                    'attribute_id',
-                    'bibliography_id',
-                    'description',
-                    'user_id',
-                    'created_at',
-                    'updated_at',
-                    'bibliography'
-                ]
+    $response->assertStatus(200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        '*' => [
+            [
+                'id',
+                'entity_id',
+                'attribute_id',
+                'bibliography_id',
+                'description',
+                'user_id',
+                'created_at',
+                'updated_at',
+                'bibliography'
             ]
-        ]);
-        $response->assertJson([
-            'https://spacialist.escience.uni-tuebingen.de/<user-project>/alternativer_name#20171220165047' => [
-                [
-                    'id' => 1,
-                    'entity_id' => 1,
-                    'attribute_id' => 15,
-                    'bibliography_id' => 1318,
-                    'description' => 'See Page 10',
-                    'user_id' => 1,
-                    'created_at' => '2019-03-08T13:36:36.000000Z',
-                    'updated_at' => '2019-03-08T13:36:36.000000Z',
-                    'bibliography' => [
-                        'id' => 1318
-                    ],
-                ],
-                [
-                    'id' => 2,
-                    'entity_id' => 1,
-                    'attribute_id' => 15,
-                    'bibliography_id' => 1319,
-                    'description' => 'Picture on left side of page 12',
-                    'user_id' => 1,
-                    'created_at' => '2019-03-08T13:36:48.000000Z',
-                    'updated_at' => '2019-03-08T13:36:48.000000Z',
-                    'bibliography' => [
-                        'id' => 1319
-                    ],
+        ]
+    ]);
+    $response->assertJson([
+        'https://spacialist.escience.uni-tuebingen.de/<user-project>/alternativer_name#20171220165047' => [
+            [
+                'id' => 1,
+                'entity_id' => 1,
+                'attribute_id' => 15,
+                'bibliography_id' => 1318,
+                'description' => 'See Page 10',
+                'user_id' => 1,
+                'created_at' => '2019-03-08T13:36:36.000000Z',
+                'updated_at' => '2019-03-08T13:36:36.000000Z',
+                'bibliography' => [
+                    'id' => 1318
                 ],
             ],
-            'https://spacialist.escience.uni-tuebingen.de/<user-project>/notizen#20171220105603' => [
-                [
-                    'id' => 3,
-                    'entity_id' => 1,
-                    'attribute_id' => 13,
-                    'bibliography_id' => 1323,
-                    'description' => 'Page 10ff is interesting',
-                    'user_id' => 1,
-                    'created_at' => '2019-03-08T13:37:09.000000Z',
-                    'updated_at' => '2019-03-08T13:37:09.000000Z',
-                    'bibliography' => [
-                        'id' => 1323
-                    ],
+            [
+                'id' => 2,
+                'entity_id' => 1,
+                'attribute_id' => 15,
+                'bibliography_id' => 1319,
+                'description' => 'Picture on left side of page 12',
+                'user_id' => 1,
+                'created_at' => '2019-03-08T13:36:48.000000Z',
+                'updated_at' => '2019-03-08T13:36:48.000000Z',
+                'bibliography' => [
+                    'id' => 1319
                 ],
-            ]
-        ]);
-    }
-
-    // ==========================================
-    //              [[ POST ]]
-    // ==========================================
-
-    #[TestDox('POST   /api/v1/entity/{entity_id}/reference/{attribute_id}  -  Add a new reference to an entity (id=2).')]
-    public function testNewReferenceEndpoint()
-    {
-        $cnt = Reference::count();
-        $this->assertEquals($cnt, 3);
-
-        $response = $this->userRequest()
-        ->post('/api/v1/entity/2/reference/14', [
-            'bibliography_id' => 1322,
-            'description' => 'This is a simple test',
-        ]);
-
-        $response->assertStatus(201);
-        $response->assertJsonStructure([
-            'id',
-            'entity_id',
-            'attribute_id',
-            'bibliography_id',
-            'description',
-            'user_id',
-            'created_at',
-            'updated_at',
-            'bibliography',
-        ]);
-        $response->assertJson([
-            'entity_id' => 2,
-            'attribute_id' => 14,
-            'bibliography_id' => 1322,
-            'description' => 'This is a simple test',
-            'user_id' => 1,
-            'bibliography' => [
-                'id' => 1322,
-                'entry_type' => 'article',
-                'citekey' => 'Sh:5'
             ],
-        ]);
+        ],
+        'https://spacialist.escience.uni-tuebingen.de/<user-project>/notizen#20171220105603' => [
+            [
+                'id' => 3,
+                'entity_id' => 1,
+                'attribute_id' => 13,
+                'bibliography_id' => 1323,
+                'description' => 'Page 10ff is interesting',
+                'user_id' => 1,
+                'created_at' => '2019-03-08T13:37:09.000000Z',
+                'updated_at' => '2019-03-08T13:37:09.000000Z',
+                'bibliography' => [
+                    'id' => 1323
+                ],
+            ],
+        ]
+    ]);
+});
 
-        $cnt = Reference::count();
-        $this->assertEquals($cnt, 4);
-    }
+test('new reference endpoint', function () {
+    $cnt = Reference::count();
+    expect(3)->toEqual($cnt);
 
+    $response = $this->userRequest()
+    ->post('/api/v1/entity/2/reference/14', [
+        'bibliography_id' => 1322,
+        'description' => 'This is a simple test',
+    ]);
 
-    // ==========================================
-    //              [[ PATCH ]]
-    // ==========================================
+    $response->assertStatus(201);
+    $response->assertJsonStructure([
+        'id',
+        'entity_id',
+        'attribute_id',
+        'bibliography_id',
+        'description',
+        'user_id',
+        'created_at',
+        'updated_at',
+        'bibliography',
+    ]);
+    $response->assertJson([
+        'entity_id' => 2,
+        'attribute_id' => 14,
+        'bibliography_id' => 1322,
+        'description' => 'This is a simple test',
+        'user_id' => 1,
+        'bibliography' => [
+            'id' => 1322,
+            'entry_type' => 'article',
+            'citekey' => 'Sh:5'
+        ],
+    ]);
 
-    #[TestDox('PATCH  /api/v1/entity/reference/{id}  -  Patch description of an entity reference (id=1)')]
-    public function testPatchReferenceEndpoint()
-    {
-        $reference = Reference::find(2);
-        $this->assertEquals(1, $reference->entity_id);
-        $this->assertEquals(15, $reference->attribute_id);
-        $this->assertEquals(1319, $reference->bibliography_id);
-        $this->assertEquals('Picture on left side of page 12', $reference->description);
+    $cnt = Reference::count();
+    expect(4)->toEqual($cnt);
+});
 
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/reference/2', [
-            'description' => 'Page 12 was wrong, it is Page 15!',
-        ]);
+test('patch reference endpoint', function () {
+    $reference = Reference::find(2);
+    expect($reference->entity_id)->toEqual(1);
+    expect($reference->attribute_id)->toEqual(15);
+    expect($reference->bibliography_id)->toEqual(1319);
+    expect($reference->description)->toEqual('Picture on left side of page 12');
 
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'id',
-            'entity_id',
-            'attribute_id',
-            'bibliography_id',
-            'description',
-            'user_id',
-            'created_at',
-            'updated_at',
-        ]);
-        $response->assertJson([
-            'entity_id' => 1,
-            'attribute_id' => 15,
-            'bibliography_id' => 1319,
-            'description' => 'Page 12 was wrong, it is Page 15!',
-            'user_id' => 1,
-        ]);
-    }
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/reference/2', [
+        'description' => 'Page 12 was wrong, it is Page 15!',
+    ]);
 
-    #[TestDox('PATCH  /api/v1/entity/reference/{id}  -  Patch without description of an entity reference (id=1)')]
-    public function testPatchReferenceMissingDescriptionEndpoint()
-    {
-        $reference = Reference::find(2);
-        $this->assertEquals(1, $reference->entity_id);
-        $this->assertEquals(15, $reference->attribute_id);
-        $this->assertEquals(1319, $reference->bibliography_id);
-        $this->assertEquals('Picture on left side of page 12', $reference->description);
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'id',
+        'entity_id',
+        'attribute_id',
+        'bibliography_id',
+        'description',
+        'user_id',
+        'created_at',
+        'updated_at',
+    ]);
+    $response->assertJson([
+        'entity_id' => 1,
+        'attribute_id' => 15,
+        'bibliography_id' => 1319,
+        'description' => 'Page 12 was wrong, it is Page 15!',
+        'user_id' => 1,
+    ]);
+});
 
-        $response = $this->userRequest()
-        ->patch('/api/v1/entity/reference/2');
+test('patch reference missing description endpoint', function () {
+    $reference = Reference::find(2);
+    expect($reference->entity_id)->toEqual(1);
+    expect($reference->attribute_id)->toEqual(15);
+    expect($reference->bibliography_id)->toEqual(1319);
+    expect($reference->description)->toEqual('Picture on left side of page 12');
 
-        $response->assertStatus(422);
-    }
+    $response = $this->userRequest()
+    ->patch('/api/v1/entity/reference/2');
 
-    // ==========================================
-    //              [[ DELETE ]]
-    // ==========================================
+    $response->assertStatus(422);
+});
 
-    #[TestDox('DELETE /api/v1/entity/reference/{id}  -  Delete a reference (id=1).')]
-     public function testDeleteReferenceEndpoint()
-    {
-        $cnt = Reference::count();
-        $this->assertEquals($cnt, 3);
+test('delete reference endpoint', function () {
+    $cnt = Reference::count();
+    expect(3)->toEqual($cnt);
 
-        $response = $this->userRequest()
-            ->delete('/api/v1/entity/reference/1');
+    $response = $this->userRequest()
+        ->delete('/api/v1/entity/reference/1');
 
-        $response->assertStatus(204);
+    $response->assertStatus(204);
 
-        $cnt = Reference::count();
-        $this->assertEquals($cnt, 2);
-    }
+    $cnt = Reference::count();
+    expect(2)->toEqual($cnt);
+});
 
-    // ==========================================
-    //      [[ ADDITIONAL DATA PROVIDERS ]]
-    // ==========================================
+test('without permission', function ($permission) {
+    (new ResponseTester($this))->testMissingPermission($permission);
+})->with('permissions');
 
-    #[DataProvider('permissions')]
-    #[TestDox('[[PROVIDER]] Routes Without Permissions')]
-    public function testWithoutPermission($permission) {
-        (new ResponseTester($this))->testMissingPermission($permission);
-    }
-    
-    #[DataProvider('exceptions')]
-    #[TestDox('[[PROVIDER]] Exceptions With Permissions')]
-    public function testSucceedWithPermission($permission) {
-        (new ResponseTester($this))->testExceptions($permission);
-    }
+test('succeed with permission', function ($permission) {
+    (new ResponseTester($this))->testExceptions($permission);
+})->with('exceptions');
 
-    public static function permissions() {
-        return [
-            "GET    /api/v1/entity/99/reference"    => Permission::for("get",      "/api/v1/entity/99/reference",      "You do not have the permission to view references"),
-            "POST   /api/v1/entity/99/reference/99" => Permission::for("post",     "/api/v1/entity/99/reference/99",   "You do not have the permission to add references"),
-            "PATCH  /api/v1/entity/reference/99"    => Permission::for("patch",    "/api/v1/entity/reference/99",      "You do not have the permission to edit references"),
-            "DELETE /api/v1/entity/reference/99"    => Permission::for("delete",   "/api/v1/entity/reference/99",      "You do not have the permission to delete references"),
-        ];
-    }
+dataset('permissions', function () {
+    return [
+        "GET    /api/v1/entity/99/reference"    => Permission::for("get",      "/api/v1/entity/99/reference",      "You do not have the permission to view references"),
+        "POST   /api/v1/entity/99/reference/99" => Permission::for("post",     "/api/v1/entity/99/reference/99",   "You do not have the permission to add references"),
+        "PATCH  /api/v1/entity/reference/99"    => Permission::for("patch",    "/api/v1/entity/reference/99",      "You do not have the permission to edit references"),
+        "DELETE /api/v1/entity/reference/99"    => Permission::for("delete",   "/api/v1/entity/reference/99",      "You do not have the permission to delete references"),
+    ];
+});
 
-    public static function exceptions() {
-        return [
-            "GET    /api/v1/entity/99/reference" =>Permission::for("get",      "/api/v1/entity/99/reference",      "This entity does not exist"),
-            "POST   /api/v1/entity/99/reference/99" =>Permission::for("post",     "/api/v1/entity/99/reference/99",   "This entity does not exist", ["bibliography_id" => 1322, "description" => "This is a simple test"]),
-            "POST   /api/v1/entity/1/reference/99" =>Permission::for("post",     "/api/v1/entity/1/reference/99",      "This attribute does not exist", ["bibliography_id" => 1322, "description" => "This is a simple test"]),
-            "PATCH  /api/v1/entity/reference/99" =>Permission::for("patch",    "/api/v1/entity/reference/99",      "This reference does not exist", ["description" => "This is a simple test"]),
-            "DELETE /api/v1/entity/reference/99" =>Permission::for("delete",   "/api/v1/entity/reference/99",      "This reference does not exist"),
-        ];
-    }
-}
+dataset('exceptions', function () {
+    return [
+        "GET    /api/v1/entity/99/reference" =>Permission::for("get",      "/api/v1/entity/99/reference",      "This entity does not exist"),
+        "POST   /api/v1/entity/99/reference/99" =>Permission::for("post",     "/api/v1/entity/99/reference/99",   "This entity does not exist", ["bibliography_id" => 1322, "description" => "This is a simple test"]),
+        "POST   /api/v1/entity/1/reference/99" =>Permission::for("post",     "/api/v1/entity/1/reference/99",      "This attribute does not exist", ["bibliography_id" => 1322, "description" => "This is a simple test"]),
+        "PATCH  /api/v1/entity/reference/99" =>Permission::for("patch",    "/api/v1/entity/reference/99",      "This reference does not exist", ["description" => "This is a simple test"]),
+        "DELETE /api/v1/entity/reference/99" =>Permission::for("delete",   "/api/v1/entity/reference/99",      "This reference does not exist"),
+    ];
+});

--- a/tests/Feature/ApiSearchTest.php
+++ b/tests/Feature/ApiSearchTest.php
@@ -4,7 +4,6 @@ use App\Bibliography;
 use App\Entity;
 use App\ThLanguage;
 use App\User;
-use PHPUnit\Framework\Attributes\TestDox;
 
 
 test('global search entity endpoint', function () {

--- a/tests/Feature/ApiSearchTest.php
+++ b/tests/Feature/ApiSearchTest.php
@@ -1,411 +1,359 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Bibliography;
 use App\Entity;
 use App\ThLanguage;
 use App\User;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\TestDox;
 
-class ApiSearchTest extends TestCase
-{
-    // Testing GET requests
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search : Search Global for Entity')]
-    public function testGlobalSearchEntityEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/search?q=!e inv.');
+test('global search entity endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/search?q=!e inv.');
 
-        $response->assertJsonCount(3);
-        $response->assertJsonStructure([
-            [
-                'searchable' => [
-                    'id',
-                    'name',
-                    'entity_type_id',
-                    'root_entity_id',
-                    'rank',
-                    'user_id',
-                    'created_at',
-                    'updated_at',
-                    'parentIds',
-                ],
-                'title',
-                'url',
-                'type',
-            ]
-        ]);
+    $response->assertJsonCount(3);
+    $response->assertJsonStructure([
+        [
+            'searchable' => [
+                'id',
+                'name',
+                'entity_type_id',
+                'root_entity_id',
+                'rank',
+                'user_id',
+                'created_at',
+                'updated_at',
+                'parentIds',
+            ],
+            'title',
+            'url',
+            'type',
+        ]
+    ]);
 
-        $response->assertJsonFragment([
-            'searchable' => Entity::find(3)->toArray(),
-            'title' => 'Inv. 1234',
-            'type' => 'entities',
-            'url' => null,
-        ]);
-        $response->assertJsonFragment([
-            'searchable' => Entity::find(4)->toArray(),
-            'title' => 'Inv. 124',
-            'type' => 'entities',
-            'url' => null,
-        ]);
-        $response->assertJsonFragment([
-            'searchable' => Entity::find(5)->toArray(),
-            'title' => 'Inv. 31',
-            'type' => 'entities',
-            'url' => null,
-        ]);
+    $response->assertJsonFragment([
+        'searchable' => Entity::find(3)->toArray(),
+        'title' => 'Inv. 1234',
+        'type' => 'entities',
+        'url' => null,
+    ]);
+    $response->assertJsonFragment([
+        'searchable' => Entity::find(4)->toArray(),
+        'title' => 'Inv. 124',
+        'type' => 'entities',
+        'url' => null,
+    ]);
+    $response->assertJsonFragment([
+        'searchable' => Entity::find(5)->toArray(),
+        'title' => 'Inv. 31',
+        'type' => 'entities',
+        'url' => null,
+    ]);
+});
+
+test('global search bibliography endpoint', function () {
+    $fields = [
+        'entry_type' => 'article',
+        'citekey' => '',
+        'title' => 'Testing API',
+        'author' => 'API (Inv.) Tester',
+        'note' => 'Test Inv. Match Entity Name',
+        'user_id' => 1,
+        'year' => 2009
+    ];
+    $fields['citekey'] = Bibliography::computeCitationKey($fields);
+    $bibEntry = new Bibliography();
+    foreach($fields as $k => $v) {
+        $bibEntry->{$k} = $v;
     }
+    $bibEntry->save();
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search : Search Global for Bibliography')]
-    public function testGlobalSearchBibliographyEndpoint()
-    {
-        $fields = [
-            'entry_type' => 'article',
-            'citekey' => '',
-            'title' => 'Testing API',
-            'author' => 'API (Inv.) Tester',
-            'note' => 'Test Inv. Match Entity Name',
-            'user_id' => 1,
-            'year' => 2009
-        ];
-        $fields['citekey'] = Bibliography::computeCitationKey($fields);
-        $bibEntry = new Bibliography();
-        foreach($fields as $k => $v) {
-            $bibEntry->{$k} = $v;
-        }
-        $bibEntry->save();
+    $response = $this->userRequest()
+        ->get('/api/v1/search?q=!b iNv.');
 
-        $response = $this->userRequest()
-            ->get('/api/v1/search?q=!b iNv.');
-
-        $response->assertJsonCount(1);
-        $response->assertJsonStructure([
-            [
-                'searchable' => [
-                    'id',
-                    'entry_type',
-                    'citekey',
-                    'title',
-                    'author',
-                    'editor',
-                    'journal',
-                    'year',
-                    'pages',
-                    'volume',
-                    'number',
-                    'booktitle',
-                    'publisher',
-                    'address',
-                    'misc',
-                    'howpublished',
-                    'annote',
-                    'chapter',
-                    'crossref',
-                    'edition',
-                    'institution',
-                    'key',
-                    'month',
-                    'note',
-                    'organization',
-                    'school',
-                    'series',
-                    'user_id',
-                    'created_at',
-                    'updated_at',
-                ],
+    $response->assertJsonCount(1);
+    $response->assertJsonStructure([
+        [
+            'searchable' => [
+                'id',
+                'entry_type',
+                'citekey',
                 'title',
-                'url',
-                'type',
-            ]
-        ]);
-        $response->assertJson([
-            [
-                'searchable' => Bibliography::find($bibEntry->id)->toArray(),
-                'title' => 'Testing API',
-                'type' => 'bibliography',
-                'url' => null,
-            ]
-        ]);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search : Search Global')]
-    public function testGlobalSearchAllEndpoint()
-    {
-        $nowTs = time();
-        $now = date('Y-m-d H:i:s', $nowTs);
-
-        $fields = [
-            'entry_type' => 'article',
-            'citekey' => '',
-            'title' => 'Testing API',
-            'author' => 'API (Inv.) Tester',
-            'note' => 'Test Inv. Match Entity Name',
-            'user_id' => 1,
-            'year' => 2009
-        ];
-        $fields['citekey'] = Bibliography::computeCitationKey($fields);
-        $bibEntry = new Bibliography();
-        foreach($fields as $k => $v) {
-            $bibEntry->{$k} = $v;
-        }
-        $bibEntry->save();
-
-        $response = $this->userRequest()
-            ->get('/api/v1/search?q=inV.');
-
-        $response->assertJsonCount(4);
-
-        $response->assertJsonFragment([
-            'title' => 'Inv. 1234',
-            'type' => 'entities'
-        ]);
-        $response->assertJsonFragment([
-            'title' => 'Inv. 124',
-            'type' => 'entities'
-        ]);
-        $response->assertJsonFragment([
-            'title' => 'Inv. 31',
-            'type' => 'entities'
-        ]);
-        $response->assertJsonFragment([
+                'author',
+                'editor',
+                'journal',
+                'year',
+                'pages',
+                'volume',
+                'number',
+                'booktitle',
+                'publisher',
+                'address',
+                'misc',
+                'howpublished',
+                'annote',
+                'chapter',
+                'crossref',
+                'edition',
+                'institution',
+                'key',
+                'month',
+                'note',
+                'organization',
+                'school',
+                'series',
+                'user_id',
+                'created_at',
+                'updated_at',
+            ],
+            'title',
+            'url',
+            'type',
+        ]
+    ]);
+    $response->assertJson([
+        [
+            'searchable' => Bibliography::find($bibEntry->id)->toArray(),
             'title' => 'Testing API',
             'type' => 'bibliography',
-            'searchable' => Bibliography::find($bibEntry->id)->toArray(),
-        ]);
+            'url' => null,
+        ]
+    ]);
+});
+
+test('global search all endpoint', function () {
+    $nowTs = time();
+    $now = date('Y-m-d H:i:s', $nowTs);
+
+    $fields = [
+        'entry_type' => 'article',
+        'citekey' => '',
+        'title' => 'Testing API',
+        'author' => 'API (Inv.) Tester',
+        'note' => 'Test Inv. Match Entity Name',
+        'user_id' => 1,
+        'year' => 2009
+    ];
+    $fields['citekey'] = Bibliography::computeCitationKey($fields);
+    $bibEntry = new Bibliography();
+    foreach($fields as $k => $v) {
+        $bibEntry->{$k} = $v;
     }
+    $bibEntry->save();
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search/entity : Search Entity')]
-    public function testEntitySearchEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/search/entity?q=Inv.');
+    $response = $this->userRequest()
+        ->get('/api/v1/search?q=inV.');
 
-        $content = json_decode($response->getContent());
-        $response->assertStatus(200);
-        $response->assertJsonCount(10);
-        // response content is Laravel Paginate Array
-        $this->assertObjectHasProperty('data', $content);
-        $this->assertObjectHasProperty('from', $content);
-        $this->assertObjectHasProperty('to', $content);
-        $this->assertObjectHasProperty('per_page', $content);
-        $this->assertObjectHasProperty('current_page', $content);
-        $this->assertObjectHasProperty('current_page_url', $content);
-        $this->assertObjectHasProperty('first_page_url', $content);
-        $this->assertObjectHasProperty('next_page_url', $content);
-        $this->assertObjectHasProperty('prev_page_url', $content);
-        $this->assertObjectHasProperty('path', $content);
+    $response->assertJsonCount(4);
 
-        $this->assertObjectHasProperty('id', $content->data[0]);
-        $this->assertObjectHasProperty('name', $content->data[0]);
-        $this->assertObjectHasProperty('entity_type_id', $content->data[0]);
-        $this->assertObjectHasProperty('root_entity_id', $content->data[0]);
-        $this->assertObjectHasProperty('rank', $content->data[0]);
-        $this->assertObjectHasProperty('user_id', $content->data[0]);
-        $this->assertObjectHasProperty('created_at', $content->data[0]);
-        $this->assertObjectHasProperty('updated_at', $content->data[0]);
-        $this->assertObjectHasProperty('ancestors', $content->data[0]);
+    $response->assertJsonFragment([
+        'title' => 'Inv. 1234',
+        'type' => 'entities'
+    ]);
+    $response->assertJsonFragment([
+        'title' => 'Inv. 124',
+        'type' => 'entities'
+    ]);
+    $response->assertJsonFragment([
+        'title' => 'Inv. 31',
+        'type' => 'entities'
+    ]);
+    $response->assertJsonFragment([
+        'title' => 'Testing API',
+        'type' => 'bibliography',
+        'searchable' => Bibliography::find($bibEntry->id)->toArray(),
+    ]);
+});
 
-        $this->assertEquals('Inv. 1234', $content->data[0]->name);
-        $this->assertEquals('Inv. 124', $content->data[1]->name);
-        $this->assertEquals('Inv. 31', $content->data[2]->name);
-    }
+test('entity search endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/search/entity?q=Inv.');
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search/label : Search for Thesaurex Label')]
-    public function testLabelSearchEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/search/label?q=ind');
+    $content = json_decode($response->getContent());
+    $response->assertStatus(200);
+    $response->assertJsonCount(10);
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'concept_url',
-                'concept_scheme',
-                'is_top_concept',
-                'user_id',
-                'created_at',
-                'updated_at',
-                'labels',
-                'parent_path'
-            ]
-        ]);
-        $response->assertJson([
-            [
-                'id' => 3,
-                'is_top_concept' => true,
-                'labels' => [
-                    [
-                        'label' => 'Fundobjekt',
-                        'language_id' => 1
-                    ],
-                    [
-                        'label' => 'Find',
-                        'language_id' => 2
-                    ]
-                ]
-            ],
-            [
-                'id' => 41,
-                'is_top_concept' => false,
-                'labels' => [
-                    [
-                        'label' => 'Kammeindruck',
-                        'language_id' => 1
-                    ]
+    // response content is Laravel Paginate Array
+    $this->assertObjectHasProperty('data', $content);
+    $this->assertObjectHasProperty('from', $content);
+    $this->assertObjectHasProperty('to', $content);
+    $this->assertObjectHasProperty('per_page', $content);
+    $this->assertObjectHasProperty('current_page', $content);
+    $this->assertObjectHasProperty('current_page_url', $content);
+    $this->assertObjectHasProperty('first_page_url', $content);
+    $this->assertObjectHasProperty('next_page_url', $content);
+    $this->assertObjectHasProperty('prev_page_url', $content);
+    $this->assertObjectHasProperty('path', $content);
+
+    $this->assertObjectHasProperty('id', $content->data[0]);
+    $this->assertObjectHasProperty('name', $content->data[0]);
+    $this->assertObjectHasProperty('entity_type_id', $content->data[0]);
+    $this->assertObjectHasProperty('root_entity_id', $content->data[0]);
+    $this->assertObjectHasProperty('rank', $content->data[0]);
+    $this->assertObjectHasProperty('user_id', $content->data[0]);
+    $this->assertObjectHasProperty('created_at', $content->data[0]);
+    $this->assertObjectHasProperty('updated_at', $content->data[0]);
+    $this->assertObjectHasProperty('ancestors', $content->data[0]);
+
+    expect($content->data[0]->name)->toEqual('Inv. 1234');
+    expect($content->data[1]->name)->toEqual('Inv. 124');
+    expect($content->data[2]->name)->toEqual('Inv. 31');
+});
+
+test('label search endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/search/label?q=ind');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'concept_url',
+            'concept_scheme',
+            'is_top_concept',
+            'user_id',
+            'created_at',
+            'updated_at',
+            'labels',
+            'parent_path'
+        ]
+    ]);
+    $response->assertJson([
+        [
+            'id' => 3,
+            'is_top_concept' => true,
+            'labels' => [
+                [
+                    'label' => 'Fundobjekt',
+                    'language_id' => 1
                 ],
-                'parent_path' => [
-                    ["Fundobjekt","Art Fundobjekt","Keramik","Verzierung","Verzierungselement","Kammeindruck"]
+                [
+                    'label' => 'Find',
+                    'language_id' => 2
+                ]
+            ]
+        ],
+        [
+            'id' => 41,
+            'is_top_concept' => false,
+            'labels' => [
+                [
+                    'label' => 'Kammeindruck',
+                    'language_id' => 1
                 ]
             ],
-        ]);
-    }
+            'parent_path' => [
+                ["Fundobjekt","Art Fundobjekt","Keramik","Verzierung","Verzierungselement","Kammeindruck"]
+            ]
+        ],
+    ]);
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search/attribute : Search Attributes')]
-    public function testAttributeSearchEndpoint()
-    {
+test('attribute search endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/search/attribute?q=ung');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(1);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'thesaurus_url',
+            'datatype',
+            'text',
+            'thesaurus_root_url',
+            'parent_id',
+            'created_at',
+            'updated_at',
+            'recursive',
+            'root_attribute_id',
+            'thesaurus_concept'
+        ]
+    ]);
+    $response->assertJson([
+        [
+            'id' => 7,
+            'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440',
+            'datatype' => 'string-sc',
+            'text' => null,
+            'thesaurus_root_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440',
+            'parent_id' => 5,
+            'recursive' => TRUE,
+            'root_attribute_id' => null,
+            'thesaurus_concept' => [
+                'id' => 34
+            ]
+        ]
+    ]);
+});
+
+test('selection search endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/search/selection/13');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(5);
+    $response->assertJsonStructure([
+        [
+            'id',
+            'concept_url',
+            'concept_scheme',
+            'is_top_concept',
+            'user_id',
+            'broader_id',
+            'narrower_id',
+            'created_at',
+            'updated_at'
+        ]
+    ]);
+    $response->assertJson([
+        ['id' => 15],
+        ['id' => 16],
+        ['id' => 17],
+        ['id' => 43],
+        ['id' => 47]
+    ]);
+});
+
+test('permissions', function () {
+    User::first()->roles()->detach();
+
+    $calls = [
+        ['url' => '', 'error' => 'You do not have the permission to search global'],
+        ['url' => '/entity', 'error' => 'You do not have the permission to search for entities'],
+        ['url' => '/label', 'error' => 'You do not have the permission to search for concepts'],
+        ['url' => '/selection/12', 'error' => 'You do not have the permission to search for concepts'],
+    ];
+
+    $response = null;
+    foreach($calls as $c) {
         $response = $this->userRequest()
-            ->get('/api/v1/search/attribute?q=ung');
+            ->get('/api/v1/search' . $c['url']);
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(1);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'thesaurus_url',
-                'datatype',
-                'text',
-                'thesaurus_root_url',
-                'parent_id',
-                'created_at',
-                'updated_at',
-                'recursive',
-                'root_attribute_id',
-                'thesaurus_concept'
-            ]
-        ]);
-        $response->assertJson([
-            [
-                'id' => 7,
-                'thesaurus_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440',
-                'datatype' => 'string-sc',
-                'text' => null,
-                'thesaurus_root_url' => 'https://spacialist.escience.uni-tuebingen.de/<user-project>/verzierungselement#20171220105440',
-                'parent_id' => 5,
-                'recursive' => TRUE,
-                'root_attribute_id' => null,
-                'thesaurus_concept' => [
-                    'id' => 34
-                ]
-            ]
+        $this->assertStatus($response, 403);
+        $response->assertSimilarJson([
+            'error' => $c['error']
         ]);
     }
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/search/selection/{id} : Search in Attribute Selection')]
-    public function testSelectionSearchEndpoint()
-    {
+test('exceptions', function () {
+    $lang = User::first()->getLanguage();
+    ThLanguage::where('short_name', $lang)->delete();
+    $calls = [
+        ['url' => '/label', 'error' => 'Your language does not exist in ThesauRex'],
+        ['url' => '/selection/99', 'error' => 'This concept does not exist'],
+    ];
+
+    $response = null;
+    foreach($calls as $c) {
         $response = $this->userRequest()
-            ->get('/api/v1/search/selection/13');
+            ->get('/api/v1/search' . $c['url']);
 
-        $response->assertStatus(200);
-        $response->assertJsonCount(5);
-        $response->assertJsonStructure([
-            [
-                'id',
-                'concept_url',
-                'concept_scheme',
-                'is_top_concept',
-                'user_id',
-                'broader_id',
-                'narrower_id',
-                'created_at',
-                'updated_at'
-            ]
-        ]);
-        $response->assertJson([
-            ['id' => 15],
-            ['id' => 16],
-            ['id' => 17],
-            ['id' => 43],
-            ['id' => 47]
+        $this->assertStatus($response, 400);
+        $response->assertSimilarJson([
+            'error' => $c['error']
         ]);
     }
-
-    // Testing exceptions and permissions
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('Test Permissions')]
-    public function testPermissions()
-    {
-        User::first()->roles()->detach();
-
-        $calls = [
-            ['url' => '', 'error' => 'You do not have the permission to search global'],
-            ['url' => '/entity', 'error' => 'You do not have the permission to search for entities'],
-            ['url' => '/label', 'error' => 'You do not have the permission to search for concepts'],
-            ['url' => '/selection/12', 'error' => 'You do not have the permission to search for concepts'],
-        ];
-
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->get('/api/v1/search' . $c['url']);
-
-            $this->assertStatus($response, 403);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
-    }
-    /**
-	 * @return void
-	 */
-	#[TestDox('Test Exceptions')]
-    public function testExceptions()
-    {
-        $lang = User::first()->getLanguage();
-        ThLanguage::where('short_name', $lang)->delete();
-        $calls = [
-            ['url' => '/label', 'error' => 'Your language does not exist in ThesauRex'],
-            ['url' => '/selection/99', 'error' => 'This concept does not exist'],
-        ];
-
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->get('/api/v1/search' . $c['url']);
-
-            $this->assertStatus($response, 400);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
-    }
-}
+});

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,109 +1,80 @@
 <?php
 
-namespace Tests\Feature;
-
-use Tests\TestCase;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\TestDox;
 
 use App\VersionInfo;
 
-class ApiTest extends TestCase
-{
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    / : Get Base App Endpoint')]
-    public function testApiRoot()
-    {
-        $response = $this->get('/');
 
-        $response->assertStatus(200);
+test('api root', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});
+
+test('welcome page', function () {
+    $response = $this->get('/welcome');
+
+    $response->assertStatus(200);
+});
+
+test('unauth pre request', function () {
+    $this->unsetTestUser();
+
+    // Unauthenticated request redirects to /login
+    $response = $this->get('/api/v1/pre');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('/login');
+});
+
+test('auth pre request', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/pre');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(21);
+    $response->assertJsonStructure([
+        'system_preferences',
+        'preferences',
+        'concepts',
+        'entityTypes',
+        'datatype_data',
+        'colorsets',
+        'analysis',
+        'attributes',
+        'attributeSelections',
+        'users',
+        'deleted_users',
+        'roles',
+        'permissions',
+        'presets',
+        'topEntities',
+        'bibliography',
+        'tags',
+        'version',
+        'plugins',
+        'geometryTypes',
+        'attributeTypes',
+    ]);
+});
+
+test('version request', function () {
+    $vi = new VersionInfo();
+    $response = $this->userRequest()
+        ->get('/api/v1/version');
+
+    $response->assertStatus(200);
+    $content = $response->decodeResponseJson();
+    expect($content['time'])->toMatch('/^\d+$/');
+    expect($content['name'])->toMatch('/^[A-ZÄÖÜ][a-zäöüß]+$/');
+    expect($content['release'])->toMatch('/^v\d+\.\d+\.\d+$/');
+    expect($content['readable'])->toMatch('/^v\d+\.\d+\.\d+ \([A-ZÄÖÜ][a-zäöüß]+\)$/');
+    expect($content['full'])->toMatch('/^v\d+\.\d+\.\d+-[a-zäöüß]+(-g[a-f0-9]{8})?$/');
+    expect('v' . $vi->getMajor() . "." . $vi->getMinor() . "." . $vi->getPatch())->toEqual($content['release']);
+
+    $hash = $vi->getReleaseHash();
+    if(isset($hash)) {
+        expect(Str::endsWith($content['full'], $hash))->toBeTrue();
     }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /welcome : Get Welcome Page Endpoint')]
-    public function testWelcomePage()
-    {
-        $response = $this->get('/welcome');
-
-        $response->assertStatus(200);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/pre : Get Pre Endpoint Failed Unauth')]
-    public function testUnauthPreRequest()
-    {
-        $this->unsetTestUser();
-        // Unauthenticated request redirects to /login
-        $response = $this->get('/api/v1/pre');
-
-        $response->assertStatus(302);
-        $response->assertRedirect('/login');
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/pre : Get Pre Endpoint')]
-    public function testAuthPreRequest()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/pre');
-
-        $response->assertStatus(200);
-        $response->assertJsonCount(21);
-        $response->assertJsonStructure([
-            'system_preferences',
-            'preferences',
-            'concepts',
-            'entityTypes',
-            'datatype_data',
-            'colorsets',
-            'analysis',
-            'attributes',
-            'attributeSelections',
-            'users',
-            'deleted_users',
-            'roles',
-            'permissions',
-            'presets',
-            'topEntities',
-            'bibliography',
-            'tags',
-            'version',
-            'plugins',
-            'geometryTypes',
-            'attributeTypes',
-        ]);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/version : Get Version Endpoint')]
-    public function testVersionRequest()
-    {
-        $vi = new VersionInfo();
-        $response = $this->userRequest()
-            ->get('/api/v1/version');
-
-        $response->assertStatus(200);
-        $content = $response->decodeResponseJson();
-        $this->assertMatchesRegularExpression('/^\d+$/', $content['time']);
-        $this->assertMatchesRegularExpression('/^[A-ZÄÖÜ][a-zäöüß]+$/', $content['name']);
-        $this->assertMatchesRegularExpression('/^v\d+\.\d+\.\d+$/', $content['release']);
-        $this->assertMatchesRegularExpression('/^v\d+\.\d+\.\d+ \([A-ZÄÖÜ][a-zäöüß]+\)$/', $content['readable']);
-        $this->assertMatchesRegularExpression('/^v\d+\.\d+\.\d+-[a-zäöüß]+(-g[a-f0-9]{8})?$/', $content['full']);
-        $this->assertEquals($content['release'], 'v' . $vi->getMajor() . "." . $vi->getMinor() . "." . $vi->getPatch());
-
-        $hash = $vi->getReleaseHash();
-        if(isset($hash)) {
-            $this->assertTrue(Str::endsWith($content['full'], $hash));
-        }
-    }
-}
+});

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -65,7 +65,7 @@ test('version request', function () {
 
     $response->assertStatus(200);
     $content = $response->decodeResponseJson();
-    expect($content['time'])->toMatch('/^\d+$/');
+    expect((string)$content['time'])->toMatch('/^\d+$/');
     expect($content['name'])->toMatch('/^[A-ZÄÖÜ][a-zäöüß]+$/');
     expect($content['release'])->toMatch('/^v\d+\.\d+\.\d+$/');
     expect($content['readable'])->toMatch('/^v\d+\.\d+\.\d+ \([A-ZÄÖÜ][a-zäöüß]+\)$/');

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use PHPUnit\Framework\Attributes\TestDox;
 
 use App\VersionInfo;
 

--- a/tests/Feature/ApiUserTest.php
+++ b/tests/Feature/ApiUserTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Http\UploadedFile;
-use PHPUnit\Framework\Attributes\TestDox;
 
 use App\User;
 use App\Role;

--- a/tests/Feature/ApiUserTest.php
+++ b/tests/Feature/ApiUserTest.php
@@ -1,8 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
-use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\TestDox;
 
@@ -10,730 +7,578 @@ use App\User;
 use App\Role;
 use Carbon\Carbon;
 
-class ApiUserTest extends TestCase
-{
-    // Testing GET requests
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/auth/user : Get Auth User')]
-    public function testGetUserEndpoint()
-    {
-        $user = User::find(1);
-        $user->setPermissions();
-        $response = $this->userRequest()
-            ->get('/api/v1/auth/user');
+test('get user endpoint', function () {
+    $user = User::find(1);
+    $user->setPermissions();
+    $response = $this->userRequest()
+        ->get('/api/v1/auth/user');
 
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'status',
-            'data'
-        ]);
-        $response->assertJson([
-            'status' => 'success',
-            'data' => [
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'status',
+        'data'
+    ]);
+    $response->assertJson([
+        'status' => 'success',
+        'data' => [
+            'id' => 1,
+            'name' => 'Admin',
+            'nickname' => 'admin',
+            'email' => 'admin@localhost',
+            'created_at' => '2017-12-20T09:47:36.000000Z',
+            'updated_at' => '2017-12-20T09:47:36.000000Z',
+            'permissions' => []
+        ]
+    ]);
+
+    // Check permission count (45 permissions in total)
+    $content = json_decode($response->getContent());
+    expect(45)->toEqual(count(get_object_vars($content->data->permissions)));
+});
+
+test('get users endpoint', function () {
+    $user = User::factory()->create();
+
+    $response = $this->userRequest()
+        ->get('/api/v1/user');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(2);
+    $response->assertJsonStructure([
+        'users',
+        'deleted_users',
+    ]);
+    $response->assertJson([
+        'users' => [
+            [
                 'id' => 1,
                 'name' => 'Admin',
-                'nickname' => 'admin',
-                'email' => 'admin@localhost',
-                'created_at' => '2017-12-20T09:47:36.000000Z',
-                'updated_at' => '2017-12-20T09:47:36.000000Z',
-                'permissions' => []
-            ]
-        ]);
-
-        // Check permission count (45 permissions in total)
-        $content = json_decode($response->getContent());
-        $this->assertEquals(count(get_object_vars($content->data->permissions)), 45);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/user : Get All Users')]
-    public function testGetUsersEndpoint()
-    {
-        $user = User::factory()->create();
-
-        $response = $this->userRequest()
-            ->get('/api/v1/user');
-
-        $response->assertStatus(200);
-        $response->assertJsonCount(2);
-        $response->assertJsonStructure([
-            'users',
-            'deleted_users',
-        ]);
-        $response->assertJson([
-            'users' => [
-                [
-                    'id' => 1,
-                    'name' => 'Admin',
-                ],[
-                  'id' => 2,
-                    'name' => "John Doe",
-                ],[
-                    'id' => $user->id,
-                    'name' => $user->name,
-                ],
+            ],[
+              'id' => 2,
+                'name' => "John Doe",
+            ],[
+                'id' => $user->id,
+                'name' => $user->name,
             ],
-            'deleted_users' => [
-                [
-                    'id' => 3,
-                    'name' => "Gary Guest",
-                ],
-            ]
-        ]);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/role : Get All Roles')]
-    public function testGetRolesEndpoint()
-    {
-        $response = $this->userRequest()
-            ->get('/api/v1/role');
-
-        $response->assertStatus(200);
-        $response->assertJsonCount(3);
-        $response->assertJsonStructure([
-            'roles',
-            'permissions'
-        ]);
-        $response->assertJson([
-            'roles' => [
-                [
-                    'id' => 1,
-                    'name' => 'admin'
-                ],
-                [
-                    'id' => 2,
-                    'name' => 'guest'
-                ]
+        ],
+        'deleted_users' => [
+            [
+                'id' => 3,
+                'name' => "Gary Guest",
             ],
-            'permissions' => [],
-            'presets' => [],
+        ]
+    ]);
+});
+
+test('get roles endpoint', function () {
+    $response = $this->userRequest()
+        ->get('/api/v1/role');
+
+    $response->assertStatus(200);
+    $response->assertJsonCount(3);
+    $response->assertJsonStructure([
+        'roles',
+        'permissions'
+    ]);
+    $response->assertJson([
+        'roles' => [
+            [
+                'id' => 1,
+                'name' => 'admin'
+            ],
+            [
+                'id' => 2,
+                'name' => 'guest'
+            ]
+        ],
+        'permissions' => [],
+        'presets' => [],
+    ]);
+});
+
+test('login endpoint', function () {
+    $response = $this->userRequest()
+        ->post('/api/v1/auth/login', [
+            'email' => 'admin@localhost',
+            'password' => 'admin'
         ]);
-    }
 
-    // Testing POST requests
+    $response->assertStatus(200);
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/auth/login : Login')]
-    public function testLoginEndpoint()
-    {
-        $response = $this->userRequest()
-            ->post('/api/v1/auth/login', [
-                'email' => 'admin@localhost',
-                'password' => 'admin'
-            ]);
-
-        $response->assertStatus(200);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/auth/login : Login with nickname')]
-    public function testLoginWithNicknameEndpoint()
-    {
-        $response = $this->userRequest()
-            ->post('/api/v1/auth/login', [
-                'nickname' => 'admin',
-                'password' => 'admin'
-            ]);
-
-        $response->assertStatus(200);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('GET    /api/v1/user : Failed Login')]
-    public function testLoginWrongCredentialsEndpoint()
-    {
-        $response = $this->userRequest()
-            ->post('/api/v1/auth/login', [
-                'email' => 'admin@localhost',
-                'password' => 'admin1337'
-            ]);
-
-        $response->assertStatus(400);
-        $response->assertSimilarJson([
-            'error' => 'Invalid Credentials'
+test('login with nickname endpoint', function () {
+    $response = $this->userRequest()
+        ->post('/api/v1/auth/login', [
+            'nickname' => 'admin',
+            'password' => 'admin'
         ]);
-    }
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/user : Create User')]
-    public function testCreateUserEndpoint()
-    {
-        $cnt = User::count();
-        $this->assertEquals(2, $cnt);
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $response = $this->userRequest()
-            ->post('/api/v1/user', [
-                'email' => 'test@test.com',
-                'name' => 'Test User',
-                'nickname' => 'tuser',
-                'password' => 'test1234' // at least 6 characters
-            ]);
+    $response->assertStatus(200);
+});
 
-        $user = User::latest()->first();
-        $cnt = User::count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(4, $cnt);
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'id',
-            'email',
-            'name',
-            'created_at',
-            'updated_at'
+test('login wrong credentials endpoint', function () {
+    $response = $this->userRequest()
+        ->post('/api/v1/auth/login', [
+            'email' => 'admin@localhost',
+            'password' => 'admin1337'
         ]);
-        $response->assertJson([
-            'id' => $user->id,
+
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'Invalid Credentials'
+    ]);
+});
+
+test('create user endpoint', function () {
+    $cnt = User::count();
+    expect($cnt)->toEqual(2);
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $response = $this->userRequest()
+        ->post('/api/v1/user', [
             'email' => 'test@test.com',
             'name' => 'Test User',
             'nickname' => 'tuser',
-            'created_at' => $user->created_at->toJSON(),
-            'updated_at' => $user->updated_at->toJSON()
+            'password' => 'test1234' // at least 6 characters
         ]);
-    }
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/user/avatar : Add Avatar')]
-    public function testCreateAvatarEndpoint()
-    {
-        $user = User::find(1);
-        $this->assertNull($user->avatar);
-        $file = UploadedFile::fake()->image('spacialist_screenshot.png', 350, 100);
-        $response = $this->userRequest()
-            ->post('/api/v1/user/avatar', [
-                'file' => $file
-            ]);
+    $user = User::latest()->first();
+    $cnt = User::count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(4);
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'id',
+        'email',
+        'name',
+        'created_at',
+        'updated_at'
+    ]);
+    $response->assertJson([
+        'id' => $user->id,
+        'email' => 'test@test.com',
+        'name' => 'Test User',
+        'nickname' => 'tuser',
+        'created_at' => $user->created_at->toJSON(),
+        'updated_at' => $user->updated_at->toJSON()
+    ]);
+});
 
-        $user = User::find(1);
-        $this->assertEquals('avatars/1.png', $user->avatar);
-        $this->assertStatus($response, 200);
-        $response->assertJsonStructure([
-            'id',
-            'email',
-            'name',
-            'nickname',
-            'created_at',
-            'updated_at',
-            'avatar'
+test('create avatar endpoint', function () {
+    $user = User::find(1);
+    expect($user->avatar)->toBeNull();
+    $file = UploadedFile::fake()->image('spacialist_screenshot.png', 350, 100);
+    $response = $this->userRequest()
+        ->post('/api/v1/user/avatar', [
+            'file' => $file
         ]);
-        $response->assertJson([
-            'id' => 1,
-            'email' => 'admin@localhost',
-            'name' => 'Admin',
-            'avatar' => 'avatars/1.png'
-        ]);
-    }
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/role : Create Role')]
-    public function testCreateRoleEndpoint()
-    {
-        $cnt = Role::count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->post('/api/v1/role', [
-                'name' => 'test_role',
-                'display_name' => 'Test Role'
-            ]);
+    $user = User::find(1);
+    expect($user->avatar)->toEqual('avatars/1.png');
+    $this->assertStatus($response, 200);
+    $response->assertJsonStructure([
+        'id',
+        'email',
+        'name',
+        'nickname',
+        'created_at',
+        'updated_at',
+        'avatar'
+    ]);
+    $response->assertJson([
+        'id' => 1,
+        'email' => 'admin@localhost',
+        'name' => 'Admin',
+        'avatar' => 'avatars/1.png'
+    ]);
+});
 
-        $role = Role::latest()->first();
-        $cnt = Role::count();
-        $this->assertEquals(3, $cnt);
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'id',
-            'name',
-            'display_name',
-            'description',
-            'created_at',
-            'updated_at'
-        ]);
-        $response->assertJson([
-            'id' => $role->id,
+test('create role endpoint', function () {
+    $cnt = Role::count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->post('/api/v1/role', [
             'name' => 'test_role',
-            'display_name' => 'Test Role',
-            'description' => null,
-            'created_at' => $role->created_at->toJSON(),
-            'updated_at' => $role->updated_at->toJSON()
+            'display_name' => 'Test Role'
         ]);
+
+    $role = Role::latest()->first();
+    $cnt = Role::count();
+    expect($cnt)->toEqual(3);
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'id',
+        'name',
+        'display_name',
+        'description',
+        'created_at',
+        'updated_at'
+    ]);
+    $response->assertJson([
+        'id' => $role->id,
+        'name' => 'test_role',
+        'display_name' => 'Test Role',
+        'description' => null,
+        'created_at' => $role->created_at->toJSON(),
+        'updated_at' => $role->updated_at->toJSON()
+    ]);
+});
+
+test('logout endpoint', function () {
+    $cnt = Role::count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->post('/api/v1/auth/logout');
+
+    $response->assertStatus(200);
+    if($response->headers->has('authorization')) {
+        $token = $response->headers->get('authorization');
+
+        $response = $this->withHeaders([
+            'Authorization' => "$token"
+        ])
+        ->get('/api/v1/user');
+        $response->assertStatus(401);
+        expect($response->exception->getMessage())->toEqual("Unauthenticated.");
     }
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/auth/logout : Logout')]
-    public function testLogoutEndpoint()
-    {
-        $cnt = Role::count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->post('/api/v1/auth/logout');
+test('update avatar endpoint', function () {
+    $user = User::find(1);
+    expect($user->avatar)->toBeNull();
+    $file = UploadedFile::fake()->image('spacialist_screenshot.png', 350, 100);
+    $response = $this->userRequest()
+        ->post('/api/v1/user/avatar', [
+            'file' => $file
+        ]);
 
-        $response->assertStatus(200);
-        if($response->headers->has('authorization')) {
-            $token = $response->headers->get('authorization');
+    $user = User::find(1);
+    expect($user->avatar)->toEqual('avatars/1.png');
+    $this->assertStatus($response, 200);
+});
 
-            $response = $this->withHeaders([
-                'Authorization' => "$token"
-            ])
-            ->get('/api/v1/user');
-            $response->assertStatus(401);
-            $this->assertEquals("Unauthenticated.", $response->exception->getMessage());
-        }
-    }
+test('patch user endpoint', function () {
+    $user = User::find(1);
+    expect($user->name)->toEqual('Admin');
+    expect($user->nickname)->toEqual('admin');
+    expect($user->email)->toEqual('admin@localhost');
+    expect($user->metadata)->toBeNull();
+    expect($user->avatar)->toBeNull();
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('POST   /api/v1/user/avatar : Update User Avatar')]
-    public function testUpdateAvatarEndpoint()
-    {
-        $user = User::find(1);
-        $this->assertNull($user->avatar);
-        $file = UploadedFile::fake()->image('spacialist_screenshot.png', 350, 100);
-        $response = $this->userRequest()
-            ->post('/api/v1/user/avatar', [
-                'file' => $file
-            ]);
-
-        $user = User::find(1);
-        $this->assertEquals('avatars/1.png', $user->avatar);
-        $this->assertStatus($response, 200);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User')]
-    public function testPatchUserEndpoint()
-    {
-        $user = User::find(1);
-        $this->assertEquals('Admin', $user->name);
-        $this->assertEquals('admin', $user->nickname);
-        $this->assertEquals('admin@localhost', $user->email);
-        $this->assertNull($user->metadata);
-        $this->assertNull($user->avatar);
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/1', [
-                'roles' => [2],
-                'email' => 'test@test.com',
-                'name' => 'Admin Updated',
-                'nickname' => 'admin1',
-                'phonenumber' => '+43 123 1234',
-                'orcid' => '0000-0002-1694-233X'
-            ]);
-
-        $user = User::find(1);
-        $this->assertTrue(!$user->hasRole('admin'));
-        $this->assertTrue($user->hasRole('guest'));
-        $response->assertStatus(200);
-        $response->assertSimilarJson([
-            'id' => 1,
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/1', [
+            'roles' => [2],
+            'email' => 'test@test.com',
             'name' => 'Admin Updated',
             'nickname' => 'admin1',
-            'email' => 'test@test.com',
-            'created_at' => '2017-12-20T09:47:36.000000Z',
-            'updated_at' => $user->updated_at->toJSON(),
-            'deleted_at' => null,
-            'avatar' => null,
-            'login_attempts' => null,
-            'metadata' => [
-                'phonenumber' => '+43 123 1234',
-                'orcid' => '0000-0002-1694-233X',
-            ],
+            'phonenumber' => '+43 123 1234',
+            'orcid' => '0000-0002-1694-233X'
         ]);
 
-        $this->assertEquals('Admin Updated', $user->name);
-        $this->assertEquals('admin1', $user->nickname);
-        $this->assertEquals('test@test.com', $user->email);
-        $this->assertEquals('+43 123 1234', $user->metadata['phonenumber']);
-        $this->assertEquals('0000-0002-1694-233X', $user->metadata['orcid']);
-        $this->assertNull($user->avatar);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User Metadata')]
-    public function testPatchUserOrcidEndpoint()
-    {
-        $user = User::find(1);
-        $this->assertNull($user->metadata);
-        $user->metadata = [
+    $user = User::find(1);
+    expect(!$user->hasRole('admin'))->toBeTrue();
+    expect($user->hasRole('guest'))->toBeTrue();
+    $response->assertStatus(200);
+    $response->assertSimilarJson([
+        'id' => 1,
+        'name' => 'Admin Updated',
+        'nickname' => 'admin1',
+        'email' => 'test@test.com',
+        'created_at' => '2017-12-20T09:47:36.000000Z',
+        'updated_at' => $user->updated_at->toJSON(),
+        'deleted_at' => null,
+        'avatar' => null,
+        'login_attempts' => null,
+        'metadata' => [
+            'phonenumber' => '+43 123 1234',
             'orcid' => '0000-0002-1694-233X',
-        ];
-        $user->save();
+        ],
+    ]);
 
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/1', [
-                'orcid' => '0000-0001-5109-3700'
-            ]);
+    expect($user->name)->toEqual('Admin Updated');
+    expect($user->nickname)->toEqual('admin1');
+    expect($user->email)->toEqual('test@test.com');
+    expect($user->metadata['phonenumber'])->toEqual('+43 123 1234');
+    expect($user->metadata['orcid'])->toEqual('0000-0002-1694-233X');
+    expect($user->avatar)->toBeNull();
+});
 
-        $response->assertStatus(200);
-        $user = User::find(1);
-        $this->assertNotNull($user->metadata);
-        $this->assertEquals('0000-0001-5109-3700', $user->metadata['orcid']);
+test('patch user orcid endpoint', function () {
+    $user = User::find(1);
+    expect($user->metadata)->toBeNull();
+    $user->metadata = [
+        'orcid' => '0000-0002-1694-233X',
+    ];
+    $user->save();
 
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User Fail ORCID Check')]
-    public function testPatchUserWrongOrcidEndpoint()
-    {
-        $user = User::find(1);
-
-        $response = $this->userRequest()
-            ->json('patch', '/api/v1/user/1', [
-                'orcid' => '0000-0002-1694-2338'
-            ]);
-
-        $response->assertStatus(422);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User Fail ORCID Format')]
-    public function testPatchUserAnotherWrongOrcidEndpoint()
-    {
-        $user = User::find(1);
-
-        $response = $this->userRequest()
-            ->json('patch', '/api/v1/user/1', [
-                'orcid' => '0000-0002-1694233X'
-            ]);
-
-        $response->assertStatus(422);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User Fail ORCID Format')]
-    public function testPatchUserAnotherSecondWrongOrcidEndpoint()
-    {
-        $user = User::find(1);
-
-        $response = $this->userRequest()
-            ->json('patch', '/api/v1/user/1', [
-                'orcid' => '0000-0002-1694-23aX'
-            ]);
-
-        $response->assertStatus(422);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/{id} : Patch User Emtpy Request')]
-    public function testPatchUserWithoutDataEndpoint()
-    {
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/1', []);
-
-        $response->assertStatus(204);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/role/{id} : Patch Role Permissions')]
-    public function testPatchRoleEndpoint()
-    {
-        $response = $this->userRequest()
-            ->patch('/api/v1/role/1', [
-                'permissions' => [1, 2],
-                'display_name' => 'NOT Admin',
-                'description' => 'No longer a Admin User'
-            ]);
-
-        $role = Role::find(1);
-        $this->assertTrue($role->hasPermissionTo('entity_read'));
-        $this->assertTrue($role->hasPermissionTo('entity_write'));
-        $this->assertTrue(!$role->hasPermissionTo('entity_create'));
-        $this->assertEquals(2, count($role->permissions));
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'id',
-            'name',
-            'display_name',
-            'description',
-            'created_at',
-            'updated_at',
-            'permissions'
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/1', [
+            'orcid' => '0000-0001-5109-3700'
         ]);
-        $response->assertJson([
-            'id' => 1,
-            'name' => 'admin',
+
+    $response->assertStatus(200);
+    $user = User::find(1);
+    expect($user->metadata)->not->toBeNull();
+    expect($user->metadata['orcid'])->toEqual('0000-0001-5109-3700');
+});
+
+test('patch user wrong orcid endpoint', function () {
+    $user = User::find(1);
+
+    $response = $this->userRequest()
+        ->json('patch', '/api/v1/user/1', [
+            'orcid' => '0000-0002-1694-2338'
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('patch user another wrong orcid endpoint', function () {
+    $user = User::find(1);
+
+    $response = $this->userRequest()
+        ->json('patch', '/api/v1/user/1', [
+            'orcid' => '0000-0002-1694233X'
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('patch user another second wrong orcid endpoint', function () {
+    $user = User::find(1);
+
+    $response = $this->userRequest()
+        ->json('patch', '/api/v1/user/1', [
+            'orcid' => '0000-0002-1694-23aX'
+        ]);
+
+    $response->assertStatus(422);
+});
+
+test('patch user without data endpoint', function () {
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/1', []);
+
+    $response->assertStatus(204);
+});
+
+test('patch role endpoint', function () {
+    $response = $this->userRequest()
+        ->patch('/api/v1/role/1', [
+            'permissions' => [1, 2],
             'display_name' => 'NOT Admin',
-            'description' => 'No longer a Admin User',
-            'created_at' => '2017-12-20T09:47:35.000000Z',
-            'updated_at' => $role->updated_at->toJSON()
+            'description' => 'No longer a Admin User'
+        ]);
+
+    $role = Role::find(1);
+    expect($role->hasPermissionTo('entity_read'))->toBeTrue();
+    expect($role->hasPermissionTo('entity_write'))->toBeTrue();
+    expect(!$role->hasPermissionTo('entity_create'))->toBeTrue();
+    expect(count($role->permissions))->toEqual(2);
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'id',
+        'name',
+        'display_name',
+        'description',
+        'created_at',
+        'updated_at',
+        'permissions'
+    ]);
+    $response->assertJson([
+        'id' => 1,
+        'name' => 'admin',
+        'display_name' => 'NOT Admin',
+        'description' => 'No longer a Admin User',
+        'created_at' => '2017-12-20T09:47:35.000000Z',
+        'updated_at' => $role->updated_at->toJSON()
+    ]);
+});
+
+test('patch role without data endpoint', function () {
+    $response = $this->userRequest()
+        ->patch('/api/v1/role/1', []);
+
+    $response->assertStatus(204);
+});
+
+test('restore user endpoint', function () {
+    $user = User::find(1);
+    $user->deleted_at = Carbon::now();
+    $user->save();
+
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::onlyTrashed()->count();
+    expect($cnt)->toEqual(2);
+    $cnt = User::withoutTrashed()->count();
+    expect($cnt)->toEqual(1);
+    $user = User::onlyTrashed()->find(1);
+    expect($user->deleted_at)->not->toBeNull();
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/restore/1');
+
+    $user = User::find(2);
+    expect($user->deleted_at)->toBeNull();
+
+    $response->assertStatus(204);
+});
+
+test('delete user endpoint', function () {
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::onlyTrashed()->count();
+    expect($cnt)->toEqual(1);
+    $cnt = User::withoutTrashed()->count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->delete('/api/v1/user/1');
+
+    $response->assertStatus(200);
+
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::onlyTrashed()->count();
+    expect($cnt)->toEqual(2);
+    $cnt = User::withoutTrashed()->count();
+    expect($cnt)->toEqual(1);
+    $user = User::onlyTrashed()->find(1);
+    expect($user->deleted_at)->not->toBeNull();
+
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/restore/1');
+
+    $user = User::find(1);
+    expect($user->deleted_at)->toBeNull();
+
+    $response->assertStatus(204);
+});
+
+test('delete non exsting user endpoint', function () {
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->delete('/api/v1/user/99');
+
+    $cnt = User::withTrashed()->count();
+    expect($cnt)->toEqual(3);
+    $cnt = User::count();
+    expect($cnt)->toEqual(2);
+
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'This user does not exist'
+    ]);
+});
+
+test('delete role endpoint', function () {
+    $cnt = Role::count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->delete('/api/v1/role/1');
+
+    $cnt = Role::count();
+    expect($cnt)->toEqual(1);
+
+    $response->assertStatus(204);
+});
+
+test('delete non exsting role endpoint', function () {
+    $cnt = Role::count();
+    expect($cnt)->toEqual(2);
+    $response = $this->userRequest()
+        ->delete('/api/v1/role/99');
+
+    $cnt = Role::count();
+    expect($cnt)->toEqual(2);
+
+    $response->assertStatus(400);
+    $response->assertSimilarJson([
+        'error' => 'This role does not exist'
+    ]);
+});
+
+test('delete avatar endpoint', function () {
+    $response = $this->userRequest()
+        ->delete('/api/v1/user/avatar');
+
+    $user = User::find(1);
+    expect($user->avatar)->toBeNull();
+
+    $this->assertStatus($response, 204);
+});
+
+test('permissions', function () {
+    User::first()->roles()->detach();
+
+    $calls = [
+        ['url' => '/user', 'error' => 'You do not have the permission to view users', 'verb' => 'get'],
+        ['url' => '/role', 'error' => 'You do not have the permission to view roles', 'verb' => 'get'],
+        ['url' => '/user', 'error' => 'You do not have the permission to add new users', 'verb' => 'post'],
+        ['url' => '/role', 'error' => 'You do not have the permission to add roles', 'verb' => 'post'],
+        ['url' => '/user/1', 'error' => 'You do not have the permission to modify user data', 'verb' => 'patch'],
+        ['url' => '/role/1', 'error' => 'You do not have the permission to set role permissions', 'verb' => 'patch'],
+        ['url' => '/user/restore/1', 'error' => 'You do not have the permission to restore users', 'verb' => 'patch'],
+        ['url' => '/user/1', 'error' => 'You do not have the permission to delete users', 'verb' => 'delete'],
+        ['url' => '/role/1', 'error' => 'You do not have the permission to delete roles', 'verb' => 'delete'],
+    ];
+
+    $response = null;
+    foreach($calls as $c) {
+        $response = $this->userRequest()
+            ->json($c['verb'], '/api/v1' . $c['url']);
+
+        $this->assertStatus($response, 403);
+        $response->assertSimilarJson([
+            'error' => $c['error']
         ]);
     }
+});
 
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/role/{id} : Patch Role Empty Request')]
-    public function testPatchRoleWithoutDataEndpoint()
-    {
+test('exceptions', function () {
+    $calls = [
+        ['url' => '/user/99', 'error' => 'This user does not exist', 'verb' => 'patch'],
+        ['url' => '/role/99', 'error' => 'This role does not exist', 'verb' => 'patch'],
+        ['url' => '/user/restore/99', 'error' => 'This user does not exist', 'verb' => 'patch'],
+    ];
+
+    foreach($calls as $c) {
         $response = $this->userRequest()
-            ->patch('/api/v1/role/1', []);
-
-        $response->assertStatus(204);
-    }
-
-    /**
-	 * @return void
-	 */
-	#[TestDox('PATCH  /api/v1/user/restore/{id} : Restore User')]
-    public function testRestoreUserEndpoint()
-    {
-        $user = User::find(1);
-        $user->deleted_at = Carbon::now();
-        $user->save();
-
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::onlyTrashed()->count();
-        $this->assertEquals(2, $cnt);
-        $cnt = User::withoutTrashed()->count();
-        $this->assertEquals(1, $cnt);
-        $user = User::onlyTrashed()->find(1);
-        $this->assertNotNull($user->deleted_at);
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/restore/1');
-
-        $user = User::find(2);
-        $this->assertNull($user->deleted_at);
-
-        $response->assertStatus(204);
-    }
-
-    /**
-     * @return void
-     */
-     #[TestDox('DELETE /api/v1/user/{id} : Delete User')]
-    public function testDeleteUserEndpoint()
-    {
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::onlyTrashed()->count();
-        $this->assertEquals(1, $cnt);
-        $cnt = User::withoutTrashed()->count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->delete('/api/v1/user/1');
-
-        $response->assertStatus(200);
-
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::onlyTrashed()->count();
-        $this->assertEquals(2, $cnt);
-        $cnt = User::withoutTrashed()->count();
-        $this->assertEquals(1, $cnt);
-        $user = User::onlyTrashed()->find(1);
-        $this->assertNotNull($user->deleted_at);
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/restore/1');
-
-        $user = User::find(1);
-        $this->assertNull($user->deleted_at);
-
-        $response->assertStatus(204);
-    }
-
-    /**
-     * @return void
-     */
-     #[TestDox('DELETE /api/v1/user/99 : Delete User Fail')]
-    public function testDeleteNonExstingUserEndpoint()
-    {
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->delete('/api/v1/user/99');
-
-        $cnt = User::withTrashed()->count();
-        $this->assertEquals(3, $cnt);
-        $cnt = User::count();
-        $this->assertEquals(2, $cnt);
+            ->json($c['verb'], '/api/v1' . $c['url'], [
+                'description' => 'does not matter'
+            ]);
 
         $response->assertStatus(400);
         $response->assertSimilarJson([
-            'error' => 'This user does not exist'
+            'error' => $c['error']
         ]);
     }
+});
 
-    /**
-     * @return void
-     */
-     #[TestDox('DELETE /api/v1/role/{id} : Delete Role')]
-    public function testDeleteRoleEndpoint()
-    {
-        $cnt = Role::count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->delete('/api/v1/role/1');
+test('validations', function () {
+    $user = new User();
+    $user->name = 'Test';
+    $user->nickname = 'test';
+    $user->email = 'mail@example.com';
+    $user->password = 'not_safe';
+    $user->save();
 
-        $cnt = Role::count();
-        $this->assertEquals(1, $cnt);
-
-        $response->assertStatus(204);
-    }
-
-    /**
-     * @return void
-     */
-     #[TestDox('DELETE /api/v1/role/99 : Delete Role Fail')]
-    public function testDeleteNonExstingRoleEndpoint()
-    {
-        $cnt = Role::count();
-        $this->assertEquals(2, $cnt);
-        $response = $this->userRequest()
-            ->delete('/api/v1/role/99');
-
-        $cnt = Role::count();
-        $this->assertEquals(2, $cnt);
-
-        $response->assertStatus(400);
-        $response->assertSimilarJson([
-            'error' => 'This role does not exist'
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/' . $user->id, [
+            'email' => 'admin@localhost'
         ]);
-    }
 
-    /**
-     * @return void
-     */
-    #[TestDox('DELETE /api/v1/user/avatar : Delete User Avatar')]
-    public function testDeleteAvatarEndpoint()
-    {
-        $response = $this->userRequest()
-            ->delete('/api/v1/user/avatar');
+    expect($response->exception->getMessage())->toEqual('The email has already been taken.');
 
-        $user = User::find(1);
-        $this->assertNull($user->avatar);
+    $response = $this->userRequest()
+        ->patch('/api/v1/user/' . $user->id, [
+            'email' => 'admin@localhost!'
+        ]);
 
-        $this->assertStatus($response, 204);
-    }
-
-    // Testing exceptions and permissions
-
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testPermissions()
-    {
-        User::first()->roles()->detach();
-
-        $calls = [
-            ['url' => '/user', 'error' => 'You do not have the permission to view users', 'verb' => 'get'],
-            ['url' => '/role', 'error' => 'You do not have the permission to view roles', 'verb' => 'get'],
-            ['url' => '/user', 'error' => 'You do not have the permission to add new users', 'verb' => 'post'],
-            ['url' => '/role', 'error' => 'You do not have the permission to add roles', 'verb' => 'post'],
-            ['url' => '/user/1', 'error' => 'You do not have the permission to modify user data', 'verb' => 'patch'],
-            ['url' => '/role/1', 'error' => 'You do not have the permission to set role permissions', 'verb' => 'patch'],
-            ['url' => '/user/restore/1', 'error' => 'You do not have the permission to restore users', 'verb' => 'patch'],
-            ['url' => '/user/1', 'error' => 'You do not have the permission to delete users', 'verb' => 'delete'],
-            ['url' => '/role/1', 'error' => 'You do not have the permission to delete roles', 'verb' => 'delete'],
-        ];
-
-        $response = null;
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->json($c['verb'], '/api/v1' . $c['url']);
-
-            $this->assertStatus($response, 403);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
-    }
-
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testExceptions()
-    {
-        $calls = [
-            ['url' => '/user/99', 'error' => 'This user does not exist', 'verb' => 'patch'],
-            ['url' => '/role/99', 'error' => 'This role does not exist', 'verb' => 'patch'],
-            ['url' => '/user/restore/99', 'error' => 'This user does not exist', 'verb' => 'patch'],
-        ];
-
-        foreach($calls as $c) {
-            $response = $this->userRequest()
-                ->json($c['verb'], '/api/v1' . $c['url'], [
-                    'description' => 'does not matter'
-                ]);
-
-            $response->assertStatus(400);
-            $response->assertSimilarJson([
-                'error' => $c['error']
-            ]);
-        }
-    }
-
-    /**
-     *
-     *
-     * @return void
-     */
-    public function testValidations()
-    {
-        $user = new User();
-        $user->name = 'Test';
-        $user->nickname = 'test';
-        $user->email = 'mail@example.com';
-        $user->password = 'not_safe';
-        $user->save();
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/' . $user->id, [
-                'email' => 'admin@localhost'
-            ]);
-
-        $this->assertEquals('The email has already been taken.', $response->exception->getMessage());
-
-        $response = $this->userRequest()
-            ->patch('/api/v1/user/' . $user->id, [
-                'email' => 'admin@localhost!'
-            ]);
-
-        $this->assertEquals('The email must be a valid email address.', $response->exception->getMessage());
-    }
-}
+    expect($response->exception->getMessage())->toEqual('The email must be a valid email address.');
+});

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('returns a successful response', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind a different classes or traits.
+|
+*/
+
+pest()->extend(Tests\TestCase::class)
+ // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,10 +13,12 @@
 
 pest()->extend(Tests\TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature');
+    ->in('Feature')
+    ->in('Browser');
 
 pest()->extend(Tests\TransactionedTestCase::class)
     ->in('Unit');
+
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,6 +15,9 @@ pest()->extend(Tests\TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 
+pest()->extend(Tests\TransactionedTestCase::class)
+    ->in('Unit');
+
 /*
 |--------------------------------------------------------------------------
 | Expectations

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,8 +12,9 @@
 */
 
 pest()->extend(Tests\TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature')
+    ->in('Feature');
+
+pest()->extend(Tests\TestCase::class)
     ->in('Browser');
 
 pest()->extend(Tests\TransactionedTestCase::class)

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -21,5 +21,5 @@ const models = [
 
 test('loggable models', function () {
     $compModels = sp_loggable_models();
-    expect($compModels)->toEqual(self::models);
+    expect($compModels)->toEqual(models);
 });

--- a/tests/Unit/ActivityTest.php
+++ b/tests/Unit/ActivityTest.php
@@ -1,39 +1,25 @@
 <?php
 
-namespace Tests\Unit;
+const models = [
+    ['id' => "App\\Attribute", 'label' => 'Attribute'],
+    ['id' => "App\\AttributeValue", 'label' => 'AttributeValue'],
+    ['id' => "App\\AvailableLayer", 'label' => 'AvailableLayer'], // TODO move to Map Plugin
+    ['id' => "App\\Bibliography", 'label' => 'Bibliography'],
+    ['id' => "App\\Entity", 'label' => 'Entity'],
+    ['id' => "App\\EntityAttribute", 'label' => 'EntityAttribute'],
+    ['id' => "App\\EntityFile", 'label' => 'EntityFile'], // TODO move to File Plugin
+    ['id' => "App\\EntityType", 'label' => 'EntityType'],
+    ['id' => "App\\EntityTypeRelation", 'label' => 'EntityTypeRelation'],
+    ['id' => "App\\Reference", 'label' => 'Reference'],
+    ['id' => "App\\Role", 'label' => 'Role'],
+    ['id' => "App\\ThBroader", 'label' => 'ThBroader'],
+    ['id' => "App\\ThConcept", 'label' => 'ThConcept'],
+    ['id' => "App\\ThConceptLabel", 'label' => 'ThConceptLabel'],
+    ['id' => "App\\ThLanguage", 'label' => 'ThLanguage'],
+    ['id' => "App\\User", 'label' => 'User'],
+];
 
-use Tests\TestCase;
-
-
-class ActivityTest extends TestCase
-{
-    const models = [
-        ['id' => "App\\Attribute", 'label' => 'Attribute'],
-        ['id' => "App\\AttributeValue", 'label' => 'AttributeValue'],
-        ['id' => "App\\AvailableLayer", 'label' => 'AvailableLayer'], // TODO move to Map Plugin
-        ['id' => "App\\Bibliography", 'label' => 'Bibliography'],
-        ['id' => "App\\Entity", 'label' => 'Entity'],
-        ['id' => "App\\EntityAttribute", 'label' => 'EntityAttribute'],
-        ['id' => "App\\EntityFile", 'label' => 'EntityFile'], // TODO move to File Plugin
-        ['id' => "App\\EntityType", 'label' => 'EntityType'],
-        ['id' => "App\\EntityTypeRelation", 'label' => 'EntityTypeRelation'],
-        ['id' => "App\\Reference", 'label' => 'Reference'],
-        ['id' => "App\\Role", 'label' => 'Role'],
-        ['id' => "App\\ThBroader", 'label' => 'ThBroader'],
-        ['id' => "App\\ThConcept", 'label' => 'ThConcept'],
-        ['id' => "App\\ThConceptLabel", 'label' => 'ThConceptLabel'],
-        ['id' => "App\\ThLanguage", 'label' => 'ThLanguage'],
-        ['id' => "App\\User", 'label' => 'User'],
-    ];
-
-    /**
-     * Test get list of loggable models
-     *
-     * @return void
-     */
-    public function testLoggableModels()
-    {
-        $compModels = sp_loggable_models();
-        $this->assertEquals(self::models, $compModels);
-    }
-}
+test('loggable models', function () {
+    $compModels = sp_loggable_models();
+    expect($compModels)->toEqual(self::models);
+});

--- a/tests/Unit/AttributeTest.php
+++ b/tests/Unit/AttributeTest.php
@@ -1,70 +1,57 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\Attribute;
 
-class AttributeTest extends TestCase
-{
-    /**
-     * Test relations of attributes (id=5 and id=6)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $attribute = Attribute::with(['children', 'entities', 'entity_types', 'parent', 'thesaurus_root_concept', 'thesaurus_concept'])->find(6);
 
-        $this->assertTrue($attribute->children->isEmpty());
-        $this->assertTrue($attribute->entities->isEmpty());
-        $this->assertTrue($attribute->entity_types->isEmpty());
-        $this->assertEquals(5, $attribute->parent->id);
-        $this->assertEquals(33, $attribute->thesaurus_root_concept->id);
-        $this->assertEquals(33, $attribute->thesaurus_concept->id);
+test('relations', function () {
+    $attribute = Attribute::with(['children', 'entities', 'entity_types', 'parent', 'thesaurus_root_concept', 'thesaurus_concept'])->find(6);
 
-        $attribute = Attribute::with(['children', 'entities', 'entity_types', 'parent', 'thesaurus_root_concept', 'thesaurus_concept'])->find(5);
+    expect($attribute->children->isEmpty())->toBeTrue();
+    expect($attribute->entities->isEmpty())->toBeTrue();
+    expect($attribute->entity_types->isEmpty())->toBeTrue();
+    expect($attribute->parent->id)->toEqual(5);
+    expect($attribute->thesaurus_root_concept->id)->toEqual(33);
+    expect($attribute->thesaurus_concept->id)->toEqual(33);
 
-        $this->assertEquals(3, $attribute->children->count());
-        $this->assertEquals(3, $attribute->entities->count());
-        $this->assertEquals(1, $attribute->entity_types->count());
-        $this->assertNull($attribute->parent);
-        $this->assertNull($attribute->thesaurus_root_concept);
-        $this->assertEquals(32, $attribute->thesaurus_concept->id);
+    $attribute = Attribute::with(['children', 'entities', 'entity_types', 'parent', 'thesaurus_root_concept', 'thesaurus_concept'])->find(5);
 
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            ['id' => 6],
-            ['id' => 7],
-            ['id' => 8],
-        ], $attribute->children->toArray(),
-        ['id']
-        );
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            [
-                'id' => 4,
-                'pivot' => [
-                    'json_val' => '[{"6": {"id": 37, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/schulter#20171220105500"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}]',
-                ],
+    expect($attribute->children->count())->toEqual(3);
+    expect($attribute->entities->count())->toEqual(3);
+    expect($attribute->entity_types->count())->toEqual(1);
+    expect($attribute->parent)->toBeNull();
+    expect($attribute->thesaurus_root_concept)->toBeNull();
+    expect($attribute->thesaurus_concept->id)->toEqual(32);
+
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+        ['id' => 6],
+        ['id' => 7],
+        ['id' => 8],
+    ], $attribute->children->toArray(),
+    ['id']
+    );
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+        [
+            'id' => 4,
+            'pivot' => [
+                'json_val' => '[{"6": {"id": 37, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/schulter#20171220105500"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}]',
             ],
-            [
-                'id' => 3,
-                'pivot' => [
-                    'json_val' => '[{"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}, {"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
-                ],
+        ],
+        [
+            'id' => 3,
+            'pivot' => [
+                'json_val' => '[{"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}, {"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
             ],
-            [
-                'id' => 8,
-                'pivot' => [
-                    'json_val' => '[{"6": {"id": 39, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/boden#20171220105508"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
-                ],
+        ],
+        [
+            'id' => 8,
+            'pivot' => [
+                'json_val' => '[{"6": {"id": 39, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/boden#20171220105508"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
             ],
-        ], $attribute->entities->toArray(),
-        ['id', 'pivot']);
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            ['id' => 5],
-        ], $attribute->entity_types->toArray(),
-        ['id']);
-    }
-}
+        ],
+    ], $attribute->entities->toArray(),
+    ['id', 'pivot']);
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+        ['id' => 5],
+    ], $attribute->entity_types->toArray(),
+    ['id']);
+});

--- a/tests/Unit/AttributeValueTest.php
+++ b/tests/Unit/AttributeValueTest.php
@@ -1,59 +1,34 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\AttributeValue;
 
-class AttributeValueTest extends TestCase
-{
-    /**
-     * Test relations of an attribute value (id=60)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $value = AttributeValue::with(['entity', 'attribute', 'entity_value', 'concept'])->find(60);
 
-        $this->assertEquals(2, $value->entity->id);
-        $this->assertEquals(14, $value->attribute->id);
-        $this->assertEquals(53, $value->concept->id);
-        $this->assertNull($value->entity_value);
+test('relations', function () {
+    $value = AttributeValue::with(['entity', 'attribute', 'entity_value', 'concept'])->find(60);
 
-        $value = AttributeValue::with(['entity', 'attribute', 'entity_value', 'concept'])->find(35);
+    expect($value->entity->id)->toEqual(2);
+    expect($value->attribute->id)->toEqual(14);
+    expect($value->concept->id)->toEqual(53);
+    expect($value->entity_value)->toBeNull();
 
-        $this->assertEquals(5, $value->entity->id);
-        $this->assertEquals(18, $value->attribute->id);
-        $this->assertNull($value->concept);
-        $this->assertEquals(6, $value->entity_value->id);
-        $this->assertEquals('Aufschluss', $value->entity_value->name);
-    }
+    $value = AttributeValue::with(['entity', 'attribute', 'entity_value', 'concept'])->find(35);
 
-    /**
-     * Test get value of an attribute value (eid=2, aid=16)
-     *
-     * @return void
-     */
-    public function testGetAttributeValueById()
-    {
-        $value = AttributeValue::getValueById(16, 2);
-        $this->assertEquals('SRID=4326;POINT(8.92 48.45)', $value);
+    expect($value->entity->id)->toEqual(5);
+    expect($value->attribute->id)->toEqual(18);
+    expect($value->concept)->toBeNull();
+    expect($value->entity_value->id)->toEqual(6);
+    expect($value->entity_value->name)->toEqual('Aufschluss');
+});
 
-        $value = AttributeValue::getValueById(99, 2);
-        $this->assertNull($value);
-    }
+test('get attribute value by id', function () {
+    $value = AttributeValue::getValueById(16, 2);
+    expect($value)->toEqual('SRID=4326;POINT(8.92 48.45)');
 
-    /**
-     * Test get last editor of first attribute value
-     *
-     * @return void
-     */
-    public function testGetAttributeValueLasteditor()
-    {
-        $value = AttributeValue::first();
-        $this->assertEquals(1, $value->user->id);
-    }
-}
+    $value = AttributeValue::getValueById(99, 2);
+    expect($value)->toBeNull();
+});
+
+test('get attribute value lasteditor', function () {
+    $value = AttributeValue::first();
+    expect($value->user->id)->toEqual(1);
+});

--- a/tests/Unit/Attributes/AttributeBaseTest.php
+++ b/tests/Unit/Attributes/AttributeBaseTest.php
@@ -1,18 +1,8 @@
 <?php
 
-namespace Tests\Unit\Attributes;
-
 use App\AttributeTypes\AttributeBase;
-use Tests\TestCase;
 
-class AttributeBaseTest extends TestCase {
-    /**
-     * Test parseExport method of attributebase class
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $exportValue = AttributeBase::parseExport(1);
-        $this->assertEquals('1', $exportValue);
-    }
-}
+test('parse export', function () {
+    $exportValue = AttributeBase::parseExport(1);
+    expect($exportValue)->toEqual('1');
+});

--- a/tests/Unit/Attributes/BooleanAttributeTest.php
+++ b/tests/Unit/Attributes/BooleanAttributeTest.php
@@ -1,43 +1,37 @@
 <?php
 
-namespace Tests\Unit\Attributes;
-
 use App\AttributeTypes\BooleanAttribute;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class BooleanAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->assertTrue(BooleanAttribute::fromImport($input));
-    }
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->assertFalse(BooleanAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    expect(BooleanAttribute::fromImport($input))->toBeTrue();
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            [true],
-            [1],
-            ['1'],
-            ['true'],
-            ['t'],
-            ['x'],
-            ['wahr'],
-            ['w'],
-        ];
-    }
+test('from import falsy', function ($input) {
+    expect(BooleanAttribute::fromImport($input))->toBeFalse();
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            [false],
-            [0],
-            [-1],
-            ['ok'],
-            ['0'],
-            ['kauderwelsch'],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        [true],
+        [1],
+        ['1'],
+        ['true'],
+        ['t'],
+        ['x'],
+        ['wahr'],
+        ['w'],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        [false],
+        [0],
+        [-1],
+        ['ok'],
+        ['0'],
+        ['kauderwelsch'],
+    ];
+});

--- a/tests/Unit/Attributes/DateAttributeTest.php
+++ b/tests/Unit/Attributes/DateAttributeTest.php
@@ -1,44 +1,38 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\DateAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DateAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(InvalidDataException::class);
-        DateAttribute::fromImport($input);
-    }
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        DateAttribute::fromImport($input);
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(InvalidDataException::class);
+    DateAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "correct format"=>["2024-10-30"],
-            "whitespace should be trimmed" => [" 2024-10-30 "],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DateAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "fail when datetime is passed" =>["2024-10-30 10:00:00"],
-            "fail when year has only two letters" => ["24-10-10"],
-            "fail for unix timestring" => ["1727876634"],
-            "fail for boolean true" => [true],
-            "fail for boolean false" => [false],
-            "fail for numeric 0" => [0],
-            "fail for positive numeric unix timestring" => [1727876634],
-            "fail for negative numeric unix timestring" =>[-1727876634],
-            "fail for positive numeric float value" => [1727876634.2312],
-            "fail for negative numeric float value" => [-1727876634.2312],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "correct format"=>["2024-10-30"],
+        "whitespace should be trimmed" => [" 2024-10-30 "],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when datetime is passed" =>["2024-10-30 10:00:00"],
+        "fail when year has only two letters" => ["24-10-10"],
+        "fail for unix timestring" => ["1727876634"],
+        "fail for boolean true" => [true],
+        "fail for boolean false" => [false],
+        "fail for numeric 0" => [0],
+        "fail for positive numeric unix timestring" => [1727876634],
+        "fail for negative numeric unix timestring" =>[-1727876634],
+        "fail for positive numeric float value" => [1727876634.2312],
+        "fail for negative numeric float value" => [-1727876634.2312],
+    ];
+});

--- a/tests/Unit/Attributes/DaterangeAttributeTest.php
+++ b/tests/Unit/Attributes/DaterangeAttributeTest.php
@@ -1,60 +1,49 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\DaterangeAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DaterangeAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(DaterangeAttribute::class);
-        DaterangeAttribute::fromImport($input);
-    }
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        DaterangeAttribute::fromImport($input);
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(DaterangeAttribute::class);
+    DaterangeAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = 79)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(79);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DaterangeAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('2025-02-01;2025-02-07', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(79);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "correct format" => ["2024-10-25;2024-10-30"],
-            "correct if same date" => ["2024-10-25;2024-10-30"],
-            "should trim formats" => [" 2024-10-25 ; 2024-10-30 "]
-        ];
-    }
+    expect($parseResult)->toEqual('2025-02-01;2025-02-07');
+});
 
-    public static function falsyProvider() {
-        return [
-            "end cannot be before start" => ["2024-10-30;2024-10-25"],
-            "fails for datetime" => ["2024-10-30 10:00:00;2024-10-30 10:00:00"],
-            "fails for year with two letters" => ["24-10-10;24-10-10"],
-            "fail for unix timestring" => ["1727876634;1727876634"],
-            "fail for boolean true" => [true],
-            "fail for boolean false" => [false],
-            "fail for numeric 0" => [0],
-            "fail for positive numeric unix timestring" => [1727876634],
-            "fail for negative numeric unix timestring" =>[-1727876634],
-            "fail for positive numeric float value" => [1727876634.2312],
-            "fail for negative numeric float value" => [-1727876634.2312],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "correct format" => ["2024-10-25;2024-10-30"],
+        "correct if same date" => ["2024-10-25;2024-10-30"],
+        "should trim formats" => [" 2024-10-25 ; 2024-10-30 "]
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "end cannot be before start" => ["2024-10-30;2024-10-25"],
+        "fails for datetime" => ["2024-10-30 10:00:00;2024-10-30 10:00:00"],
+        "fails for year with two letters" => ["24-10-10;24-10-10"],
+        "fail for unix timestring" => ["1727876634;1727876634"],
+        "fail for boolean true" => [true],
+        "fail for boolean false" => [false],
+        "fail for numeric 0" => [0],
+        "fail for positive numeric unix timestring" => [1727876634],
+        "fail for negative numeric unix timestring" =>[-1727876634],
+        "fail for positive numeric float value" => [1727876634.2312],
+        "fail for negative numeric float value" => [-1727876634.2312],
+    ];
+});

--- a/tests/Unit/Attributes/DimensionAttributeTest.php
+++ b/tests/Unit/Attributes/DimensionAttributeTest.php
@@ -1,64 +1,52 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\DimensionAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DimensionAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportNoException($input) {
-        $this->expectNotToPerformAssertions(DimensionAttribute::class);
-        DimensionAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, DimensionAttribute::fromImport($input));
-    }
+test('from import no exception', function ($input) {
+    $this->expectNotToPerformAssertions(DimensionAttribute::class);
+    DimensionAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportException($input) {
-        $this->expectException(InvalidDataException::class);
-        DimensionAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(DimensionAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = 33)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(33);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import exception', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DimensionAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('10;3;1.5;cm', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(33);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "no value" => ["", null],
-            "input using 0" => ["0;0;0;cm", json_encode(["B" => 0, "H" => 0, "T" => 0, "unit" => "cm"])],
-            "input using integers" => ["22;51;210;m", json_encode(["B" => 22, "H" => 51, "T" => 210, "unit" => "m"])],
-            "input using floats" => ["22.5;51.2;210.3;cm", json_encode(["B" => 22.5, "H" => 51.2, "T" => 210.3, "unit" => "cm"])],
-            "input using negative values" => ["-22.5;-51.2;-210.3;cm", json_encode(["B" => -22.5, "H" => -51.2, "T" => -210.3, "unit" => "cm"])], // Discuss: Maybe this should not be allowed?
-            "input whitespaces should be trimmed" => [" 1 ; 2 ; 3 ; cm ", json_encode(["B" => 1, "H" => 2, "T" => 3, "unit" => "cm"])],
-        ];
-    }
+    expect($parseResult)->toEqual('10;3;1.5;cm');
+});
 
-    public static function falsyProvider() {
-        return [
-            "fail when input is not a string (int)" => [1],
-            "fail when input is not a string (bool)" => [true],
-            "fail when a dimension is missing" => ["1;2;cm"],
-            "fail when no unit is provided" => ["1;2;3"],
-            "fail when first is not a number" => ["a;2;3;cm"],
-            "fail when second is not a number" => ["1;a;3;cm"],
-            "fail when third is not a number" => ["1;2;a;cm"],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "no value" => ["", null],
+        "input using 0" => ["0;0;0;cm", json_encode(["B" => 0, "H" => 0, "T" => 0, "unit" => "cm"])],
+        "input using integers" => ["22;51;210;m", json_encode(["B" => 22, "H" => 51, "T" => 210, "unit" => "m"])],
+        "input using floats" => ["22.5;51.2;210.3;cm", json_encode(["B" => 22.5, "H" => 51.2, "T" => 210.3, "unit" => "cm"])],
+        "input using negative values" => ["-22.5;-51.2;-210.3;cm", json_encode(["B" => -22.5, "H" => -51.2, "T" => -210.3, "unit" => "cm"])], // Discuss: Maybe this should not be allowed?
+        "input whitespaces should be trimmed" => [" 1 ; 2 ; 3 ; cm ", json_encode(["B" => 1, "H" => 2, "T" => 3, "unit" => "cm"])],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when input is not a string (int)" => [1],
+        "fail when input is not a string (bool)" => [true],
+        "fail when a dimension is missing" => ["1;2;cm"],
+        "fail when no unit is provided" => ["1;2;3"],
+        "fail when first is not a number" => ["a;2;3;cm"],
+        "fail when second is not a number" => ["1;a;3;cm"],
+        "fail when third is not a number" => ["1;2;a;cm"],
+    ];
+});

--- a/tests/Unit/Attributes/DoubleAttributeTest.php
+++ b/tests/Unit/Attributes/DoubleAttributeTest.php
@@ -1,49 +1,42 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\DoubleAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DoubleAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(DoubleAttribute::class);
-        DoubleAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, DoubleAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(DoubleAttribute::class);
+    DoubleAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        DoubleAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(DoubleAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            ["", null],
-            [0, "0"],
-            [123, "123"],
-            [-42, "-42"],
-            [8.23, "8.23"],
-            [13e3, "13000"],
-            [2.3E-3,"0.0023"]
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DoubleAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-             // insert failing tests
-            ["a"],
-            [true],
-            [false],
-            ["123,23"] // Don't allow comma as decimal separator
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        ["", null],
+        [0, "0"],
+        [123, "123"],
+        [-42, "-42"],
+        [8.23, "8.23"],
+        [13e3, "13000"],
+        [2.3E-3,"0.0023"]
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+         // insert failing tests
+        ["a"],
+        [true],
+        [false],
+        ["123,23"] // Don't allow comma as decimal separator
+    ];
+});

--- a/tests/Unit/Attributes/DropdownMultipleAttributeTest.php
+++ b/tests/Unit/Attributes/DropdownMultipleAttributeTest.php
@@ -1,67 +1,60 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\DropdownMultipleAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DropdownMultipleAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(DropdownMultipleAttribute::class);
-        DropdownMultipleAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportCheckReturnValues($input, $expected) {
-        $this->assertEquals($expected, DropdownMultipleAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(DropdownMultipleAttribute::class);
+    DropdownMultipleAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        DropdownMultipleAttribute::fromImport($input);
-    }
+test('from import check return values', function ($input, $expected) {
+    expect(DropdownMultipleAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public function testParseExport() {
-        $testValue = AttributeValue::find(78);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DropdownMultipleAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('rot;grün', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(78);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        $find = [
-            "id" => 3,
-            "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921",
-        ];
+    expect($parseResult)->toEqual('rot;grün');
+});
 
-        $pottery = [
-            "id" => 9,
-            "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/keramik#20171220095651",
-        ];
+dataset('truthyProvider', function () {
+    $find = [
+        "id" => 3,
+        "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921",
+    ];
 
-        $dataJson = json_encode([$find, $pottery]);
+    $pottery = [
+        "id" => 9,
+        "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/keramik#20171220095651",
+    ];
 
-        return [
-            "no value" => ["", null],
-            "value in english" => ["Find;Pottery", $dataJson],
-            "value in german" => ["Fundobjekt;Keramik", $dataJson],
-            "value with whitespace" => [" Find ; Pottery ", $dataJson],
-            "value with different languages" => ["Find;Keramik", $dataJson]
-        ];
-    }
+    $dataJson = json_encode([$find, $pottery]);
 
-    public static function falsyProvider() {
-        return [
-            "fail when input is not a string (int)" => [1],
-            "fail when input is not a string (bool)" => [true],
-            "fail when one input is not a valid concept/label in the vocabulary" => ["Fund;Pottery"],
-            "fail when case sensitivity is not considered" => ["find;pottery"],
-        ];
-    }
-}
+    return [
+        "no value" => ["", null],
+        "value in english" => ["Find;Pottery", $dataJson],
+        "value in german" => ["Fundobjekt;Keramik", $dataJson],
+        "value with whitespace" => [" Find ; Pottery ", $dataJson],
+        "value with different languages" => ["Find;Keramik", $dataJson]
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when input is not a string (int)" => [1],
+        "fail when input is not a string (bool)" => [true],
+        "fail when one input is not a valid concept/label in the vocabulary" => ["Fund;Pottery"],
+        "fail when case sensitivity is not considered" => ["find;pottery"],
+    ];
+});

--- a/tests/Unit/Attributes/DropdownSingleAttributeTest.php
+++ b/tests/Unit/Attributes/DropdownSingleAttributeTest.php
@@ -1,59 +1,47 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\DropdownSingleAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class DropdownSingleAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(DropdownSingleAttribute::class);
-        DropdownSingleAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, DropdownSingleAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(DropdownSingleAttribute::class);
+    DropdownSingleAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        DropdownSingleAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(DropdownSingleAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = 60)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(60);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    DropdownSingleAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('Graben', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(60);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "no value" => ["", null],
-            "value in english" => ["Find","https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
-            "value in german" => ["Fundobjekt", "https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
-            "value with whitespace" => [" Find ","https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
-        ];
-    }
+    expect($parseResult)->toEqual('Graben');
+});
 
-    public static function falsyProvider() {
-        return [
-            "fail when input is not a string (int)" => [1],
-            "fail when input is not a string (bool)" => [true],
-            "fail when input is not a valid concept/label in the vocabulary" => ["Fund"],
-            "fail when case is not correct" => ["fundobjekt"],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "no value" => ["", null],
+        "value in english" => ["Find","https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
+        "value in german" => ["Fundobjekt", "https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
+        "value with whitespace" => [" Find ","https://spacialist.escience.uni-tuebingen.de/<user-project>/fundobjekt#20171220094921"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when input is not a string (int)" => [1],
+        "fail when input is not a string (bool)" => [true],
+        "fail when input is not a valid concept/label in the vocabulary" => ["Fund"],
+        "fail when case is not correct" => ["fundobjekt"],
+    ];
+});

--- a/tests/Unit/Attributes/EntityAttributeTest.php
+++ b/tests/Unit/Attributes/EntityAttributeTest.php
@@ -1,59 +1,47 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\EntityAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class EntityAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(EntityAttribute::class);
-        EntityAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, EntityAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(EntityAttribute::class);
+    EntityAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        EntityAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(EntityAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = 35)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(35);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    EntityAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('Aufschluss', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(35);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "no value" => ["", null],
-            "value" => ["Inv. 1234", 3],
-            "value with whitespace" => [" Inv. 1234 ", 3],
+    expect($parseResult)->toEqual('Aufschluss');
+});
 
-        ];
-    }
+dataset('truthyProvider', function () {
+    return [
+        "no value" => ["", null],
+        "value" => ["Inv. 1234", 3],
+        "value with whitespace" => [" Inv. 1234 ", 3],
 
-    public static function falsyProvider() {
-        return [
-            "fail when input is not a string (int)" => [1],
-            "fail when input is not a string (bool)" => [true],
-            "fail when input is not a valid concept/label in the vocabulary" => ["Fund"],
-            "fail when case is not correct" => ["inv. 1234"],
-        ];
-    }
-}
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when input is not a string (int)" => [1],
+        "fail when input is not a string (bool)" => [true],
+        "fail when input is not a valid concept/label in the vocabulary" => ["Fund"],
+        "fail when case is not correct" => ["inv. 1234"],
+    ];
+});

--- a/tests/Unit/Attributes/EntityMultipleAttributeTest.php
+++ b/tests/Unit/Attributes/EntityMultipleAttributeTest.php
@@ -1,60 +1,48 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\EntityMultipleAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class EntityMultipleAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(EntityMultipleAttribute::class);
-        EntityMultipleAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, EntityMultipleAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(EntityMultipleAttribute::class);
+    EntityMultipleAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        EntityMultipleAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(EntityMultipleAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = 75)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(75);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    EntityMultipleAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('Inv. 31;Befund 1', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(75);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        $dataJson = json_encode([3, 4]);
+    expect($parseResult)->toEqual('Inv. 31;Befund 1');
+});
 
-        return [
-            "no value" => ["", null],
-            "value in english" => ["Inv. 1234;Inv. 124", $dataJson],
-            "value with whitespace" => [" Inv. 1234 ; Inv. 124 ", $dataJson],
-        ];
-    }
+dataset('truthyProvider', function () {
+    $dataJson = json_encode([3, 4]);
 
-    public static function falsyProvider() {
-        return [
-            "fail when input is not a string (int)" => [1],
-            "fail when input is not a string (bool)" => [true],
-            "fail when one input is not a valid entity name" => ["Inv. 1234;invalid entity"],
-            "fail when case sensitivity is not considered" => ["Inv. 1234;inv. 124"],
-        ];
-    }
-}
+    return [
+        "no value" => ["", null],
+        "value in english" => ["Inv. 1234;Inv. 124", $dataJson],
+        "value with whitespace" => [" Inv. 1234 ; Inv. 124 ", $dataJson],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fail when input is not a string (int)" => [1],
+        "fail when input is not a string (bool)" => [true],
+        "fail when one input is not a valid entity name" => ["Inv. 1234;invalid entity"],
+        "fail when case sensitivity is not considered" => ["Inv. 1234;inv. 124"],
+    ];
+});

--- a/tests/Unit/Attributes/EpochAttributeTest.php
+++ b/tests/Unit/Attributes/EpochAttributeTest.php
@@ -1,88 +1,74 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\EpochAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class EpochAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(EpochAttribute::class);
-        EpochAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, EpochAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(EpochAttribute::class);
+    EpochAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        EpochAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(EpochAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of epoch attribute (attribute value id = 62)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(62);
-        $parseResult = EpochAttribute::parseExport(json_encode($testValue->getValue()));
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    EpochAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('-340;-300;Eisenzeit', $parseResult);
-    }
-    /**
-     * Test export value of epoch attribute value without epoch key (id=62)
-     *
-     * @return void
-     */
-    public function testParseExportWihtoutEpoch() {
-        $testValue = AttributeValue::find(62);
-        // remove epoch key from json data
-        $jsonVal = json_decode($testValue->json_val);
-        $jsonVal->epoch = null;
-        // and store value
-        $testValue->json_val = json_encode($jsonVal);
+test('parse export', function () {
+    $testValue = AttributeValue::find(62);
+    $parseResult = EpochAttribute::parseExport(json_encode($testValue->getValue()));
 
-        $parseResult = EpochAttribute::parseExport(json_encode($testValue->getValue()));
-        $this->assertEquals('-340;-300;', $parseResult);
+    expect($parseResult)->toEqual('-340;-300;Eisenzeit');
+});
 
-    }
+test('parse export wihtout epoch', function () {
+    $testValue = AttributeValue::find(62);
 
-    public static function truthyProvider() {
-        $baseData = [
-            "start" => 100,
-            "startLabel" => "bc",
-            "end" => 100,
-            "endLabel" => "ad",
-        ];
+    // remove epoch key from json data
+    $jsonVal = json_decode($testValue->json_val);
+    $jsonVal->epoch = null;
 
-        $epochData = $baseData;
-        $epochData["epoch"] = ["id"=>59, "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/steinzeit#20171220165355"];
-        $epochData = json_encode($epochData);
+    // and store value
+    $testValue->json_val = json_encode($jsonVal);
 
-        $noEpochData = $baseData;
-        $noEpochData["epoch"] = null;
-        $noEpochData = json_encode($noEpochData);
+    $parseResult = EpochAttribute::parseExport(json_encode($testValue->getValue()));
+    expect($parseResult)->toEqual('-340;-300;');
+});
 
-        return [
-            "no value" => ["", null],
-            "corret value" => ["-100;100;Steinzeit", $epochData],
-            "correct value with no epoch" => ["-100;100;", $noEpochData],
-            //TODO :: need english epoch, this is currently not in the test data
-        ];
-    }
+dataset('truthyProvider', function () {
+    $baseData = [
+        "start" => 100,
+        "startLabel" => "bc",
+        "end" => 100,
+        "endLabel" => "ad",
+    ];
 
-    public static function falsyProvider() {
-        return [
-            "missing data" => ["-100;100"],
-            "epoch does not exist" => ["-100;100;Moderne"],
-            "floating point" => ["-100.5;100;Steinzeit"],
-        ];
-    }
-}
+    $epochData = $baseData;
+    $epochData["epoch"] = ["id"=>59, "concept_url" => "https://spacialist.escience.uni-tuebingen.de/<user-project>/steinzeit#20171220165355"];
+    $epochData = json_encode($epochData);
+
+    $noEpochData = $baseData;
+    $noEpochData["epoch"] = null;
+    $noEpochData = json_encode($noEpochData);
+
+    return [
+        "no value" => ["", null],
+        "corret value" => ["-100;100;Steinzeit", $epochData],
+        "correct value with no epoch" => ["-100;100;", $noEpochData],
+        //TODO :: need english epoch, this is currently not in the test data
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "missing data" => ["-100;100"],
+        "epoch does not exist" => ["-100;100;Moderne"],
+        "floating point" => ["-100.5;100;Steinzeit"],
+    ];
+});

--- a/tests/Unit/Attributes/GeographyAttributeTest.php
+++ b/tests/Unit/Attributes/GeographyAttributeTest.php
@@ -1,108 +1,105 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\GeographyAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class GeographyAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
+
+test('from import truthy', function ($input) {
     $this->expectNotToPerformAssertions(GeographyAttribute::class);
-        GeographyAttribute::fromImport($input);
-    }
+    GeographyAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    private function assertPoint($expected, $actual) {
-        $this->assertEquals($expected[0], $actual->getX());
-        $this->assertEquals($expected[1], $actual->getY());
-        $this->assertEquals(isset($expected[2]), $actual->is3d());
-        if($actual->is3d()) {
-            $this->assertEquals($expected[2], $actual->getZ());
-        }
-    }
-
-    private function assertLineString($expected, $actual) {
-        $this->assertEquals(count($expected), count($actual->getPoints()));
-        for($i = 0; $i < count($expected); $i++) {
-            $this->assertPoint($expected[$i], $actual->getPoints()[$i]);
-        }
-    }
-
-    private function assertMultiLineString($expected, $actual) {
-        $this->assertEquals(count($expected), count($actual->getLineStrings()));
-        for($i = 0; $i < count($expected); $i++) {
-            $this->assertLineString($expected[$i], $actual->getLineStrings()[$i]);
-        }
-    }
-
-    private function assertMultiPolygon($expected, $actual) {
-        $this->assertEquals(count($expected), count($actual->getPolygons()));
-
-        // Hotfix for MSTAACK, as there is a filter function that remove a (supposedly) empty string that
-        // increments the index of the array, leading to a mismatch in the indexes of the arrays.
-        $fixedActualValues = array_values($actual->getPolygons());
-        for($i = 0; $i < count($expected); $i++) {
-            $this->assertMultiLineString($expected[$i], $fixedActualValues[$i]);
-        }
-    }
-
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $type, $coordinates) {
-        $geo = GeographyAttribute::fromImport($input);
-
-        if($type == null) {
-            $this->assertEquals($coordinates, $geo);
-        } else {
-            switch($type){
-                case 'point':
-                    $this->assertPoint($coordinates, $geo);
-                    break;
-                case 'multipoint':
-                case 'linestring':
-                    $this->assertLineString($coordinates, $geo);
-                    break;
-                case 'multilinestring':
-                case 'polygon':
-                    $this->assertMultiLineString($coordinates, $geo);
-                    break;
-                case 'multipolygon':
-                    $this->assertMultiPolygon($coordinates, $geo);
-                    break;
-            }
-        }
-    }
-
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        GeographyAttribute::fromImport($input);
-    }
-
-    public static function truthyProvider() {
-        return [
-            "empty" => ["", null, null],
-            "point" => ["POINT(1 1)", 'point', [1,1]],
-            "point3d0" => ["POINTZ(1 3 0)", 'point', [1,3,0]],
-            "point3d" => ["POINTZ(2 1 5)", 'point', [2,1,5]],
-            "linestring" => ["LINESTRING(0 0, 1 1, 2 2)",'linestring', [[0,0], [1,1], [2,2]]],
-            "polygon" => ["POLYGON((0 0, 1 1, 1 0, 0 0))",'polygon', [[[0,0], [1,1], [1,0], [0,0]]]],
-            "multipoint" => ["MULTIPOINT(0 0, 1 1, 2 2)", 'multipoint', [[0,0], [1,1], [2,2]]],
-            "multilinestring" => ["MULTILINESTRING((0 0, 1 1, 2 2), (3 3, 4 4, 5 5))", "multilinestring", [[[0,0], [1,1], [2,2]], [[3,3], [4,4], [5,5]]]],
-            "multipolygon" => ["MULTIPOLYGON(((0 0, 1 1, 1 0, 0 0)), ((2 2, 3 3, 3 2, 2 2)))", "multipolygon", [[[[0,0], [1,1], [1,0], [0,0]]], [[[2,2], [3,3], [3,2], [2,2]]]]],
-            "point with floating point" => ["POINT(1.15847 1.13687)","point", [1.15847, 1.13687]],
-        ];
-    }
-
-    public static function falsyProvider() {
-        return [
-            "invalid point format" => ["POINT(1 "],
-            "invalid linestring format" => ["LINESTRING(0 0, 1 1, 2 "],
-            "invalid polygon format" => ["POLYGON((0 0, 1 1, 1 0, 0 "],
-            "invalid multipoint format" => ["MULTIPOINT(0 0, 1 1, 2 "],
-            "invalid multilinestring format" => ["MULTILINESTRING((0 0, 1 1, 2 2), (3 3, 4 4, 5"],
-            "invalid multipolygon format" => ["MULTIPOLYGON(((0 0, 1 1, 1 0, 0)), ((2 2, 3 3, 3 2, 2"],
-        ];
+function assertPoint($expected, $actual)
+{
+    expect($actual->getX())->toEqual($expected[0]);
+    expect($actual->getY())->toEqual($expected[1]);
+    expect($actual->is3d())->toEqual(isset($expected[2]));
+    if($actual->is3d()) {
+        expect($actual->getZ())->toEqual($expected[2]);
     }
 }
+
+function assertLineString($expected, $actual)
+{
+    expect(count($actual->getPoints()))->toEqual(count($expected));
+    for($i = 0; $i < count($expected); $i++) {
+        assertPoint($expected[$i], $actual->getPoints()[$i]);
+    }
+}
+
+function assertMultiLineString($expected, $actual)
+{
+    expect(count($actual->getLineStrings()))->toEqual(count($expected));
+    for($i = 0; $i < count($expected); $i++) {
+        assertLineString($expected[$i], $actual->getLineStrings()[$i]);
+    }
+}
+
+function assertMultiPolygon($expected, $actual)
+{
+    expect(count($actual->getPolygons()))->toEqual(count($expected));
+
+    // Hotfix for MSTAACK, as there is a filter function that remove a (supposedly) empty string that
+    // increments the index of the array, leading to a mismatch in the indexes of the arrays.
+    $fixedActualValues = array_values($actual->getPolygons());
+    for($i = 0; $i < count($expected); $i++) {
+        assertMultiLineString($expected[$i], $fixedActualValues[$i]);
+    }
+}
+
+test('from import return values', function ($input, $type, $coordinates) {
+    $geo = GeographyAttribute::fromImport($input);
+
+    if($type == null) {
+        expect($geo)->toEqual($coordinates);
+    } else {
+        switch($type){
+            case 'point':
+                assertPoint($coordinates, $geo);
+                break;
+            case 'multipoint':
+            case 'linestring':
+                assertLineString($coordinates, $geo);
+                break;
+            case 'multilinestring':
+            case 'polygon':
+                assertMultiLineString($coordinates, $geo);
+                break;
+            case 'multipolygon':
+                assertMultiPolygon($coordinates, $geo);
+                break;
+        }
+    }
+})->with('truthyProvider');
+
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    GeographyAttribute::fromImport($input);
+})->with('falsyProvider');
+
+dataset('truthyProvider', function () {
+    return [
+        "empty" => ["", null, null],
+        "point" => ["POINT(1 1)", 'point', [1,1]],
+        "point3d0" => ["POINTZ(1 3 0)", 'point', [1,3,0]],
+        "point3d" => ["POINTZ(2 1 5)", 'point', [2,1,5]],
+        "linestring" => ["LINESTRING(0 0, 1 1, 2 2)",'linestring', [[0,0], [1,1], [2,2]]],
+        "polygon" => ["POLYGON((0 0, 1 1, 1 0, 0 0))",'polygon', [[[0,0], [1,1], [1,0], [0,0]]]],
+        "multipoint" => ["MULTIPOINT(0 0, 1 1, 2 2)", 'multipoint', [[0,0], [1,1], [2,2]]],
+        "multilinestring" => ["MULTILINESTRING((0 0, 1 1, 2 2), (3 3, 4 4, 5 5))", "multilinestring", [[[0,0], [1,1], [2,2]], [[3,3], [4,4], [5,5]]]],
+        "multipolygon" => ["MULTIPOLYGON(((0 0, 1 1, 1 0, 0 0)), ((2 2, 3 3, 3 2, 2 2)))", "multipolygon", [[[[0,0], [1,1], [1,0], [0,0]]], [[[2,2], [3,3], [3,2], [2,2]]]]],
+        "point with floating point" => ["POINT(1.15847 1.13687)","point", [1.15847, 1.13687]],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "invalid point format" => ["POINT(1 "],
+        "invalid linestring format" => ["LINESTRING(0 0, 1 1, 2 "],
+        "invalid polygon format" => ["POLYGON((0 0, 1 1, 1 0, 0 "],
+        "invalid multipoint format" => ["MULTIPOINT(0 0, 1 1, 2 "],
+        "invalid multilinestring format" => ["MULTILINESTRING((0 0, 1 1, 2 2), (3 3, 4 4, 5"],
+        "invalid multipolygon format" => ["MULTIPOLYGON(((0 0, 1 1, 1 0, 0)), ((2 2, 3 3, 3 2, 2"],
+    ];
+});

--- a/tests/Unit/Attributes/IconclassAttributeTest.php
+++ b/tests/Unit/Attributes/IconclassAttributeTest.php
@@ -1,40 +1,33 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\IconclassAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class IconclassAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(IconclassAttribute::class);
-        IconclassAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, IconclassAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(IconclassAttribute::class);
+    IconclassAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        IconclassAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(IconclassAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["string", "string"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    IconclassAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "number" => [4],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["string", "string"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "number" => [4],
+    ];
+});

--- a/tests/Unit/Attributes/IntegerAttributeTest.php
+++ b/tests/Unit/Attributes/IntegerAttributeTest.php
@@ -1,48 +1,41 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\IntegerAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class IntegerAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
+
+test('from import truthy', function ($input) {
     $this->expectNotToPerformAssertions(IntegerAttribute::class);
-        IntegerAttribute::fromImport($input);
-    }
+    IntegerAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, IntegerAttribute::fromImport($input));
-    }
+test('from import return values', function ($input, $expected) {
+    expect(IntegerAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
+test('from import falsy', function ($input) {
     $this->expectException(InvalidDataException::class);
     IntegerAttribute::fromImport($input);
-    }
+})->with('falsyProvider');
 
-    public static function truthyProvider() {
-        return [
-                "empty string" => ["", null],
-                "zero" => [0, 0],
-                "positive integer" => [1, 1],
-                "negative integer" => [-1, -1],
-                "string integer" => ["1", 1],
-                "big integer (max int on 32 bit system)" => ["2147483647", 2147483647],
-                "big negative integer (max int on 32 bit system)" => ["-2147483647", -2147483647],
-        ];
-    }
+dataset('truthyProvider', function () {
+    return [
+            "empty string" => ["", null],
+            "zero" => [0, 0],
+            "positive integer" => [1, 1],
+            "negative integer" => [-1, -1],
+            "string integer" => ["1", 1],
+            "big integer (max int on 32 bit system)" => ["2147483647", 2147483647],
+            "big negative integer (max int on 32 bit system)" => ["-2147483647", -2147483647],
+    ];
+});
 
-    public static function falsyProvider() {
-        return [
-                "fail when integer is too big (max int on 64 bit system +1)" => ["9223372036854775808"],
-                "fail when float" => [1.1],
-                "fail when string" => ["string"],
-                "fail when boolean" => [true],
-        ];
-    }
-}
+dataset('falsyProvider', function () {
+    return [
+            "fail when integer is too big (max int on 64 bit system +1)" => ["9223372036854775808"],
+            "fail when float" => [1.1],
+            "fail when string" => ["string"],
+            "fail when boolean" => [true],
+    ];
+});

--- a/tests/Unit/Attributes/ListAttributeTest.php
+++ b/tests/Unit/Attributes/ListAttributeTest.php
@@ -1,57 +1,50 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\ListAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class ListAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(ListAttribute::class);
-        ListAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        if($expected != null)
-        $expected = json_encode($expected);
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(ListAttribute::class);
+    ListAttribute::fromImport($input);
+})->with('truthyProvider');
 
-        $this->assertEquals($expected, ListAttribute::fromImport($input));
-    }
+test('from import return values', function ($input, $expected) {
+    if($expected != null)
+    $expected = json_encode($expected);
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        ListAttribute::fromImport($input);
-    }
+    expect(ListAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public function testParseExport() {
-        $testValue = AttributeValue::find(69);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    ListAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('Fundstelle A', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(69);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "empty value" => ["", null],
-            "single item" => ["item", ["item"]],
-            "multiple items" => ["item1;item2", ["item1", "item2"]],
-            "multiple items with spaces" => [" item1 ; item2 ", ["item1", "item2"]],
-            "list with empty values" => ["item1;;item2", ["item1", "", "item2"]],
-        ];
-    }
+    expect($parseResult)->toEqual('Fundstelle A');
+});
 
-    public static function falsyProvider() {
-        return [
-            "boolean" => [true],
-            "integer" => [1],
-            "float" => [1.1],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty value" => ["", null],
+        "single item" => ["item", ["item"]],
+        "multiple items" => ["item1;item2", ["item1", "item2"]],
+        "multiple items with spaces" => [" item1 ; item2 ", ["item1", "item2"]],
+        "list with empty values" => ["item1;;item2", ["item1", "", "item2"]],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "boolean" => [true],
+        "integer" => [1],
+        "float" => [1.1],
+    ];
+});

--- a/tests/Unit/Attributes/PercentageAttributeTest.php
+++ b/tests/Unit/Attributes/PercentageAttributeTest.php
@@ -1,53 +1,46 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\PercentageAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class PercentageAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
+
+test('from import truthy', function ($input) {
     $this->expectNotToPerformAssertions(PercentageAttribute::class);
-        PercentageAttribute::fromImport($input);
-    }
+    PercentageAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, PercentageAttribute::fromImport($input));
-    }
+test('from import return values', function ($input, $expected) {
+    expect(PercentageAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        PercentageAttribute::fromImport($input);
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    PercentageAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function truthyProvider() {
-        return [
-                "empty" => ["", null],
-                "zero" => ["0", 0],
-                "fifty" => ["50", 50],
-                "hundred" => ["100", 100],
-                "integer zero" => [0, 0],
-                "integer fifty" => [50, 50],
-                "integer hundred" => [100, 100],
-        ];
-    }
+dataset('truthyProvider', function () {
+    return [
+            "empty" => ["", null],
+            "zero" => ["0", 0],
+            "fifty" => ["50", 50],
+            "hundred" => ["100", 100],
+            "integer zero" => [0, 0],
+            "integer fifty" => [50, 50],
+            "integer hundred" => [100, 100],
+    ];
+});
 
-    public static function falsyProvider() {
-        return [
-                "boolean" => [true],
-                "float" => [1.1],
-                "negative integer" => [-1],
-                "negative float" => [-1.1],
-                "integer over hundred" => [101],
-                "string is float" => ["1.1"],
-                "string is negative integer" => ["-1"],
-                "string is negative float" => ["-1.1"],
-                "string is over hundred" => ["101"],
-        ];
-    }
-}
+dataset('falsyProvider', function () {
+    return [
+            "boolean" => [true],
+            "float" => [1.1],
+            "negative integer" => [-1],
+            "negative float" => [-1.1],
+            "integer over hundred" => [101],
+            "string is float" => ["1.1"],
+            "string is negative integer" => ["-1"],
+            "string is negative float" => ["-1.1"],
+            "string is over hundred" => ["101"],
+    ];
+});

--- a/tests/Unit/Attributes/RichtextAttributeTest.php
+++ b/tests/Unit/Attributes/RichtextAttributeTest.php
@@ -1,43 +1,36 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\RichtextAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class RichtextAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(RichtextAttribute::class);
-        RichtextAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, RichtextAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(RichtextAttribute::class);
+    RichtextAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        RichtextAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(RichtextAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["test", "test"],
-            "markdown string" => ["# test", "# test"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    RichtextAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["test", "test"],
+        "markdown string" => ["# test", "# test"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+    ];
+});

--- a/tests/Unit/Attributes/RismAttributeTest.php
+++ b/tests/Unit/Attributes/RismAttributeTest.php
@@ -1,49 +1,42 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\RismAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class RismAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(RismAttribute::class);
-        RismAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, RismAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(RismAttribute::class);
+    RismAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        RismAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(RismAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "number as string" => ["600146721", "600146721"],
-            "number as string with spaces" => [" 600146721 ", "600146721"],
-            "number can start with 0" => ["00000600146721", "00000600146721"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    RismAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-             // insert failing tests
-            "fails on integer value" => [1],
-            "fails on float" => [1.1],
-            "fails on float string" => ["1.1"],
-            "fails on boolean" => [true],
-            "fails on non-numeric string" => ["string"],
-            "fails on negative integer" => [-1],
-            "fails on negative integer string" => ["-1"],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "number as string" => ["600146721", "600146721"],
+        "number as string with spaces" => [" 600146721 ", "600146721"],
+        "number can start with 0" => ["00000600146721", "00000600146721"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+         // insert failing tests
+        "fails on integer value" => [1],
+        "fails on float" => [1.1],
+        "fails on float string" => ["1.1"],
+        "fails on boolean" => [true],
+        "fails on non-numeric string" => ["string"],
+        "fails on negative integer" => [-1],
+        "fails on negative integer string" => ["-1"],
+    ];
+});

--- a/tests/Unit/Attributes/SerialAttributeTest.php
+++ b/tests/Unit/Attributes/SerialAttributeTest.php
@@ -1,30 +1,25 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\SerialAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class SerialAttributeTest extends TestCase {
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        SerialAttribute::fromImport($input);
-    }
 
-    public static function falsyProvider() {
-        return [
-            "fails on import" => [false],
-            "fails on 0" => [0],
-            "fails on integer" => [1],
-            "fails on negative integer" => [-1],
-            "fails on string" => ['ok'],
-            "fails on string 0" => ['0'],
-            "fails on another string" => ['kauderwelsch'],
-            "fails on float" => [1.1],
-            "fails on float string" => ["1.1"],
-        ];
-    }
-}
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    SerialAttribute::fromImport($input);
+})->with('falsyProvider');
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on import" => [false],
+        "fails on 0" => [0],
+        "fails on integer" => [1],
+        "fails on negative integer" => [-1],
+        "fails on string" => ['ok'],
+        "fails on string 0" => ['0'],
+        "fails on another string" => ['kauderwelsch'],
+        "fails on float" => [1.1],
+        "fails on float string" => ["1.1"],
+    ];
+});

--- a/tests/Unit/Attributes/SiAttributeTest.php
+++ b/tests/Unit/Attributes/SiAttributeTest.php
@@ -241,26 +241,26 @@ test('volume units', function () {
     expect($fluidOunce)->not->toBeNull();
     expect($fluidOunce->getSymbol())->toEqual('fl oz');
     expect($fluidOunce->is(1))->toEqual(2.95735295625e-5);
-    expect($fluidOunce->is(1))->toEqualWithDelta($millilitre->is(29.5735295625), self::INACCURACY);
+    expect($fluidOunce->is(1))->toEqualWithDelta($millilitre->is(29.5735295625), INACCURACY);
 
     $pint = $volumeUnits->get('pint_us');
     expect($pint)->not->toBeNull();
     expect($pint->getSymbol())->toEqual('pt');
-    expect($pint->is(1))->toEqualWithDelta($millilitre->is(473.176473), self::INACCURACY);
+    expect($pint->is(1))->toEqualWithDelta($millilitre->is(473.176473), INACCURACY);
 
     $gallon = $volumeUnits->get('gallon_us');
     expect($gallon)->not->toBeNull();
     expect($gallon->getSymbol())->toEqual('gal');
-    expect($gallon->is(1))->toEqualWithDelta($litre->is(3.785411784), self::INACCURACY);
+    expect($gallon->is(1))->toEqualWithDelta($litre->is(3.785411784), INACCURACY);
 
     // Imperal Conversions
-    expect($gallon->is(1 / 8))->toEqualWithDelta($pint->is(1), self::INACCURACY);
-    expect($fluidOunce->is(16))->toEqualWithDelta($pint->is(1), self::INACCURACY);
+    expect($gallon->is(1 / 8))->toEqualWithDelta($pint->is(1), INACCURACY);
+    expect($fluidOunce->is(16))->toEqualWithDelta($pint->is(1), INACCURACY);
 
     $cubicMile = $volumeUnits->get('cubic_mile');
     expect($cubicMile)->not->toBeNull();
     expect($cubicMile->getSymbol())->toEqual('mi³');
-    expect($cubicMile->is(1))->toEqualWithDelta($baseUnit->is(4168181825.44058), self::INACCURACY);
+    expect($cubicMile->is(1))->toEqualWithDelta($baseUnit->is(4168181825.44058), INACCURACY);
 });
 
 test('speed units', function () {
@@ -274,22 +274,22 @@ test('speed units', function () {
 
     $kmh = $speedUnits->get('kilometre_per_hour');
     expect($kmh->getSymbol())->toEqual('km/h');
-    expect($kmh->is(3.6))->toEqualWithDelta(1, self::INACCURACY);
+    expect($kmh->is(3.6))->toEqualWithDelta(1, INACCURACY);
 
     $timeUnits = new TimeUnits();
     $lengthUnits = new LengthUnits();
 
     $msToKmhFactor = $lengthUnits->get('kilometre')->is(1) / $timeUnits->get('hour')->is(1);
-    expect($msToKmhFactor)->toEqualWithDelta($kmh->is(1), self::INACCURACY);
+    expect($msToKmhFactor)->toEqualWithDelta($kmh->is(1), INACCURACY);
 
     $mph = $speedUnits->get('mile_per_hour');
     expect($mph->getSymbol())->toEqual('mph');
-    expect($mph->is(1))->toEqualWithDelta(0.44704, self::INACCURACY);
+    expect($mph->is(1))->toEqualWithDelta(0.44704, INACCURACY);
 
     $msToMphFactor = $lengthUnits->get('mile')->is(1) / $timeUnits->get('hour')->is(1);
-    expect($msToMphFactor)->toEqualWithDelta($mph->is(1), self::INACCURACY);
+    expect($msToMphFactor)->toEqualWithDelta($mph->is(1), INACCURACY);
 
-    expect($mph->is(1))->toEqualWithDelta($kmh->is(1.609344), self::INACCURACY);
+    expect($mph->is(1))->toEqualWithDelta($kmh->is(1.609344), INACCURACY);
 });
 
 test('force units', function () {
@@ -336,19 +336,19 @@ test('pressure units', function () {
     // Various
     $psi = $pressureUnits->get('pound_per_square_inch');
     expect($psi->getSymbol())->toEqual('psi');
-    expect($psi->is(0.0001450377438972831))->toEqualWithDelta(1, self::INACCURACY);
+    expect($psi->is(0.0001450377438972831))->toEqualWithDelta(1, INACCURACY);
 
     $torr = $pressureUnits->get('torr');
     expect($torr->getSymbol())->toEqual('Torr');
-    expect($torr->is(0.0075006150504341364))->toEqualWithDelta(1, self::INACCURACY);
+    expect($torr->is(0.0075006150504341364))->toEqualWithDelta(1, INACCURACY);
 
     $at = $pressureUnits->get('technical_atmosphere');
     expect($at->getSymbol())->toEqual('at');
-    expect($at->is(1.019716212977928e-5))->toEqualWithDelta(1, self::INACCURACY);
+    expect($at->is(1.019716212977928e-5))->toEqualWithDelta(1, INACCURACY);
 
     $atm = $pressureUnits->get('standard_atmosphere');
     expect($atm->getSymbol())->toEqual('atm');
-    expect($atm->is(9.869232667160128e-6))->toEqualWithDelta(1, self::INACCURACY);
+    expect($atm->is(9.869232667160128e-6))->toEqualWithDelta(1, INACCURACY);
 });
 
 test('volumetric flow', function () {

--- a/tests/Unit/Attributes/SiAttributeTest.php
+++ b/tests/Unit/Attributes/SiAttributeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Unit\Attributes;
-
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\SiUnitAttribute;
 use App\AttributeTypes\Units\Implementations\AreaUnits;
@@ -17,473 +15,455 @@ use App\AttributeTypes\Units\Implementations\VolumetricFlowUnits;
 use App\AttributeTypes\Units\Implementations\VolumeUnits;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
-
-class SiAttributeTest extends TestCase {
-
-    const INACCURACY = 1e-10;
-
-    /// Area
-    public function testAreaUnits() {
-        $areaUnits = new AreaUnits();
-        $this->assertEquals('area', $areaUnits->getName());
-
-        $baseUnit = $areaUnits->getBaseUnit();
-        $this->assertNotNull($baseUnit);
-        $this->assertEquals('square_metre', $baseUnit->getLabel());
-        $this->assertEquals('m²', $baseUnit->getSymbol());
-        $this->assertEquals(1, $baseUnit->is(1));
-
-        $centimetre = $areaUnits->get('square_centimetre');
-        $this->assertNotNull($centimetre);
-        $this->assertEquals(10 ** -4, $centimetre->is(1));
-        $this->assertEquals('cm²', $centimetre->getSymbol());
-
-        $kilometre = $areaUnits->get('square_kilometre');
-        $this->assertNotNull($kilometre);
-        $this->assertEquals(10 ** 6, $kilometre->is(1));
-        $this->assertEquals('km²', $kilometre->getSymbol());
-
-        /// Imperial Units
-        $squareInch = $areaUnits->get('square_inch');
-        $this->assertNotNull($squareInch);
-        $this->assertEquals('in²', $squareInch->getSymbol());
-        $this->assertEquals(0.00064516, $squareInch->is(1));
-
-        $squareFeet = $areaUnits->get('square_feet');
-        $this->assertNotNull($squareFeet);
-        $this->assertEquals('ft²', $squareFeet->getSymbol());
-        $this->assertEquals(0.09290304, $squareFeet->is(1));
-
-        $squareYard = $areaUnits->get('square_yard');
-        $this->assertNotNull($squareYard);
-        $this->assertEquals('yd²', $squareYard->getSymbol());
-        $this->assertEquals(0.83612736, $squareYard->is(1));
-
-        $acre = $areaUnits->get('acre');
-        $this->assertNotNull($acre);
-        $this->assertEquals('ac', $acre->getSymbol());
-        $this->assertEquals(4046.8564224, $acre->is(1));
-
-        $squareMile = $areaUnits->get('square_mile');
-        $this->assertNotNull($squareMile);
-        $this->assertEquals('mi²', $squareMile->getSymbol());
-        $this->assertEquals(2589988.1103360, $squareMile->is(1));
-    }
-
-    /// Length
-    public function testLengthUnits() {
-        $lengthUnits = new LengthUnits();
-        $this->assertEquals('length', $lengthUnits->getName());
-
-        $baseUnit = $lengthUnits->getBaseUnit();
-        $this->assertEquals('metre', $baseUnit->getLabel());
-        $this->assertEquals('m', $baseUnit->getSymbol());
-
-        $nanometre = $lengthUnits->get('nanometre');
-        $this->assertNotNull($nanometre);
-        $this->assertEquals(10 ** -9, $nanometre->is(1));
-        $this->assertEquals('nm', $nanometre->getSymbol());
-
-        $micrometre = $lengthUnits->get('micrometre');
-        $this->assertNotNull($micrometre);
-        $this->assertEquals(10 ** -6, $micrometre->is(1));
-        $this->assertEquals('µm', $micrometre->getSymbol());
-
-        $millimetre = $lengthUnits->get('millimetre');
-        $this->assertNotNull($millimetre);
-        $this->assertEquals(10 ** -3, $millimetre->is(1));
-
-        $centimetre = $lengthUnits->get('centimetre');
-        $this->assertNotNull($centimetre);
-        $this->assertEquals(10 ** -2, $centimetre->is(1));
-        $this->assertEquals('cm', $centimetre->getSymbol());
-
-        $kilometre = $lengthUnits->get('kilometre');
-        $this->assertNotNull($kilometre);
-        $this->assertEquals(1000, $kilometre->is(1));
-        $this->assertEquals('km', $kilometre->getSymbol());
-
-        /// Imperial Units
-
-        $inch = $lengthUnits->get('inch');
-        $this->assertNotNull($inch);
-        $this->assertEquals('inch', $inch->getLabel());
-        $this->assertEquals('in', $inch->getSymbol());
-        $this->assertEquals(0.0254, $inch->is(1));
-
-        $feet = $lengthUnits->get('feet');
-        $this->assertNotNull($feet);
-        $this->assertEquals('feet', $feet->getLabel());
-        $this->assertEquals('ft', $feet->getSymbol());
-        $this->assertEquals(0.3048, $feet->is(1));
-
-        $yard = $lengthUnits->get('yard');
-        $this->assertNotNull($yard);
-        $this->assertEquals('yard', $yard->getLabel());
-        $this->assertEquals('yd', $yard->getSymbol());
-        $this->assertEquals(0.9144, $yard->is(1));
-
-        $mile = $lengthUnits->get('mile');
-        $this->assertNotNull($mile);
-        $this->assertEquals('mile', $mile->getLabel());
-        $this->assertEquals('mi', $mile->getSymbol());
-        $this->assertEquals(1609.344, $mile->is(1));
-    }
-
-    /// Mass
-    public function testMassUnits() {
-        $massUnits = new MassUnits();
-        $this->assertEquals('mass', $massUnits->getName());
-
-        $baseUnit = $massUnits->getBaseUnit();
-        $this->assertNotNull($baseUnit);
-        $this->assertEquals('gram', $baseUnit->getLabel());
-        $this->assertEquals('g', $baseUnit->getSymbol());
-
-        $milligram = $massUnits->get('milligram');
-        $this->assertNotNull($milligram);
-        $this->assertEquals(10 ** -3, $milligram->is(1));
-        $this->assertEquals('mg', $milligram->getSymbol());
-
-
-        $kilogram = $massUnits->get('kilogram');
-        $this->assertNotNull($kilogram);
-        $this->assertEquals(1000, $kilogram->is(1));
-        $this->assertEquals('kg', $kilogram->getSymbol());
-
-        $ton = $massUnits->get('ton');
-        $this->assertNotNull($ton);
-        $this->assertEquals($kilogram->is(1000), $ton->is(1));
-        $this->assertEquals('t', $ton->getSymbol());
-
-        /// Imperial Units
-        $ounce = $massUnits->get('ounce');
-        $this->assertNotNull($ounce);
-        $this->assertEquals('oz', $ounce->getSymbol());
-        $this->assertEquals(28.349523125, $ounce->is(1));
-
-        $pound = $massUnits->get('pound');
-        $this->assertNotNull($pound);
-        $this->assertEquals('lb', $pound->getSymbol());
-        $this->assertEquals(453.59237, $pound->is(1));
-    }
-
-    /// Temperature
-    public function testTemperatureUnits() {
-        $temperatureUnits = new TemperatureUnits();
-        $this->assertEquals('temperature', $temperatureUnits->getName());
-
-        $baseUnit = $temperatureUnits->getBaseUnit();
-        $this->assertNotNull($baseUnit);
-        $this->assertEquals('kelvin', $baseUnit->getLabel());
-        $this->assertEquals('K', $baseUnit->getSymbol());
-
-        $celsius = $temperatureUnits->get('celsius');
-        $this->assertNotNull($celsius);
-        $this->assertEquals('celsius', $celsius->getLabel());
-        $this->assertEquals('°C', $celsius->getSymbol());
-        $this->assertEquals(273.15, $celsius->is(0));
-
-        $fahrenheit = $temperatureUnits->get('fahrenheit');
-        $this->assertNotNull($fahrenheit);
-        $this->assertEquals('fahrenheit', $fahrenheit->getLabel());
-        $this->assertEquals('°F', $fahrenheit->getSymbol());
-        $this->assertEquals(255.3722222222222, $fahrenheit->is(0));
-
-        $réaumur = $temperatureUnits->get('réaumur');
-        $this->assertNotNull($réaumur);
-        $this->assertEquals('réaumur', $réaumur->getLabel());
-        $this->assertEquals('°Ré', $réaumur->getSymbol());
-        $this->assertEquals(273.15, $réaumur->is(0));
-        $this->assertEquals(373.15, $réaumur->is(80));
-    }
-
-    /// Time
-    public function testTimeUnits() {
-        $timeUnits =  new TimeUnits();
-        $this->assertEquals('time', $timeUnits->getName());
-
-        $baseUnit = $timeUnits->getBaseUnit();
-        $this->assertEquals('second', $baseUnit->getLabel());
-        $this->assertEquals('s', $baseUnit->getSymbol());
-
-        $minute = $timeUnits->get('minute');
-        $this->assertEquals('minute', $minute->getLabel());
-        $this->assertEquals('min', $minute->getSymbol());
-        $this->assertEquals(60, $minute->is(1));
-
-        $hour = $timeUnits->get('hour');
-        $this->assertEquals('hour', $hour->getLabel());
-        $this->assertEquals('h', $hour->getSymbol());
-        $this->assertEquals($minute->is(60), $hour->is(1));
-
-        $day = $timeUnits->get('day');
-        $this->assertEquals('day', $day->getLabel());
-        $this->assertEquals('d', $day->getSymbol());
-        $this->assertEquals($hour->is(24), $day->is(1));
-
-        $year = $timeUnits->get('year');
-        $this->assertEquals('year', $year->getLabel());
-        $this->assertEquals('a', $year->getSymbol());
-        $this->assertEquals($day->is(365), $year->is(1));
-    }
-
-    /// Volume
-    public function testVolumeUnits() {
-        $volumeUnits = new VolumeUnits();
-        $this->assertEquals('volume', $volumeUnits->getName());
-
-        $baseUnit = $volumeUnits->getBaseUnit();
-        $this->assertNotNull($baseUnit);
-        $this->assertEquals('cubic_metre', $baseUnit->getLabel());
-        $this->assertEquals('m³', $baseUnit->getSymbol());
-
-        $millilitre = $volumeUnits->get('millilitre');
-        $this->assertNotNull($millilitre);
-        $this->assertEquals(10 ** -6, $millilitre->is(1));
-        $this->assertEquals('ml', $millilitre->getSymbol());
-
-        $litre = $volumeUnits->get('litre');
-        $this->assertNotNull($litre);
-        $this->assertEquals(10 ** -3, $litre->is(1));
-        $this->assertEquals('l', $litre->getSymbol());
-
-        // Imperial Units
-        $fluidOunce = $volumeUnits->get('fluid_ounce_us');
-        $this->assertNotNull($fluidOunce);
-        $this->assertEquals('fl oz', $fluidOunce->getSymbol());
-        $this->assertEquals(2.95735295625e-5, $fluidOunce->is(1));
-        $this->assertEqualsWithDelta($millilitre->is(29.5735295625), $fluidOunce->is(1), self::INACCURACY);
-
-        $pint = $volumeUnits->get('pint_us');
-        $this->assertNotNull($pint);
-        $this->assertEquals('pt', $pint->getSymbol());
-        $this->assertEqualsWithDelta($millilitre->is(473.176473), $pint->is(1), self::INACCURACY);
-
-        $gallon = $volumeUnits->get('gallon_us');
-        $this->assertNotNull($gallon);
-        $this->assertEquals('gal', $gallon->getSymbol());
-        $this->assertEqualsWithDelta($litre->is(3.785411784), $gallon->is(1), self::INACCURACY);
-
-        // Imperal Conversions
-        $this->assertEqualsWithDelta($pint->is(1), $gallon->is(1 / 8), self::INACCURACY);
-        $this->assertEqualsWithDelta($pint->is(1), $fluidOunce->is(16), self::INACCURACY);
-
-
-        $cubicMile = $volumeUnits->get('cubic_mile');
-        $this->assertNotNull($cubicMile);
-        $this->assertEquals('mi³', $cubicMile->getSymbol());
-        $this->assertEqualsWithDelta($baseUnit->is(4168181825.44058), $cubicMile->is(1), self::INACCURACY);
-    }
-
-    # Speeds
-    function testSpeedUnits() {
-        $speedUnits = new SpeedUnits();
-
-        $baseUnit = $speedUnits->getBaseUnit();
-
-        $this->assertEquals('metre_per_second', $baseUnit->getLabel());
-        $this->assertEquals('m/s', $baseUnit->getSymbol());
-        $this->assertEquals(1, $baseUnit->is(1));
-
-        $kmh = $speedUnits->get('kilometre_per_hour');
-        $this->assertEquals('km/h', $kmh->getSymbol());
-        $this->assertEqualsWithDelta(1, $kmh->is(3.6), self::INACCURACY);
-
-        $timeUnits = new TimeUnits();
-        $lengthUnits = new LengthUnits();
-
-        $msToKmhFactor = $lengthUnits->get('kilometre')->is(1) / $timeUnits->get('hour')->is(1);
-        $this->assertEqualsWithDelta($kmh->is(1), $msToKmhFactor, self::INACCURACY);
-
-        $mph = $speedUnits->get('mile_per_hour');
-        $this->assertEquals('mph', $mph->getSymbol());
-        $this->assertEqualsWithDelta(0.44704, $mph->is(1), self::INACCURACY);
-
-        $msToMphFactor = $lengthUnits->get('mile')->is(1) / $timeUnits->get('hour')->is(1);
-        $this->assertEqualsWithDelta($mph->is(1), $msToMphFactor, self::INACCURACY);
-
-        $this->assertEqualsWithDelta($kmh->is(1.609344), $mph->is(1), self::INACCURACY);
-    }
-
-    /// Force
-    public function testForceUnits() {
-        $forceUnits = new ForceUnits();
-
-        $baseUnit = $forceUnits->getBaseUnit();
-        $this->assertEquals('newton', $baseUnit->getLabel());
-        $this->assertEquals('N', $baseUnit->getSymbol());
-
-        $kN = $forceUnits->get('kilonewton');
-        $this->assertEquals('kN', $kN->getSymbol());
-        $this->assertEquals(1000, $kN->is(1));
-    }
-
-
-    /// Pressure
-    public function testPressureUnits() {
-        $pressureUnits = new PressureUnits();
-
-        // Pascal
-        $baseUnit = $pressureUnits->getBaseUnit();
-        $this->assertEquals('pascal', $baseUnit->getLabel());
-        $this->assertEquals('Pa', $baseUnit->getSymbol());
-
-        $kN = $pressureUnits->get('kilopascal');
-        $this->assertEquals('kPa', $kN->getSymbol());
-        $this->assertEquals(1000, $kN->is(1));
-
-        $hN = $pressureUnits->get('hectopascal');
-        $this->assertEquals('hPa', $hN->getSymbol());
-        $this->assertEquals(100, $hN->is(1));
-
-        // Bar
-        $bar = $pressureUnits->get('bar');
-        $this->assertEquals('bar', $bar->getSymbol());
-        $this->assertEquals(100000, $bar->is(1));
-
-        $decibar = $pressureUnits->get('decibar');
-        $this->assertEquals('dbar', $decibar->getSymbol());
-        $this->assertEquals(10000, $decibar->is(1));
-
-        $mbar = $pressureUnits->get('millibar');
-        $this->assertEquals('mbar', $mbar->getSymbol());
-        $this->assertEquals(100, $mbar->is(1));
-
-        // Various
-        $psi = $pressureUnits->get('pound_per_square_inch');
-        $this->assertEquals('psi', $psi->getSymbol());
-        $this->assertEqualsWithDelta(1, $psi->is(0.0001450377438972831), self::INACCURACY);
-
-        $torr = $pressureUnits->get('torr');
-        $this->assertEquals('Torr', $torr->getSymbol());
-        $this->assertEqualsWithDelta(1, $torr->is(0.0075006150504341364), self::INACCURACY);
-
-        $at = $pressureUnits->get('technical_atmosphere');
-        $this->assertEquals('at', $at->getSymbol());
-        $this->assertEqualsWithDelta(1, $at->is(1.019716212977928e-5), self::INACCURACY);
-
-        $atm = $pressureUnits->get('standard_atmosphere');
-        $this->assertEquals('atm', $atm->getSymbol());
-        $this->assertEqualsWithDelta(1, $atm->is(9.869232667160128e-6), self::INACCURACY);
-    }
-
-    /// Volumetric Flow Rate
-    public function testVolumetricFlow() {
-        $volumetricFlowUnits = new VolumetricFlowUnits();
-
-        $baseUnit = $volumetricFlowUnits->getBaseUnit();
-        $this->assertEquals('cubic_metre_per_second', $baseUnit->getLabel());
-        $this->assertEquals('m³/s', $baseUnit->getSymbol());
-
-        $lps = $volumetricFlowUnits->get('litre_per_second');
-        $this->assertEquals('l/s', $lps->getSymbol());
-        $this->assertEquals(10 ** -3, $lps->is(1));
-    }
-
-    public function testQuotients() {
-        $quotientUnits = new QuotientUnits();
-
-        $baseUnit = $quotientUnits->getBaseUnit();
-        $this->assertEquals('ppm', $baseUnit->getSymbol());
-        $this->assertEquals('parts per million', $baseUnit->getLabel());
-
-        $percent = $quotientUnits->get('percent');
-        $this->assertEquals('%', $percent->getSymbol());
-        $this->assertEquals(1, $percent->is(1e-4));
-        $this->assertEquals(1e6, $percent->is(100));
-    }
-
-    public function testImportErrorWrongValue() {
-        $importValue = 10;
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('The value must be a string.');
-        SiUnitAttribute::fromImport($importValue);
-    }
-
-    public function testImportErrorWrongFormatNoSeparator() {
-        $importValue = "wrong format";
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('Provided data has the wrong format, expected: value;unit');
-        SiUnitAttribute::fromImport($importValue);
-    }
-
-    public function testImportErrorWrongFormatTooManySeparators() {
-        $importValue = "value;unit;extra";
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('Provided data has the wrong format, expected: value;unit');
-        SiUnitAttribute::fromImport($importValue);
-    }
-
-    public function testImportErrorNotANumber() {
-        $importValue = "not a number;unit";
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('The value must be a number: section 1 => not a number');
-        SiUnitAttribute::fromImport($importValue);
-    }
-
-    public function testImportErrorNotAUnit() {
-        $importValue = "2;not a unit";
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('Unit does not exist: section 2 => not a unit');
-        SiUnitAttribute::fromImport($importValue);
-    }
-
-    public function testImportSuccess() {
-        $importValue = "10.5;km";
-        $expected = json_encode([
-            'value' => 10.5,
-            'unit' => 'km',
-            'normalized' => 10500,
-        ]);
-        $this->assertEquals($expected, SiUnitAttribute::fromImport($importValue));
-    }
-
-    public function testSerialize() {
-        $data = "{
+
+const INACCURACY = 1e-10;
+
+test('area units', function () {
+    $areaUnits = new AreaUnits();
+    expect($areaUnits->getName())->toEqual('area');
+
+    $baseUnit = $areaUnits->getBaseUnit();
+    expect($baseUnit)->not->toBeNull();
+    expect($baseUnit->getLabel())->toEqual('square_metre');
+    expect($baseUnit->getSymbol())->toEqual('m²');
+    expect($baseUnit->is(1))->toEqual(1);
+
+    $centimetre = $areaUnits->get('square_centimetre');
+    expect($centimetre)->not->toBeNull();
+    expect($centimetre->is(1))->toEqual(10 ** -4);
+    expect($centimetre->getSymbol())->toEqual('cm²');
+
+    $kilometre = $areaUnits->get('square_kilometre');
+    expect($kilometre)->not->toBeNull();
+    expect($kilometre->is(1))->toEqual(10 ** 6);
+    expect($kilometre->getSymbol())->toEqual('km²');
+
+    /// Imperial Units
+    $squareInch = $areaUnits->get('square_inch');
+    expect($squareInch)->not->toBeNull();
+    expect($squareInch->getSymbol())->toEqual('in²');
+    expect($squareInch->is(1))->toEqual(0.00064516);
+
+    $squareFeet = $areaUnits->get('square_feet');
+    expect($squareFeet)->not->toBeNull();
+    expect($squareFeet->getSymbol())->toEqual('ft²');
+    expect($squareFeet->is(1))->toEqual(0.09290304);
+
+    $squareYard = $areaUnits->get('square_yard');
+    expect($squareYard)->not->toBeNull();
+    expect($squareYard->getSymbol())->toEqual('yd²');
+    expect($squareYard->is(1))->toEqual(0.83612736);
+
+    $acre = $areaUnits->get('acre');
+    expect($acre)->not->toBeNull();
+    expect($acre->getSymbol())->toEqual('ac');
+    expect($acre->is(1))->toEqual(4046.8564224);
+
+    $squareMile = $areaUnits->get('square_mile');
+    expect($squareMile)->not->toBeNull();
+    expect($squareMile->getSymbol())->toEqual('mi²');
+    expect($squareMile->is(1))->toEqual(2589988.1103360);
+});
+
+test('length units', function () {
+    $lengthUnits = new LengthUnits();
+    expect($lengthUnits->getName())->toEqual('length');
+
+    $baseUnit = $lengthUnits->getBaseUnit();
+    expect($baseUnit->getLabel())->toEqual('metre');
+    expect($baseUnit->getSymbol())->toEqual('m');
+
+    $nanometre = $lengthUnits->get('nanometre');
+    expect($nanometre)->not->toBeNull();
+    expect($nanometre->is(1))->toEqual(10 ** -9);
+    expect($nanometre->getSymbol())->toEqual('nm');
+
+    $micrometre = $lengthUnits->get('micrometre');
+    expect($micrometre)->not->toBeNull();
+    expect($micrometre->is(1))->toEqual(10 ** -6);
+    expect($micrometre->getSymbol())->toEqual('µm');
+
+    $millimetre = $lengthUnits->get('millimetre');
+    expect($millimetre)->not->toBeNull();
+    expect($millimetre->is(1))->toEqual(10 ** -3);
+
+    $centimetre = $lengthUnits->get('centimetre');
+    expect($centimetre)->not->toBeNull();
+    expect($centimetre->is(1))->toEqual(10 ** -2);
+    expect($centimetre->getSymbol())->toEqual('cm');
+
+    $kilometre = $lengthUnits->get('kilometre');
+    expect($kilometre)->not->toBeNull();
+    expect($kilometre->is(1))->toEqual(1000);
+    expect($kilometre->getSymbol())->toEqual('km');
+
+    /// Imperial Units
+    $inch = $lengthUnits->get('inch');
+    expect($inch)->not->toBeNull();
+    expect($inch->getLabel())->toEqual('inch');
+    expect($inch->getSymbol())->toEqual('in');
+    expect($inch->is(1))->toEqual(0.0254);
+
+    $feet = $lengthUnits->get('feet');
+    expect($feet)->not->toBeNull();
+    expect($feet->getLabel())->toEqual('feet');
+    expect($feet->getSymbol())->toEqual('ft');
+    expect($feet->is(1))->toEqual(0.3048);
+
+    $yard = $lengthUnits->get('yard');
+    expect($yard)->not->toBeNull();
+    expect($yard->getLabel())->toEqual('yard');
+    expect($yard->getSymbol())->toEqual('yd');
+    expect($yard->is(1))->toEqual(0.9144);
+
+    $mile = $lengthUnits->get('mile');
+    expect($mile)->not->toBeNull();
+    expect($mile->getLabel())->toEqual('mile');
+    expect($mile->getSymbol())->toEqual('mi');
+    expect($mile->is(1))->toEqual(1609.344);
+});
+
+test('mass units', function () {
+    $massUnits = new MassUnits();
+    expect($massUnits->getName())->toEqual('mass');
+
+    $baseUnit = $massUnits->getBaseUnit();
+    expect($baseUnit)->not->toBeNull();
+    expect($baseUnit->getLabel())->toEqual('gram');
+    expect($baseUnit->getSymbol())->toEqual('g');
+
+    $milligram = $massUnits->get('milligram');
+    expect($milligram)->not->toBeNull();
+    expect($milligram->is(1))->toEqual(10 ** -3);
+    expect($milligram->getSymbol())->toEqual('mg');
+
+    $kilogram = $massUnits->get('kilogram');
+    expect($kilogram)->not->toBeNull();
+    expect($kilogram->is(1))->toEqual(1000);
+    expect($kilogram->getSymbol())->toEqual('kg');
+
+    $ton = $massUnits->get('ton');
+    expect($ton)->not->toBeNull();
+    expect($ton->is(1))->toEqual($kilogram->is(1000));
+    expect($ton->getSymbol())->toEqual('t');
+
+    /// Imperial Units
+    $ounce = $massUnits->get('ounce');
+    expect($ounce)->not->toBeNull();
+    expect($ounce->getSymbol())->toEqual('oz');
+    expect($ounce->is(1))->toEqual(28.349523125);
+
+    $pound = $massUnits->get('pound');
+    expect($pound)->not->toBeNull();
+    expect($pound->getSymbol())->toEqual('lb');
+    expect($pound->is(1))->toEqual(453.59237);
+});
+
+test('temperature units', function () {
+    $temperatureUnits = new TemperatureUnits();
+    expect($temperatureUnits->getName())->toEqual('temperature');
+
+    $baseUnit = $temperatureUnits->getBaseUnit();
+    expect($baseUnit)->not->toBeNull();
+    expect($baseUnit->getLabel())->toEqual('kelvin');
+    expect($baseUnit->getSymbol())->toEqual('K');
+
+    $celsius = $temperatureUnits->get('celsius');
+    expect($celsius)->not->toBeNull();
+    expect($celsius->getLabel())->toEqual('celsius');
+    expect($celsius->getSymbol())->toEqual('°C');
+    expect($celsius->is(0))->toEqual(273.15);
+
+    $fahrenheit = $temperatureUnits->get('fahrenheit');
+    expect($fahrenheit)->not->toBeNull();
+    expect($fahrenheit->getLabel())->toEqual('fahrenheit');
+    expect($fahrenheit->getSymbol())->toEqual('°F');
+    expect($fahrenheit->is(0))->toEqual(255.3722222222222);
+
+    $réaumur = $temperatureUnits->get('réaumur');
+    expect($réaumur)->not->toBeNull();
+    expect($réaumur->getLabel())->toEqual('réaumur');
+    expect($réaumur->getSymbol())->toEqual('°Ré');
+    expect($réaumur->is(0))->toEqual(273.15);
+    expect($réaumur->is(80))->toEqual(373.15);
+});
+
+test('time units', function () {
+    $timeUnits =  new TimeUnits();
+    expect($timeUnits->getName())->toEqual('time');
+
+    $baseUnit = $timeUnits->getBaseUnit();
+    expect($baseUnit->getLabel())->toEqual('second');
+    expect($baseUnit->getSymbol())->toEqual('s');
+
+    $minute = $timeUnits->get('minute');
+    expect($minute->getLabel())->toEqual('minute');
+    expect($minute->getSymbol())->toEqual('min');
+    expect($minute->is(1))->toEqual(60);
+
+    $hour = $timeUnits->get('hour');
+    expect($hour->getLabel())->toEqual('hour');
+    expect($hour->getSymbol())->toEqual('h');
+    expect($hour->is(1))->toEqual($minute->is(60));
+
+    $day = $timeUnits->get('day');
+    expect($day->getLabel())->toEqual('day');
+    expect($day->getSymbol())->toEqual('d');
+    expect($day->is(1))->toEqual($hour->is(24));
+
+    $year = $timeUnits->get('year');
+    expect($year->getLabel())->toEqual('year');
+    expect($year->getSymbol())->toEqual('a');
+    expect($year->is(1))->toEqual($day->is(365));
+});
+
+test('volume units', function () {
+    $volumeUnits = new VolumeUnits();
+    expect($volumeUnits->getName())->toEqual('volume');
+
+    $baseUnit = $volumeUnits->getBaseUnit();
+    expect($baseUnit)->not->toBeNull();
+    expect($baseUnit->getLabel())->toEqual('cubic_metre');
+    expect($baseUnit->getSymbol())->toEqual('m³');
+
+    $millilitre = $volumeUnits->get('millilitre');
+    expect($millilitre)->not->toBeNull();
+    expect($millilitre->is(1))->toEqual(10 ** -6);
+    expect($millilitre->getSymbol())->toEqual('ml');
+
+    $litre = $volumeUnits->get('litre');
+    expect($litre)->not->toBeNull();
+    expect($litre->is(1))->toEqual(10 ** -3);
+    expect($litre->getSymbol())->toEqual('l');
+
+    // Imperial Units
+    $fluidOunce = $volumeUnits->get('fluid_ounce_us');
+    expect($fluidOunce)->not->toBeNull();
+    expect($fluidOunce->getSymbol())->toEqual('fl oz');
+    expect($fluidOunce->is(1))->toEqual(2.95735295625e-5);
+    expect($fluidOunce->is(1))->toEqualWithDelta($millilitre->is(29.5735295625), self::INACCURACY);
+
+    $pint = $volumeUnits->get('pint_us');
+    expect($pint)->not->toBeNull();
+    expect($pint->getSymbol())->toEqual('pt');
+    expect($pint->is(1))->toEqualWithDelta($millilitre->is(473.176473), self::INACCURACY);
+
+    $gallon = $volumeUnits->get('gallon_us');
+    expect($gallon)->not->toBeNull();
+    expect($gallon->getSymbol())->toEqual('gal');
+    expect($gallon->is(1))->toEqualWithDelta($litre->is(3.785411784), self::INACCURACY);
+
+    // Imperal Conversions
+    expect($gallon->is(1 / 8))->toEqualWithDelta($pint->is(1), self::INACCURACY);
+    expect($fluidOunce->is(16))->toEqualWithDelta($pint->is(1), self::INACCURACY);
+
+    $cubicMile = $volumeUnits->get('cubic_mile');
+    expect($cubicMile)->not->toBeNull();
+    expect($cubicMile->getSymbol())->toEqual('mi³');
+    expect($cubicMile->is(1))->toEqualWithDelta($baseUnit->is(4168181825.44058), self::INACCURACY);
+});
+
+test('speed units', function () {
+    $speedUnits = new SpeedUnits();
+
+    $baseUnit = $speedUnits->getBaseUnit();
+
+    expect($baseUnit->getLabel())->toEqual('metre_per_second');
+    expect($baseUnit->getSymbol())->toEqual('m/s');
+    expect($baseUnit->is(1))->toEqual(1);
+
+    $kmh = $speedUnits->get('kilometre_per_hour');
+    expect($kmh->getSymbol())->toEqual('km/h');
+    expect($kmh->is(3.6))->toEqualWithDelta(1, self::INACCURACY);
+
+    $timeUnits = new TimeUnits();
+    $lengthUnits = new LengthUnits();
+
+    $msToKmhFactor = $lengthUnits->get('kilometre')->is(1) / $timeUnits->get('hour')->is(1);
+    expect($msToKmhFactor)->toEqualWithDelta($kmh->is(1), self::INACCURACY);
+
+    $mph = $speedUnits->get('mile_per_hour');
+    expect($mph->getSymbol())->toEqual('mph');
+    expect($mph->is(1))->toEqualWithDelta(0.44704, self::INACCURACY);
+
+    $msToMphFactor = $lengthUnits->get('mile')->is(1) / $timeUnits->get('hour')->is(1);
+    expect($msToMphFactor)->toEqualWithDelta($mph->is(1), self::INACCURACY);
+
+    expect($mph->is(1))->toEqualWithDelta($kmh->is(1.609344), self::INACCURACY);
+});
+
+test('force units', function () {
+    $forceUnits = new ForceUnits();
+
+    $baseUnit = $forceUnits->getBaseUnit();
+    expect($baseUnit->getLabel())->toEqual('newton');
+    expect($baseUnit->getSymbol())->toEqual('N');
+
+    $kN = $forceUnits->get('kilonewton');
+    expect($kN->getSymbol())->toEqual('kN');
+    expect($kN->is(1))->toEqual(1000);
+});
+
+test('pressure units', function () {
+    $pressureUnits = new PressureUnits();
+
+    // Pascal
+    $baseUnit = $pressureUnits->getBaseUnit();
+    expect($baseUnit->getLabel())->toEqual('pascal');
+    expect($baseUnit->getSymbol())->toEqual('Pa');
+
+    $kN = $pressureUnits->get('kilopascal');
+    expect($kN->getSymbol())->toEqual('kPa');
+    expect($kN->is(1))->toEqual(1000);
+
+    $hN = $pressureUnits->get('hectopascal');
+    expect($hN->getSymbol())->toEqual('hPa');
+    expect($hN->is(1))->toEqual(100);
+
+    // Bar
+    $bar = $pressureUnits->get('bar');
+    expect($bar->getSymbol())->toEqual('bar');
+    expect($bar->is(1))->toEqual(100000);
+
+    $decibar = $pressureUnits->get('decibar');
+    expect($decibar->getSymbol())->toEqual('dbar');
+    expect($decibar->is(1))->toEqual(10000);
+
+    $mbar = $pressureUnits->get('millibar');
+    expect($mbar->getSymbol())->toEqual('mbar');
+    expect($mbar->is(1))->toEqual(100);
+
+    // Various
+    $psi = $pressureUnits->get('pound_per_square_inch');
+    expect($psi->getSymbol())->toEqual('psi');
+    expect($psi->is(0.0001450377438972831))->toEqualWithDelta(1, self::INACCURACY);
+
+    $torr = $pressureUnits->get('torr');
+    expect($torr->getSymbol())->toEqual('Torr');
+    expect($torr->is(0.0075006150504341364))->toEqualWithDelta(1, self::INACCURACY);
+
+    $at = $pressureUnits->get('technical_atmosphere');
+    expect($at->getSymbol())->toEqual('at');
+    expect($at->is(1.019716212977928e-5))->toEqualWithDelta(1, self::INACCURACY);
+
+    $atm = $pressureUnits->get('standard_atmosphere');
+    expect($atm->getSymbol())->toEqual('atm');
+    expect($atm->is(9.869232667160128e-6))->toEqualWithDelta(1, self::INACCURACY);
+});
+
+test('volumetric flow', function () {
+    $volumetricFlowUnits = new VolumetricFlowUnits();
+
+    $baseUnit = $volumetricFlowUnits->getBaseUnit();
+    expect($baseUnit->getLabel())->toEqual('cubic_metre_per_second');
+    expect($baseUnit->getSymbol())->toEqual('m³/s');
+
+    $lps = $volumetricFlowUnits->get('litre_per_second');
+    expect($lps->getSymbol())->toEqual('l/s');
+    expect($lps->is(1))->toEqual(10 ** -3);
+});
+
+test('quotients', function () {
+    $quotientUnits = new QuotientUnits();
+
+    $baseUnit = $quotientUnits->getBaseUnit();
+    expect($baseUnit->getSymbol())->toEqual('ppm');
+    expect($baseUnit->getLabel())->toEqual('parts per million');
+
+    $percent = $quotientUnits->get('percent');
+    expect($percent->getSymbol())->toEqual('%');
+    expect($percent->is(1e-4))->toEqual(1);
+    expect($percent->is(100))->toEqual(1e6);
+});
+
+test('import error wrong value', function () {
+    $importValue = 10;
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('The value must be a string.');
+    SiUnitAttribute::fromImport($importValue);
+});
+
+test('import error wrong format no separator', function () {
+    $importValue = "wrong format";
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('Provided data has the wrong format, expected: value;unit');
+    SiUnitAttribute::fromImport($importValue);
+});
+
+test('import error wrong format too many separators', function () {
+    $importValue = "value;unit;extra";
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('Provided data has the wrong format, expected: value;unit');
+    SiUnitAttribute::fromImport($importValue);
+});
+
+test('import error not anumber', function () {
+    $importValue = "not a number;unit";
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('The value must be a number: section 1 => not a number');
+    SiUnitAttribute::fromImport($importValue);
+});
+
+test('import error not aunit', function () {
+    $importValue = "2;not a unit";
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('Unit does not exist: section 2 => not a unit');
+    SiUnitAttribute::fromImport($importValue);
+});
+
+test('import success', function () {
+    $importValue = "10.5;km";
+    $expected = json_encode([
+        'value' => 10.5,
+        'unit' => 'km',
+        'normalized' => 10500,
+    ]);
+    expect(SiUnitAttribute::fromImport($importValue))->toEqual($expected);
+});
+
+test('serialize', function () {
+    $data = "{
             'value': 10.5,
             'unit': 'km',
             'normalized': 10500,
         }";
-        $expected = json_decode($data);
-        $this->assertEquals($expected, SiUnitAttribute::serialize($data));
-    }
+    $expected = json_decode($data);
+    expect(SiUnitAttribute::serialize($data))->toEqual($expected);
+});
 
-    public function testUnserializeConflictNoUnit() {
-        $data = [
-            'value' => 10.5,
-        ];
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('Unit does not exist');
-        SiUnitAttribute::unserialize($data);
-    }
+test('unserialize conflict no unit', function () {
+    $data = [
+        'value' => 10.5,
+    ];
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('Unit does not exist');
+    SiUnitAttribute::unserialize($data);
+});
 
-    public function testUnserializeConflictInvalidUnit() {
-        $data = [
-            'value' => 10.5,
-            'unit' => "invalid unit",
-        ];
-        $this->expectException(InvalidDataException::class);
-        $this->expectExceptionMessage('Unit does not exist');
-        SiUnitAttribute::unserialize($data);
-    }
+test('unserialize conflict invalid unit', function () {
+    $data = [
+        'value' => 10.5,
+        'unit' => "invalid unit",
+    ];
+    $this->expectException(InvalidDataException::class);
+    $this->expectExceptionMessage('Unit does not exist');
+    SiUnitAttribute::unserialize($data);
+});
 
-    public function testUnserializeSuccess() {
-        $data = [
-            'value' => 10.5,
-            'unit' => 'km',
-        ];
-        $expected = $data;
-        $expected["normalized"] = 10500;
-        $expected = json_encode($expected);
-        $this->assertEquals($expected, SiUnitAttribute::unserialize($data));
-    }
+test('unserialize success', function () {
+    $data = [
+        'value' => 10.5,
+        'unit' => 'km',
+    ];
+    $expected = $data;
+    $expected["normalized"] = 10500;
+    $expected = json_encode($expected);
+    expect(SiUnitAttribute::unserialize($data))->toEqual($expected);
+});
 
-    public function testParseExport() {
-        $testValue = AttributeValue::find(77);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('parse export', function () {
+    $testValue = AttributeValue::find(77);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-        $this->assertEquals('15.99;kilogram', $parseResult);
-    }
-}
+    expect($parseResult)->toEqual('15.99;kilogram');
+});

--- a/tests/Unit/Attributes/SqlAttributeTest.php
+++ b/tests/Unit/Attributes/SqlAttributeTest.php
@@ -1,27 +1,22 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\SqlAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class SqlAttributeTest extends TestCase {
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        SqlAttribute::fromImport($input);
-    }
 
-    public static function falsyProvider() {
-        return [
-            [false],
-            [0],
-            [-1],
-            ['ok'],
-            ['0'],
-            ['kauderwelsch'],
-        ];
-    }
-}
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    SqlAttribute::fromImport($input);
+})->with('falsyProvider');
+
+dataset('falsyProvider', function () {
+    return [
+        [false],
+        [0],
+        [-1],
+        ['ok'],
+        ['0'],
+        ['kauderwelsch'],
+    ];
+});

--- a/tests/Unit/Attributes/StringAttributeTest.php
+++ b/tests/Unit/Attributes/StringAttributeTest.php
@@ -1,42 +1,35 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\StringAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class StringAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(StringAttribute::class);
-        StringAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, StringAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(StringAttribute::class);
+    StringAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        StringAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(StringAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["test", "test"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    StringAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["test", "test"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+    ];
+});

--- a/tests/Unit/Attributes/StringfieldAttributeTest.php
+++ b/tests/Unit/Attributes/StringfieldAttributeTest.php
@@ -1,42 +1,35 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\StringfieldAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class StringfieldAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(StringfieldAttribute::class);
-        StringfieldAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, StringfieldAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(StringfieldAttribute::class);
+    StringfieldAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        StringfieldAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(StringfieldAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["test", "test"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    StringfieldAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["test", "test"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+    ];
+});

--- a/tests/Unit/Attributes/TimeperiodAttributeTest.php
+++ b/tests/Unit/Attributes/TimeperiodAttributeTest.php
@@ -1,81 +1,64 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\TimeperiodAttribute;
 use App\AttributeValue;
 use App\DataTypes\TimePeriod;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class TimeperiodAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(TimeperiodAttribute::class);
-        TimeperiodAttribute::fromImport($input);
+
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(TimeperiodAttribute::class);
+    TimeperiodAttribute::fromImport($input);
+})->with('truthyProvider');
+
+test('from import return values', function ($input, $expected) {
+    // Convert the TimePeriod object to a json string
+    if($expected != null){
+        $expected = json_encode($expected);
     }
+    expect(TimeperiodAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        // Convert the TimePeriod object to a json string
-        if($expected != null){
-            $expected = json_encode($expected);
-        }
-        $this->assertEquals($expected, TimeperiodAttribute::fromImport($input));
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    TimeperiodAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        TimeperiodAttribute::fromImport($input);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(74);
+    $parseResult = TimeperiodAttribute::parseExport(json_encode($testValue->getValue()));
 
-    /**
-     * Test export of attribute (attribute value id = 74)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(74);
-        $parseResult = TimeperiodAttribute::parseExport(json_encode($testValue->getValue()));
+    expect($parseResult)->toEqual('-200;-100');
+});
 
-        $this->assertEquals('-200;-100', $parseResult);
-    }
+test('parse export on attribute base', function () {
+    $testValue = AttributeValue::find(74);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    /**
-     * Test export of timeperiod attribute (attribute value id = 74) using AttributeBase's serializeExportData method
-     *
-     * @return void
-     */
-    public function testParseExportOnAttributeBase() {
-        $testValue = AttributeValue::find(74);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+    expect($parseResult)->toEqual('-200;-100');
+});
 
-        $this->assertEquals('-200;-100', $parseResult);
-    }
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["-100;200", new TimePeriod(-100, 200)],
+        "string with spaces" => [" -100 ; 200 ", new TimePeriod(-100, 200)],
+    ];
+});
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["-100;200", new TimePeriod(-100, 200)],
-            "string with spaces" => [" -100 ; 200 ", new TimePeriod(-100, 200)],
-        ];
-    }
-
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-            "fails on string without semicolon" => ["-100"],
-            "fails on string with more than one semicolon" => ["-100;200;300"],
-            "fails on string with negative values" => ["-100;-200"],
-            "fails on string with non-numeric values (1)" => ["string;200"],
-            "fails on string with non-numeric values (2)" => ["-100;string"],
-            "failsl if one value is a float (1)" => ["-100.5;200"],
-            "failsl if one value is a float (2)" => ["-100;200.1"],
-        ];
-    }
-}
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+        "fails on string without semicolon" => ["-100"],
+        "fails on string with more than one semicolon" => ["-100;200;300"],
+        "fails on string with negative values" => ["-100;-200"],
+        "fails on string with non-numeric values (1)" => ["string;200"],
+        "fails on string with non-numeric values (2)" => ["-100;string"],
+        "failsl if one value is a float (1)" => ["-100.5;200"],
+        "failsl if one value is a float (2)" => ["-100;200.1"],
+    ];
+});

--- a/tests/Unit/Attributes/UrlAttributeTest.php
+++ b/tests/Unit/Attributes/UrlAttributeTest.php
@@ -1,42 +1,35 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\UrlAttribute;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class UrlAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(UrlAttribute::class);
-        UrlAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, UrlAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(UrlAttribute::class);
+    UrlAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        UrlAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(UrlAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "string" => ["test", "test"],
-        ];
-    }
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    UrlAttribute::fromImport($input);
+})->with('falsyProvider');
 
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "string" => ["test", "test"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+    ];
+});

--- a/tests/Unit/Attributes/UserlistAttributeTest.php
+++ b/tests/Unit/Attributes/UserlistAttributeTest.php
@@ -1,62 +1,50 @@
 <?php
-namespace Tests\Unit\Attributes;
 
 use App\AttributeTypes\AttributeBase;
 use App\AttributeTypes\UserlistAttribute;
 use App\AttributeValue;
 use App\Exceptions\InvalidDataException;
-use Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-// !!!! Currently this test is only testing the fromImport function!!!
-class UserlistAttributeTest extends TestCase {
-    #[DataProvider('truthyProvider')]
-    public function testFromImportTruthy($input) {
-        $this->expectNotToPerformAssertions(UserlistAttribute::class);
-        UserlistAttribute::fromImport($input);
-    }
 
-    #[DataProvider('truthyProvider')]
-    public function testFromImportReturnValues($input, $expected) {
-        $this->assertEquals($expected, UserlistAttribute::fromImport($input));
-    }
+test('from import truthy', function ($input) {
+    $this->expectNotToPerformAssertions(UserlistAttribute::class);
+    UserlistAttribute::fromImport($input);
+})->with('truthyProvider');
 
-    #[DataProvider('falsyProvider')]
-    public function testFromImportFalsy($input) {
-        $this->expectException(InvalidDataException::class);
-        UserlistAttribute::fromImport($input);
-    }
+test('from import return values', function ($input, $expected) {
+    expect(UserlistAttribute::fromImport($input))->toEqual($expected);
+})->with('truthyProvider');
 
-    /**
-     * Test export of attribute (attribute value id = xx)
-     *
-     * @return void
-     */
-    public function testParseExport() {
-        $testValue = AttributeValue::find(76);
-        $parseResult = AttributeBase::serializeExportData($testValue);
+test('from import falsy', function ($input) {
+    $this->expectException(InvalidDataException::class);
+    UserlistAttribute::fromImport($input);
+})->with('falsyProvider');
 
-        $this->assertEquals('admin', $parseResult);
-    }
+test('parse export', function () {
+    $testValue = AttributeValue::find(76);
+    $parseResult = AttributeBase::serializeExportData($testValue);
 
-    public static function truthyProvider() {
-        return [
-            "empty string" => ["", null],
-            "single user" => ["admin", "[1]"],
-            "multiple users" => ["admin;johndoe", "[1,2]"],
-            "multiple users with spaces" => [" admin ; johndoe ", "[1,2]"],
-            "single deleted user" => ["garyguest", "[3]"],
-            "multiple users with single deleted user" => ["admin;garyguest", "[1,3]"],
-        ];
-    }
+    expect($parseResult)->toEqual('admin');
+});
 
-    public static function falsyProvider() {
-        return [
-            "fails on integer" => [1],
-            "fails on float" => [1.1],
-            "fails on boolean" => [true],
-            "fails on incorrect user" => ["unknown"],
-            "fails on any incorrect user" => ["unknown,unknown2"],
-        ];
-    }
-}
+dataset('truthyProvider', function () {
+    return [
+        "empty string" => ["", null],
+        "single user" => ["admin", "[1]"],
+        "multiple users" => ["admin;johndoe", "[1,2]"],
+        "multiple users with spaces" => [" admin ; johndoe ", "[1,2]"],
+        "single deleted user" => ["garyguest", "[3]"],
+        "multiple users with single deleted user" => ["admin;garyguest", "[1,3]"],
+    ];
+});
+
+dataset('falsyProvider', function () {
+    return [
+        "fails on integer" => [1],
+        "fails on float" => [1.1],
+        "fails on boolean" => [true],
+        "fails on incorrect user" => ["unknown"],
+        "fails on any incorrect user" => ["unknown,unknown2"],
+    ];
+});

--- a/tests/Unit/BibliographyTest.php
+++ b/tests/Unit/BibliographyTest.php
@@ -1,75 +1,51 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
 use Illuminate\Http\Request;
 
 use App\Bibliography;
 
-class BibliographyTest extends TestCase
-{
-    /**
-     * Test relations of an bibliography entry (id=1318)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $b = Bibliography::with(['entities'])->find(1318);
 
-        $this->assertEquals(1, $b->entities[0]->id);
-        $this->assertEquals(15, $b->entities[0]->pivot->attribute_id);
-        $this->assertEquals('See Page 10', $b->entities[0]->pivot->description);
+test('relations', function () {
+    $b = Bibliography::with(['entities'])->find(1318);
+
+    expect($b->entities[0]->id)->toEqual(1);
+    expect($b->entities[0]->pivot->attribute_id)->toEqual(15);
+    expect($b->entities[0]->pivot->description)->toEqual('See Page 10');
+});
+
+test('parsing request', function () {
+    $r = new Request();
+    $r->replace([
+        'year' => 1999,
+        'entry_type' => 'book',
+        'author' => 'Book Author',
+        'publisher' => 'Spacialist',
+        'title' => 'Book Title',
+    ]);
+
+    $user = new \stdClass;
+    $user->id = 1;
+
+    $ranges = array_merge([''], range('a', 'z'), range('A', 'Z'));
+    foreach($ranges as $letter) {
+        $b = new Bibliography();
+        $b->title = 'Title';
+        $b->entry_type = 'article';
+        $b->citekey = 'Book Author_Book_bt_1999'.$letter;
+        $b->user_id = 1;
+        $b->save();
     }
 
-    /**
-     * Test
-     *
-     * @return void
-     */
-    public function testParsingRequest()
-    {
-        $r = new Request();
-        $r->replace([
-            'year' => 1999,
-            'entry_type' => 'book',
-            'author' => 'Book Author',
-            'publisher' => 'Spacialist',
-            'title' => 'Book Title',
-        ]);
+    $bib = new Bibliography();
+    $bib->fieldsFromRequest($r, $user);
 
-        $user = new \stdClass;
-        $user->id = 1;
+    $newBib = Bibliography::orderBy('id', 'desc')->first();
+    expect($newBib->id)->toEqual($bib->id);
+    expect($newBib->title)->toEqual('Book Title');
+    expect($newBib->citekey)->toEqual('Book Author_Book_bt_1999aa');
+});
 
-        $ranges = array_merge([''], range('a', 'z'), range('A', 'Z'));
-        foreach($ranges as $letter) {
-            $b = new Bibliography();
-            $b->title = 'Title';
-            $b->entry_type = 'article';
-            $b->citekey = 'Book Author_Book_bt_1999'.$letter;
-            $b->user_id = 1;
-            $b->save();
-        }
-
-        $bib = new Bibliography();
-        $bib->fieldsFromRequest($r, $user);
-
-        $newBib = Bibliography::orderBy('id', 'desc')->first();
-        $this->assertEquals($bib->id, $newBib->id);
-        $this->assertEquals('Book Title', $newBib->title);
-        $this->assertEquals('Book Author_Book_bt_1999aa', $newBib->citekey);
-    }
-
-    /**
-     * Test get last editor of first bibliography entry
-     *
-     * @return void
-     */
-    public function testGetBibliographyEntryLasteditor()
-    {
-        $entry = Bibliography::first();
-        $this->assertEquals(1, $entry->user->id);
-    }
-}
+test('get bibliography entry lasteditor', function () {
+    $entry = Bibliography::first();
+    expect($entry->user->id)->toEqual(1);
+});

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -1,9 +1,7 @@
 <?php
 
-uses(\Tests\TransactionedTestCase::class);
 use App\Role;
 use App\User;
-
 
 test('spacialist create user and role command', function () {
     $this->artisan('app:create --role --user')

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -1,183 +1,135 @@
 <?php
 
-namespace Tests\Unit;
-use Tests\TransactionedTestCase;
-
+uses(\Tests\TransactionedTestCase::class);
 use App\Role;
 use App\User;
 
-class CommandTest extends TransactionedTestCase {
-    /**
-     * Test creating role and user
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserAndRoleCommand() {
-        $this->artisan('app:create --role --user')
-            ->expectsOutput('Can not create user and role simultaneously!')
-            ->assertExitCode(1);
-    }
 
-    /**
-     * Test adding a new user
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserCommand() {
-        $confirmStr = "Is this correct?\n\tName: New User\n\tNickname: nuser\n\tEmail: user@example.tld\n";
+test('spacialist create user and role command', function () {
+    $this->artisan('app:create --role --user')
+        ->expectsOutput('Can not create user and role simultaneously!')
+        ->assertExitCode(1);
+});
 
-        $this->artisan('app:create')
-            ->expectsQuestion('Please provide the new user name', 'New User')
-            ->expectsQuestion('Please enter your nick name', 'nuser')
-            ->expectsQuestion('Please enter your email address', 'user@example.tld')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsQuestion($confirmStr, true)
-            ->expectsOutput('User New User created!')
-            ->assertExitCode(0);
+test('spacialist create user command', function () {
+    $confirmStr = "Is this correct?\n\tName: New User\n\tNickname: nuser\n\tEmail: user@example.tld\n";
 
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'New User');
-        $this->assertEquals($user->nickname, 'nuser');
-        $this->assertEquals($user->email, 'user@example.tld');
-    }
+    $this->artisan('app:create')
+        ->expectsQuestion('Please provide the new user name', 'New User')
+        ->expectsQuestion('Please enter your nick name', 'nuser')
+        ->expectsQuestion('Please enter your email address', 'user@example.tld')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsQuestion($confirmStr, true)
+        ->expectsOutput('User New User created!')
+        ->assertExitCode(0);
 
-    /**
-     * Test adding a new user with --flag and name set
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserWithFlagCommand() {
-        $confirmStr = "Is this correct?\n\tName: New User #2\n\tNickname: nuser2\n\tEmail: user2@example.tld\n";
+    $user = User::latest()->first();
+    expect('New User')->toEqual($user->name);
+    expect('nuser')->toEqual($user->nickname);
+    expect('user@example.tld')->toEqual($user->email);
+});
 
-        $this->artisan('app:create --user "New User #2"')
-            ->expectsQuestion('Please enter your nick name', 'nuser2')
-            ->expectsQuestion('Please enter your email address', 'user2@example.tld')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsQuestion($confirmStr, true)
-            ->expectsOutput('User New User #2 created!')
-            ->assertExitCode(0);
+test('spacialist create user with flag command', function () {
+    $confirmStr = "Is this correct?\n\tName: New User #2\n\tNickname: nuser2\n\tEmail: user2@example.tld\n";
 
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'New User #2');
-        $this->assertEquals($user->nickname, 'nuser2');
-        $this->assertEquals($user->email, 'user2@example.tld');
-    }
+    $this->artisan('app:create --user "New User #2"')
+        ->expectsQuestion('Please enter your nick name', 'nuser2')
+        ->expectsQuestion('Please enter your email address', 'user2@example.tld')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsQuestion($confirmStr, true)
+        ->expectsOutput('User New User #2 created!')
+        ->assertExitCode(0);
 
-    /**
-     * Test adding a new user with taken email address
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserWithExistingMailCommand() {
-        $this->artisan('app:create --user "New User"')
-            ->expectsQuestion('Please enter your nick name', 'nuser')
-            ->expectsQuestion('Please enter your email address', 'admin@localhost')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsOutput('The email has already been taken.')
-            ->assertExitCode(1);
+    $user = User::latest()->first();
+    expect('New User #2')->toEqual($user->name);
+    expect('nuser2')->toEqual($user->nickname);
+    expect('user2@example.tld')->toEqual($user->email);
+});
 
-        $user = User::firstWhere("email", "=", "admin@localhost");
-        $this->assertEquals($user->name, 'Admin');
+test('spacialist create user with existing mail command', function () {
+    $this->artisan('app:create --user "New User"')
+        ->expectsQuestion('Please enter your nick name', 'nuser')
+        ->expectsQuestion('Please enter your email address', 'admin@localhost')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsOutput('The email has already been taken.')
+        ->assertExitCode(1);
 
-        $latest = User::withTrashed()->latest()->first();
-        $this->assertEquals($latest->name, 'Gary Guest');
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'John Doe');
-    }
+    $user = User::firstWhere("email", "=", "admin@localhost");
+    expect('Admin')->toEqual($user->name);
 
-    /**
-     * Test adding a new user with a wrong email address
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserWithWrongMailCommand() {
-        $this->artisan('app:create --user "New User"')
-            ->expectsQuestion('Please enter your nick name', 'nuser')
-            ->expectsQuestion('Please enter your email address', 'admin(at)localhost')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsOutput('The email must be a valid email address.')
-            ->assertExitCode(1);
+    $latest = User::withTrashed()->latest()->first();
+    expect('Gary Guest')->toEqual($latest->name);
+    $user = User::latest()->first();
+    expect('John Doe')->toEqual($user->name);
+});
 
-        $user = User::withTrashed()->latest()->first();
-        $this->assertEquals($user->name, 'Gary Guest');
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'John Doe');
-    }
+test('spacialist create user with wrong mail command', function () {
+    $this->artisan('app:create --user "New User"')
+        ->expectsQuestion('Please enter your nick name', 'nuser')
+        ->expectsQuestion('Please enter your email address', 'admin(at)localhost')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsOutput('The email must be a valid email address.')
+        ->assertExitCode(1);
 
-    /**
-     * Test adding a new user with taken email address
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserWithExistingNickCommand() {
-        $this->artisan('app:create --user "New User"')
-            ->expectsQuestion('Please enter your nick name', 'admin')
-            ->expectsQuestion('Please enter your email address', 'admin@localhost')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsOutput('The nickname has already been taken.')
-            ->assertExitCode(1);
+    $user = User::withTrashed()->latest()->first();
+    expect('Gary Guest')->toEqual($user->name);
+    $user = User::latest()->first();
+    expect('John Doe')->toEqual($user->name);
+});
 
-        $user = User::withTrashed()->latest()->first();
-        $this->assertEquals($user->name, 'Gary Guest');
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'John Doe');
-    }
+test('spacialist create user with existing nick command', function () {
+    $this->artisan('app:create --user "New User"')
+        ->expectsQuestion('Please enter your nick name', 'admin')
+        ->expectsQuestion('Please enter your email address', 'admin@localhost')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsOutput('The nickname has already been taken.')
+        ->assertExitCode(1);
 
-    /**
-     * Test adding a new user with a wrong email address
-     *
-     * @return void
-     */
-    public function testSpacialistCreateUserWithWrongNickCommand() {
-        $this->artisan('app:create --user "New User"')
-            ->expectsQuestion('Please enter your nick name', 'nickname with spaces')
-            ->expectsQuestion('Please enter your email address', 'admin@localhost')
-            ->expectsQuestion('Please enter your password', 'newpw')
-            ->expectsOutput('The nickname may only contain letters, numbers, and dashes.')
-            ->assertExitCode(1);
+    $user = User::withTrashed()->latest()->first();
+    expect('Gary Guest')->toEqual($user->name);
+    $user = User::latest()->first();
+    expect('John Doe')->toEqual($user->name);
+});
 
-        $user = User::withTrashed()->latest()->first();
-        $this->assertEquals($user->name, 'Gary Guest');
-        $user = User::latest()->first();
-        $this->assertEquals($user->name, 'John Doe');
-    }
+test('spacialist create user with wrong nick command', function () {
+    $this->artisan('app:create --user "New User"')
+        ->expectsQuestion('Please enter your nick name', 'nickname with spaces')
+        ->expectsQuestion('Please enter your email address', 'admin@localhost')
+        ->expectsQuestion('Please enter your password', 'newpw')
+        ->expectsOutput('The nickname may only contain letters, numbers, and dashes.')
+        ->assertExitCode(1);
 
-    /**
-     * Test adding a new role
-     *
-     * @return void
-     */
-    public function testSpacialistCreateRoleCommand() {
-        $confirmStr = "Is this correct?\n\tName: new_role\n\tDisplayName: New Role\n\tDescription: Description for new role\n";
+    $user = User::withTrashed()->latest()->first();
+    expect('Gary Guest')->toEqual($user->name);
+    $user = User::latest()->first();
+    expect('John Doe')->toEqual($user->name);
+});
 
-        $this->artisan('app:create --role')
-            ->expectsQuestion('Please provide the new role name', 'new_role')
-            ->expectsQuestion('Please provide the desired display name', 'New Role')
-            ->expectsQuestion('Please provide the desired description', 'Description for new role')
-            ->expectsQuestion($confirmStr, true)
-            ->expectsOutput('Role new_role created!')
-            ->assertExitCode(0);
+test('spacialist create role command', function () {
+    $confirmStr = "Is this correct?\n\tName: new_role\n\tDisplayName: New Role\n\tDescription: Description for new role\n";
 
-        $role = Role::latest()->first();
-        $this->assertEquals($role->name, 'new_role');
-        $this->assertEquals($role->display_name, 'New Role');
-        $this->assertEquals($role->description, 'Description for new role');
-    }
+    $this->artisan('app:create --role')
+        ->expectsQuestion('Please provide the new role name', 'new_role')
+        ->expectsQuestion('Please provide the desired display name', 'New Role')
+        ->expectsQuestion('Please provide the desired description', 'Description for new role')
+        ->expectsQuestion($confirmStr, true)
+        ->expectsOutput('Role new_role created!')
+        ->assertExitCode(0);
 
-    /**
-     * Test adding a new role
-     *
-     * @return void
-     */
-    public function testSpacialistCreateRoleWithExistingNameCommand() {
-        $this->artisan('app:create --role admin')
-            ->expectsQuestion('Please provide the new role name', 'admin')
-            ->expectsQuestion('Please provide the desired display name', 'Admin')
-            ->expectsQuestion('Please provide the desired description', 'The new admin')
-            ->expectsOutput('The name has already been taken.')
-            ->assertExitCode(1);
+    $role = Role::latest()->first();
+    expect('new_role')->toEqual($role->name);
+    expect('New Role')->toEqual($role->display_name);
+    expect('Description for new role')->toEqual($role->description);
+});
 
-        $role = Role::latest()->orderBy('id', 'desc')->first();
-        $this->assertEquals($role->name, 'guest');
-    }
-}
+test('spacialist create role with existing name command', function () {
+    $this->artisan('app:create --role admin')
+        ->expectsQuestion('Please provide the new role name', 'admin')
+        ->expectsQuestion('Please provide the desired display name', 'Admin')
+        ->expectsQuestion('Please provide the desired description', 'The new admin')
+        ->expectsOutput('The name has already been taken.')
+        ->assertExitCode(1);
+
+    $role = Role::latest()->orderBy('id', 'desc')->first();
+    expect('guest')->toEqual($role->name);
+});

--- a/tests/Unit/DirectoryTest.php
+++ b/tests/Unit/DirectoryTest.php
@@ -1,149 +1,131 @@
 <?php
 
-namespace Tests\Unit;
-
 use Carbon\Carbon;
-use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use App\File\Directory;
 
-class DirectoryTest extends TestCase
+
+beforeEach(function () {
+    Storage::persistentFake('test');
+    Storage::disk('test')->makeDirectory('test');
+    Storage::disk('test')->makeDirectory('test/dir1');
+    Storage::disk('test')->put('test/dir1/file_1.txt', 'Test content #1');
+    Storage::disk('test')->makeDirectory('test/dir2');
+    Storage::disk('test')->put('test/dir2/file_2.txt', 'Test content #2');
+    Storage::disk('test')->makeDirectory('external');
+    Storage::disk('test')->put('external/file.txt', 'External file content #1');
+    Storage::disk('test')->makeDirectory('external/subdir');
+    Storage::disk('test')->put('external/subdir/file.txt', 'External file content #2');
+
+    Storage::disk('test')->makeDirectory('application');
+    Storage::disk('test')->put('application/file.txt', 'Application file content');
+});
+
+/**
+ * Capture the file stream from a response
+ *
+ * @param Illuminate\Http\JsonResponse $response The response object
+ * @return string The content of the file stream
+ */
+function captureFileStream($response)
 {
-
-    public function setUp(): void
-    {
-        parent::setUp();
-        Storage::persistentFake('test');
-        Storage::disk('test')->makeDirectory('test');
-        Storage::disk('test')->makeDirectory('test/dir1');
-        Storage::disk('test')->put('test/dir1/file_1.txt', 'Test content #1');
-        Storage::disk('test')->makeDirectory('test/dir2');
-        Storage::disk('test')->put('test/dir2/file_2.txt', 'Test content #2');
-        Storage::disk('test')->makeDirectory('external');
-        Storage::disk('test')->put('external/file.txt', 'External file content #1');
-        Storage::disk('test')->makeDirectory('external/subdir');
-        Storage::disk('test')->put('external/subdir/file.txt', 'External file content #2');
-
-        Storage::disk('test')->makeDirectory('application');
-        Storage::disk('test')->put('application/file.txt', 'Application file content');
-    }
-
-
-    /**
-     * Capture the file stream from a response
-     *
-     * @param Illuminate\Http\JsonResponse $response The response object
-     * @return string The content of the file stream
-     */
-    private function captureFileStream($response){
-        ob_start();
-        $response->sendContent();
-        return ob_get_clean();
-    }
-
-    private function assertFileContents($response, $expectedContent)
-    {
-        $content = $this->captureFileStream($response);
-        $this->assertEquals($expectedContent, $content);
-    }
-
-    /**
-     * Test sp_column_names helper
-     *
-     * @return void
-     */
-    public function testDirectoryConstruction()
-    {
-        $directory = new Directory('test', 'test');
-        $this->assertEquals('test', $directory->getDirectory());
-        $this->assertEquals('test', $directory->getDisk());
-    }
-
-    public function testDefaulDisk()
-    {
-        $directory = new Directory('test');
-        $this->assertEquals('local', $directory->getDisk());
-    }
-
-    public function testContains()
-    {
-        $directory = new Directory('test', 'test');
-        $this->assertTrue($directory->contains('test/dir1/file_1.txt'));
-        $this->assertFalse($directory->contains('test/file.txt'));
-    }
-
-    public function testDelete()
-    {
-        $directory = new Directory('test', 'test');
-
-        // Delete a file inside the directory
-        $this->assertTrue($directory->delete('test/dir1/file_1.txt'));
-        $this->assertFalse(Storage::disk('test')->exists('test/dir1/file_1.txt'));
-
-        // Try to delete a file outside the directory
-        $this->assertFalse($directory->delete('external/file.txt'));
-        $this->assertTrue(Storage::disk('test')->exists('external/file.txt'));
-
-        // Try to delete external file in subdirectory
-        $this->assertFalse($directory->delete('external/subdir/file.txt'));
-        $this->assertTrue(Storage::disk('test')->exists('external/subdir/file.txt'));
-    }
-
-    public function testDownload()
-    {
-        $directory = new Directory('test', 'test');
-
-        // Download a file inside the directory
-        $response = $directory->download('test/dir1/file_1.txt');
-        $this->assertEquals($response->getStatusCode(), 200);
-        $this->assertFileContents($response, 'Test content #1');
-
-        // Try to download a file outside the directory
-        $response = $directory->download('external/file.txt');
-        $this->assertStatus($response, 404);
-
-        // Try to download a file in subdirectory
-        $response = $directory->download('external/subdir/file.txt');
-        $this->assertStatus($response, 404);
-    }
-
-    public function testDownloadRelative(){
-        $directory = new Directory('test', 'test');
-
-        // Download a file inside the directory with relative path
-        $response = $directory->downloadRelative('dir1/file_1.txt');
-        $this->assertEquals($response->getStatusCode(), 200);
-        $this->assertFileContents($response, 'Test content #1');
-
-        // Try to download a file outside the directory with relative path
-        $response = $directory->downloadRelative('external/file.txt');
-        $this->assertStatus($response, 404);
-
-        // Try to download a file in subdirectory with relative path
-        $response = $directory->downloadRelative('external/subdir/file.txt');
-        $this->assertStatus($response, 404);
-    }
-
-    public function testStore(){
-        $directory = new Directory('test', 'test');
-
-        $uniqueFile = Carbon::now()->timestamp . '_tmp_test_file.txt';
-
-        // Store a file inside the directory
-        $filePath = $directory->store('stored_test_file.txt', UploadedFile::fake()->create($uniqueFile, 100));
-        $this->assertTrue(Storage::disk('test')->exists($filePath));
-        info("Stored file at: " . $filePath);
-    }
-
-    public function testPut(){
-        $directory = new Directory('test', 'test');
-
-        $path = Storage::disk('test')->path("application/file.txt");
-        $filehandle = fopen($path, 'r');
-
-        // Store a file inside the directory using put
-        $filePath = $directory->store('put_test_file.txt', $filehandle);
-        $this->assertTrue(Storage::disk('test')->exists($filePath));
-    }
+    ob_start();
+    $response->sendContent();
+    return ob_get_clean();
 }
+
+function assertFileContents($response, $expectedContent)
+{
+    $content = captureFileStream($response);
+    expect($content)->toEqual($expectedContent);
+}
+
+test('directory construction', function () {
+    $directory = new Directory('test', 'test');
+    expect($directory->getDirectory())->toEqual('test');
+    expect($directory->getDisk())->toEqual('test');
+});
+
+test('defaul disk', function () {
+    $directory = new Directory('test');
+    expect($directory->getDisk())->toEqual('local');
+});
+
+test('contains', function () {
+    $directory = new Directory('test', 'test');
+    expect($directory->contains('test/dir1/file_1.txt'))->toBeTrue();
+    expect($directory->contains('test/file.txt'))->toBeFalse();
+});
+
+test('delete', function () {
+    $directory = new Directory('test', 'test');
+
+    // Delete a file inside the directory
+    expect($directory->delete('test/dir1/file_1.txt'))->toBeTrue();
+    expect(Storage::disk('test')->exists('test/dir1/file_1.txt'))->toBeFalse();
+
+    // Try to delete a file outside the directory
+    expect($directory->delete('external/file.txt'))->toBeFalse();
+    expect(Storage::disk('test')->exists('external/file.txt'))->toBeTrue();
+
+    // Try to delete external file in subdirectory
+    expect($directory->delete('external/subdir/file.txt'))->toBeFalse();
+    expect(Storage::disk('test')->exists('external/subdir/file.txt'))->toBeTrue();
+});
+
+test('download', function () {
+    $directory = new Directory('test', 'test');
+
+    // Download a file inside the directory
+    $response = $directory->download('test/dir1/file_1.txt');
+    expect(200)->toEqual($response->getStatusCode());
+    assertFileContents($response, 'Test content #1');
+
+    // Try to download a file outside the directory
+    $response = $directory->download('external/file.txt');
+    $this->assertStatus($response, 404);
+
+    // Try to download a file in subdirectory
+    $response = $directory->download('external/subdir/file.txt');
+    $this->assertStatus($response, 404);
+});
+
+test('download relative', function () {
+    $directory = new Directory('test', 'test');
+
+    // Download a file inside the directory with relative path
+    $response = $directory->downloadRelative('dir1/file_1.txt');
+    expect(200)->toEqual($response->getStatusCode());
+    assertFileContents($response, 'Test content #1');
+
+    // Try to download a file outside the directory with relative path
+    $response = $directory->downloadRelative('external/file.txt');
+    $this->assertStatus($response, 404);
+
+    // Try to download a file in subdirectory with relative path
+    $response = $directory->downloadRelative('external/subdir/file.txt');
+    $this->assertStatus($response, 404);
+});
+
+test('store', function () {
+    $directory = new Directory('test', 'test');
+
+    $uniqueFile = Carbon::now()->timestamp . '_tmp_test_file.txt';
+
+    // Store a file inside the directory
+    $filePath = $directory->store('stored_test_file.txt', UploadedFile::fake()->create($uniqueFile, 100));
+    expect(Storage::disk('test')->exists($filePath))->toBeTrue();
+    info("Stored file at: " . $filePath);
+});
+
+test('put', function () {
+    $directory = new Directory('test', 'test');
+
+    $path = Storage::disk('test')->path("application/file.txt");
+    $filehandle = fopen($path, 'r');
+
+    // Store a file inside the directory using put
+    $filePath = $directory->store('put_test_file.txt', $filehandle);
+    expect(Storage::disk('test')->exists($filePath))->toBeTrue();
+});

--- a/tests/Unit/EntityTest.php
+++ b/tests/Unit/EntityTest.php
@@ -1,127 +1,108 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\Entity;
 
-class EntityTest extends TestCase
-{
-    /**
-     * Test getting all children of an entity (id=2)
-     *
-     * @return void
-     */
-    public function testGetAllChildren()
-    {
-        $entity = Entity::find(2);
-        $childrenArray = $entity->getAllChildren();
-        $this->assertEquals(4, count($childrenArray));
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            [
-                '_name' => 'Befund 1',
-                '_parent' => 'Site A',
-                '_entity_type' => 'Feature',
-                '_entity_type_id' => 4,
-            ],
-            [
-                '_name' => 'Inv. 1234',
-                '_parent' => 'Site A\\\\Befund 1',
-                '_entity_type' => 'Pottery',
-                '_entity_type_id' => 5,
-            ],
-            [
-                '_name' => 'Inv. 124',
-                '_parent' => 'Site A\\\\Befund 1',
-                '_entity_type' => 'Pottery',
-                '_entity_type_id' => 5,
-            ],
-            [
-                '_name' => 'Inv. 31',
-                '_parent' => 'Site A\\\\Befund 1',
-                '_entity_type' => 'Stone',
-                '_entity_type_id' => 6,
-                12 => 3.5,
-            ],
-        ], $childrenArray,
+
+test('get all children', function () {
+    $entity = Entity::find(2);
+    $childrenArray = $entity->getAllChildren();
+    expect(count($childrenArray))->toEqual(4);
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
         [
-            '_name',
-            '_parent',
-            '_entity_type',
-            '_entity_type_id',
-            12,
-        ]);
-    }
+            '_name' => 'Befund 1',
+            '_parent' => 'Site A',
+            '_entity_type' => 'Feature',
+            '_entity_type_id' => 4,
+        ],
+        [
+            '_name' => 'Inv. 1234',
+            '_parent' => 'Site A\\\\Befund 1',
+            '_entity_type' => 'Pottery',
+            '_entity_type_id' => 5,
+        ],
+        [
+            '_name' => 'Inv. 124',
+            '_parent' => 'Site A\\\\Befund 1',
+            '_entity_type' => 'Pottery',
+            '_entity_type_id' => 5,
+        ],
+        [
+            '_name' => 'Inv. 31',
+            '_parent' => 'Site A\\\\Befund 1',
+            '_entity_type' => 'Stone',
+            '_entity_type_id' => 6,
+            12 => 3.5,
+        ],
+    ], $childrenArray,
+    [
+        '_name',
+        '_parent',
+        '_entity_type',
+        '_entity_type_id',
+        12,
+    ]);
+});
 
-    /**
-     * Test relations of an entity (id=3 and id=1)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $entity = Entity::with(['child_entities', 'entity_type', 'root_entity', 'bibliographies', 'attributes'])->find(3);
+test('relations', function () {
+    $entity = Entity::with(['child_entities', 'entity_type', 'root_entity', 'bibliographies', 'attributes'])->find(3);
 
-        $this->assertEquals(0, $entity->child_entities->count());
-        $this->assertEquals(5, $entity->entity_type->id);
-        $this->assertEquals($entity->entity_type_id, $entity->entity_type->id);
-        $this->assertEquals(2, $entity->root_entity->id);
-        $this->assertEquals(0, $entity->bibliographies->count());
-        $this->assertEquals(7, $entity->attributes->count());
-        $this->assertEquals(3, count($entity->parentIds));
-        $this->assertEquals(3, count($entity->parentNames));
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            [
-                'id' => 2,
-                'pivot' => [
-                    'int_val' => 35,
-                ],
+    expect($entity->child_entities->count())->toEqual(0);
+    expect($entity->entity_type->id)->toEqual(5);
+    expect($entity->entity_type->id)->toEqual($entity->entity_type_id);
+    expect($entity->root_entity->id)->toEqual(2);
+    expect($entity->bibliographies->count())->toEqual(0);
+    expect($entity->attributes->count())->toEqual(7);
+    expect(count($entity->parentIds))->toEqual(3);
+    expect(count($entity->parentNames))->toEqual(3);
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+        [
+            'id' => 2,
+            'pivot' => [
+                'int_val' => 35,
             ],
-            [
-                'id' => 3,
-                'pivot' => [
-                    'json_val' => '[{"id": 18, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rot#20171220100515"}, {"id": 20, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/grun#20171220100524"}]',
-                ],
+        ],
+        [
+            'id' => 3,
+            'pivot' => [
+                'json_val' => '[{"id": 18, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rot#20171220100515"}, {"id": 20, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/grun#20171220100524"}]',
             ],
-            [
-                'id' => 4,
-                'pivot' => [
-                    'int_val' => 1,
-                ],
+        ],
+        [
+            'id' => 4,
+            'pivot' => [
+                'int_val' => 1,
             ],
-            [
-                'id' => 5,
-                'pivot' => [
-                    'json_val' => '[{"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}, {"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
-                ],
+        ],
+        [
+            'id' => 5,
+            'pivot' => [
+                'json_val' => '[{"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 40, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/riefung#20171220105513"}}, {"6": {"id": 35, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/rand#20171220105447"}, "7": {"id": 41, "concept_url": "https://spacialist.escience.uni-tuebingen.de/<user-project>/kammeindruck#20171220105520"}}]',
             ],
-            [
-                'id' => 9,
-                'pivot' => [
-                    'json_val' => '{"B": 4, "H": 5, "unit": "cm"}',
-                ],
+        ],
+        [
+            'id' => 9,
+            'pivot' => [
+                'json_val' => '{"B": 4, "H": 5, "unit": "cm"}',
             ],
-            [
-                'id' => 11,
-                'pivot' => [
-                    'int_val' => 7,
-                ],
+        ],
+        [
+            'id' => 11,
+            'pivot' => [
+                'int_val' => 7,
             ],
-            [
-                'id' => 12,
-                'pivot' => [
-                    'dbl_val' => '12.5',
-                ],
+        ],
+        [
+            'id' => 12,
+            'pivot' => [
+                'dbl_val' => '12.5',
             ],
-        ], $entity->attributes->toArray(),
-        ['id', 'pivot']);
-        $this->assertEquals([
-            3, 2, 1
-        ], $entity->parentIds);
-        $this->assertEquals([
-            'Inv. 1234', 'Befund 1', 'Site A'
-        ], $entity->parentNames);
-    }
-}
+        ],
+    ], $entity->attributes->toArray(),
+    ['id', 'pivot']);
+    expect($entity->parentIds)->toEqual([
+        3, 2, 1
+    ]);
+    expect($entity->parentNames)->toEqual([
+        'Inv. 1234', 'Befund 1', 'Site A'
+    ]);
+});

--- a/tests/Unit/EntityTypeTest.php
+++ b/tests/Unit/EntityTypeTest.php
@@ -1,37 +1,24 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\EntityType;
 
-class EntityTypeTest extends TestCase
-{
-    /**
-     * Test relations of an entity type (id=4)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $type = EntityType::with(['entities', 'attributes', 'sub_entity_types', 'thesaurus_concept'])->find(4);
 
-        $this->assertEquals(1, $type->entities->count());
-        $this->assertEquals(2, $type->entities[0]->id);
-        $this->assertEquals(6, $type->attributes->count());
-        $this->assertEquals(14, $type->attributes[0]->id);
-        $this->assertEquals(1, $type->attributes[0]->pivot->position);
-        $this->assertEquals(16, $type->attributes[1]->id);
-        $this->assertEquals(2, $type->attributes[1]->pivot->position);
-        $this->assertEquals(17, $type->attributes[2]->id);
-        $this->assertEquals(3, $type->attributes[2]->pivot->position);
-        $this->assertEquals(10, $type->attributes[3]->id);
-        $this->assertEquals(4, $type->attributes[3]->pivot->position);
-        $this->assertEquals(13, $type->attributes[4]->id);
-        $this->assertEquals(5, $type->attributes[4]->pivot->position);
-        $this->assertEquals(0, $type->sub_entity_types->count());
-        $this->assertEquals(2, $type->thesaurus_concept->id);
-    }
-}
+test('relations', function () {
+    $type = EntityType::with(['entities', 'attributes', 'sub_entity_types', 'thesaurus_concept'])->find(4);
+
+    expect($type->entities->count())->toEqual(1);
+    expect($type->entities[0]->id)->toEqual(2);
+    expect($type->attributes->count())->toEqual(6);
+    expect($type->attributes[0]->id)->toEqual(14);
+    expect($type->attributes[0]->pivot->position)->toEqual(1);
+    expect($type->attributes[1]->id)->toEqual(16);
+    expect($type->attributes[1]->pivot->position)->toEqual(2);
+    expect($type->attributes[2]->id)->toEqual(17);
+    expect($type->attributes[2]->pivot->position)->toEqual(3);
+    expect($type->attributes[3]->id)->toEqual(10);
+    expect($type->attributes[3]->pivot->position)->toEqual(4);
+    expect($type->attributes[4]->id)->toEqual(13);
+    expect($type->attributes[4]->pivot->position)->toEqual(5);
+    expect($type->sub_entity_types->count())->toEqual(0);
+    expect($type->thesaurus_concept->id)->toEqual(2);
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,5 @@
 <?php
 
-test('example', function () {
+test('that true is true', function () {
     expect(true)->toBeTrue();
 });

--- a/tests/Unit/FileHelperTest.php
+++ b/tests/Unit/FileHelperTest.php
@@ -1,40 +1,22 @@
 <?php
 
-namespace Tests\Unit;
-
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
-
-
 use App\File;
 
-class FileHelperTest extends TestCase
-{
-    /**
-     * Test method to get unique temporary directory name
-     *
-     * @return void
-     */
-    public function testCreateUniqueDirectory()
-    {
-        Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
-        $tmpPath = File::getUniqueTemporaryDirectoryName();
-        $this->assertEquals('temp_20250101123000', $tmpPath);
-    }
-    /**
-     * Test method to get unique temporary directory name with name collision
-     *
-     * @return void
-     */
-    public function testCreateUniqueDirectoryWithExistingName()
-    {
-        Storage::fake('private');
-        Storage::disk('private')->makeDirectory('temp_20250101123000');
-        Storage::disk('private')->assertExists('temp_20250101123000');
-        Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
-        $tmpPath = File::getUniqueTemporaryDirectoryName();
-        $this->assertEquals('temp_20250101123000_1', $tmpPath);
-        Storage::disk('private')->assertMissing('temp_20250101123000_1');
-    }
-}
+
+test('create unique directory', function () {
+    Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
+    $tmpPath = File::getUniqueTemporaryDirectoryName();
+    expect($tmpPath)->toEqual('temp_20250101123000');
+});
+
+test('create unique directory with existing name', function () {
+    Storage::fake('private');
+    Storage::disk('private')->makeDirectory('temp_20250101123000');
+    Storage::disk('private')->assertExists('temp_20250101123000');
+    Carbon::setTestNow(Carbon::create(2025, 1, 1, 12, 30, 0));
+    $tmpPath = File::getUniqueTemporaryDirectoryName();
+    expect($tmpPath)->toEqual('temp_20250101123000_1');
+    Storage::disk('private')->assertMissing('temp_20250101123000_1');
+});

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -1,81 +1,71 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\File;
 use App\EntityFile;
 
-// TODO Move to File Plugin
-class FileTest extends TestCase
-{
-    public function testExample()
-    {
-        $this->assertTrue(true);
-    }
-    // /**
-    //  * Test getting subfiles of an entity.
-    //  *
-    //  * @return void
-    //  */
-    // public function testGetSubfilesFunction()
-    // {
-    //     // Test text sub-files for entity (id=1)
-    //     $files = File::getSubFiles(1, 'text');
-    //     $this->assertEquals(1, $files->count());
-    //     $this->assertEquals(3, $files[0]->id);
-    //     $this->assertEquals('text1.txt', $files[0]->name);
 
-    //     // Test text sub-files for entity (id=2)
-    //     $files = File::getSubFiles(2, 'text');
-    //     $this->assertEquals(1, $files->count());
-    //     $this->assertEquals(2, $files[0]->id);
-    //     $this->assertEquals('text2.txt', $files[0]->name);
-    //     // Test image sub-files for entity (id=2)
-    //     $files = File::getSubFiles(2, 'image');
-    //     $this->assertEquals(1, $files->count());
-    //     $this->assertEquals(4, $files[0]->id);
-    //     $this->assertEquals('spacialist_screenshot.png', $files[0]->name);
-    //     // Test archive sub-files for entity (id=2)
-    //     $files = File::getSubFiles(2, 'archive');
-    //     $this->assertEquals(1, $files->count());
-    //     $this->assertEquals(6, $files[0]->id);
-    //     $this->assertEquals('test_archive.zip', $files[0]->name);
-    //     // Test empty sub-file categories for entity (id=2)
-    //     $files = File::getSubFiles(2, 'audio');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'video');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'pdf');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'xml');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'html');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, '3d');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'dicom');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'document');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'spreadsheet');
-    //     $this->assertEquals(0, $files->count());
-    //     $files = File::getSubFiles(2, 'presentation');
-    //     $this->assertEquals(0, $files->count());
-    // }
+test('example', function () {
+    expect(true)->toBeTrue();
+});
 
-    // /**
-    //  * Test get last editor of first file
-    //  *
-    //  * @return void
-    //  */
-    // public function testGetReferenceEntryLasteditor()
-    // {
-    //     $file = File::first();
-    //     $this->assertEquals(1, $file->user->id);
-    //     $link = EntityFile::first();
-    //     $this->assertEquals(1, $link->user->id);
-    // }
-}
+// /**
+//  * Test getting subfiles of an entity.
+//  *
+//  * @return void
+//  */
+// public function testGetSubfilesFunction()
+// {
+//     // Test text sub-files for entity (id=1)
+//     $files = File::getSubFiles(1, 'text');
+//     $this->assertEquals(1, $files->count());
+//     $this->assertEquals(3, $files[0]->id);
+//     $this->assertEquals('text1.txt', $files[0]->name);
+//     // Test text sub-files for entity (id=2)
+//     $files = File::getSubFiles(2, 'text');
+//     $this->assertEquals(1, $files->count());
+//     $this->assertEquals(2, $files[0]->id);
+//     $this->assertEquals('text2.txt', $files[0]->name);
+//     // Test image sub-files for entity (id=2)
+//     $files = File::getSubFiles(2, 'image');
+//     $this->assertEquals(1, $files->count());
+//     $this->assertEquals(4, $files[0]->id);
+//     $this->assertEquals('spacialist_screenshot.png', $files[0]->name);
+//     // Test archive sub-files for entity (id=2)
+//     $files = File::getSubFiles(2, 'archive');
+//     $this->assertEquals(1, $files->count());
+//     $this->assertEquals(6, $files[0]->id);
+//     $this->assertEquals('test_archive.zip', $files[0]->name);
+//     // Test empty sub-file categories for entity (id=2)
+//     $files = File::getSubFiles(2, 'audio');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'video');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'pdf');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'xml');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'html');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, '3d');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'dicom');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'document');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'spreadsheet');
+//     $this->assertEquals(0, $files->count());
+//     $files = File::getSubFiles(2, 'presentation');
+//     $this->assertEquals(0, $files->count());
+// }
+// /**
+//  * Test get last editor of first file
+//  *
+//  * @return void
+//  */
+// public function testGetReferenceEntryLasteditor()
+// {
+//     $file = File::first();
+//     $this->assertEquals(1, $file->user->id);
+//     $link = EntityFile::first();
+//     $this->assertEquals(1, $link->user->id);
+// }

--- a/tests/Unit/GeodataTest.php
+++ b/tests/Unit/GeodataTest.php
@@ -1,57 +1,35 @@
 <?php
 
-namespace Tests\Unit;
-
 use App\Geodata;
 use Clickbar\Magellan\Data\Geometries\Dimension;
-use Tests\TestCase;
 
-class GeodataTest extends TestCase
-{
-    /**
-     * Test fromWKT function
-     *
-     * @return void
-     */
-    public function testFromWktWithTypo() {
-        $typoData = Geodata::fromWKT('PIONT(1 2)');
-        $this->assertNull($typoData);
-    }
+test('from wkt with typo', function () {
+    $typoData = Geodata::fromWKT('PIONT(1 2)');
+    expect($typoData)->toBeNull();
+});
 
-    /**
-     * Test fromWKT function
-     *
-     * @return void
-     */
-    public function testFromWktWith3dPoint() {
-        $point3d = Geodata::fromWKT('POINT Z(1 2 3)');
-        $this->assertEquals(1, $point3d->getX());
-        $this->assertEquals(2, $point3d->getY());
-        $this->assertEquals(3, $point3d->getZ());
-        $this->assertEquals(Dimension::DIMENSION_3DZ, $point3d->getDimension());
-        $this->assertFalse($point3d->hasSrid());
-    }
+test('from wkt with3d point', function () {
+    $point3d = Geodata::fromWKT('POINT Z(1 2 3)');
+    expect($point3d->getX())->toEqual(1);
+    expect($point3d->getY())->toEqual(2);
+    expect($point3d->getZ())->toEqual(3);
+    expect($point3d->getDimension())->toEqual(Dimension::DIMENSION_3DZ);
+    expect($point3d->hasSrid())->toBeFalse();
+});
 
-    /**
-     * Test fromWKT function
-     *
-     * @return void
-     */
-    public function testFromWktWith2dPointAndSrid() {
-        // FIXME: currently Magellan uses a Singleton/Service Container approach which leads to
-        // a problem in case an unsupported/wrong WKT-Type is provided
-        // For this wrong type the singleton's $dimension is set to 2D
-        // if later a non-2D-WKT-type is provided, a Exception is thrown, because
-        // the internal $dimension of the singleton is still 2D and does (of course)
-        // not match e.g. 3DZ
-        // $typoData = Geodata::fromWKT('PIONT(1 2)');
-        // $this->assertNull($typoData);
-
-        $sridPoint2d = Geodata::fromWKT('SRID=4326;POINT(1 2)');
-        $this->assertEquals(1, $sridPoint2d->getLongitude());
-        $this->assertEquals(2, $sridPoint2d->getLatitude());
-        $this->assertNull($sridPoint2d->getAltitude());
-        $this->assertEquals(Dimension::DIMENSION_2D, $sridPoint2d->getDimension());
-        $this->assertTrue($sridPoint2d->hasSrid());
-    }
-}
+test('from wkt with2d point and srid', function () {
+    // FIXME: currently Magellan uses a Singleton/Service Container approach which leads to
+    // a problem in case an unsupported/wrong WKT-Type is provided
+    // For this wrong type the singleton's $dimension is set to 2D
+    // if later a non-2D-WKT-type is provided, a Exception is thrown, because
+    // the internal $dimension of the singleton is still 2D and does (of course)
+    // not match e.g. 3DZ
+    // $typoData = Geodata::fromWKT('PIONT(1 2)');
+    // $this->assertNull($typoData);
+    $sridPoint2d = Geodata::fromWKT('SRID=4326;POINT(1 2)');
+    expect($sridPoint2d->getLongitude())->toEqual(1);
+    expect($sridPoint2d->getLatitude())->toEqual(2);
+    expect($sridPoint2d->getAltitude())->toBeNull();
+    expect($sridPoint2d->getDimension())->toEqual(Dimension::DIMENSION_2D);
+    expect($sridPoint2d->hasSrid())->toBeTrue();
+});

--- a/tests/Unit/HelperTest.php
+++ b/tests/Unit/HelperTest.php
@@ -1,47 +1,33 @@
 <?php
 
-namespace Tests\Unit;
+test('column names helper', function () {
+    $attributeColumns = sp_column_names('attributes');
+    expect($attributeColumns)->toEqual([
+        'id',
+        'thesaurus_url',
+        'datatype',
+        'text',
+        'thesaurus_root_url',
+        'parent_id',
+        'created_at',
+        'updated_at',
+        'recursive',
+        'root_attribute_id',
+        'is_system',
+        'multiple',
+        'restrictions',
+        'metadata',
+    ]);
 
-use Tests\TestCase;
-
-
-class HelperTest extends TestCase
-{
-    /**
-     * Test sp_column_names helper
-     *
-     * @return void
-     */
-    public function testColumnNamesHelper()
-    {
-        $attributeColumns = sp_column_names('attributes');
-        $this->assertEquals([
-            'id',
-            'thesaurus_url',
-            'datatype',
-            'text',
-            'thesaurus_root_url',
-            'parent_id',
-            'created_at',
-            'updated_at',
-            'recursive',
-            'root_attribute_id',
-            'is_system',
-            'multiple',
-            'restrictions',
-            'metadata',
-        ], $attributeColumns);
-
-        $eaColumns = sp_column_names('entity_attributes');
-        $this->assertEquals([
-            'id',
-            'entity_type_id',
-            'attribute_id',
-            'position',
-            'depends_on',
-            'created_at',
-            'updated_at',
-            'metadata',
-        ], $eaColumns);
-    }
-}
+    $eaColumns = sp_column_names('entity_attributes');
+    expect($eaColumns)->toEqual([
+        'id',
+        'entity_type_id',
+        'attribute_id',
+        'position',
+        'depends_on',
+        'created_at',
+        'updated_at',
+        'metadata',
+    ]);
+});

--- a/tests/Unit/Migration/FilesystemMigrationTest.php
+++ b/tests/Unit/Migration/FilesystemMigrationTest.php
@@ -241,6 +241,8 @@ test('fails when encountering symlinks', function () {
     // Setup source with a symlink
     $source = Storage::disk('test_source');
     $source->makeDirectory('test_dir');
+    $target->makeDirectory('test_dir');
+    
     file_put_contents(storage_path('testing/source/test_dir/file.txt'), 'content');
     symlink(storage_path('testing/source/test_dir/file.txt'), storage_path('testing/source/test_dir/symlink.txt'));
 

--- a/tests/Unit/Migration/FilesystemMigrationTest.php
+++ b/tests/Unit/Migration/FilesystemMigrationTest.php
@@ -1,57 +1,52 @@
 <?php
 
-namespace Tests\Unit\Migration;
-
-use App\Traits\FilesystemMigration;
-
-use Illuminate\Database\Migrations\Migration;
-// We need to use the default TestCase to avoid the Database to be refreshed.
-use Illuminate\Foundation\Testing\TestCase;
+uses(\Illuminate\Foundation\Testing\TestCase::class);
 use Illuminate\Support\Facades\Storage;
+use \Tests\Unit\Migration\TestMigration;
+use \Illuminate\Foundation\Testing\TestCase;
+use \Illuminate\Database\Migrations\Migration;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 
-/**
- *  The migrator is a very complex and file based system
- *  so we just emulate it's core functionality for these few tests.
- * (Only to test the proper calling of shouldRun() in up() and down())
- */
-class Migrator {
-    static function run($migration){
-        $shouldRunMigration = $migration instanceof Migration
-            ? $migration->shouldRun()
-            : true;
 
-        $skipped = true;
-        if($shouldRunMigration) {
-            $skipped = false;
-            $migration->up();
-        }
+function run($migration)
+{
+    $shouldRunMigration = $migration instanceof Migration
+        ? $migration->shouldRun()
+        : true;
 
-        return $skipped;
+    $skipped = true;
+    if($shouldRunMigration) {
+        $skipped = false;
+        up();
     }
 
-    // Currently Laravel does not call shouldRun() on rollback (12.x)
-    static function rollback($migration) {
-        $migration->down();
-        return false;
-    }
+    return $skipped;
+}
+
+// Currently Laravel does not call shouldRun() on rollback (12.x)
+function rollback($migration)
+{
+    down();
+    return false;
 }
 
 // We just need empty migrations as the Migrator is handling the check
 // whether the migration was run or not.
 class TestMigration extends Migration {
-    use FilesystemMigration;
+    uses(\App\Traits\FilesystemMigration::class);
+    
+    function up(): void
+    {
+    }
 
-    public function up(): void {}
-
-    public function down(): void {}
+    function down(): void
+    {
+    }
 }
 
 class FilesystemMigrationTest extends TestCase {
-    protected function setUp(): void {
-        parent::setUp();
-
+    beforeEach(function () {
         // Create test storage disks for testing
         config([
             'filesystems.disks.test_source' => [
@@ -65,91 +60,81 @@ class FilesystemMigrationTest extends TestCase {
         ]);
 
         // Clean up any previous test files
-        $this->cleanupTestDirectories();
-    }
+        cleanupTestDirectories();
+    });
 
-    protected function tearDown(): void {
-        $this->cleanupTestDirectories();
-        parent::tearDown();
-    }
+    afterEach(function () {
+        cleanupTestDirectories();
+    });
 
-    private function cleanupTestDirectories(): void {
+    function cleanupTestDirectories(): void
+    {
         $sourcePath = storage_path('testing/source');
         $targetPath = storage_path('testing/target');
 
         if(is_dir($sourcePath)) {
-            $this->deleteDirectory($sourcePath);
+            deleteDirectory($sourcePath);
         }
         if(is_dir($targetPath)) {
-            $this->deleteDirectory($targetPath);
+            deleteDirectory($targetPath);
         }
     }
 
-    private function deleteDirectory(string $path): void {
+    function deleteDirectory(string $path): void
+    {
         if(!is_dir($path)) return;
 
         $files = glob($path . '/*');
         foreach($files as $file) {
-            is_dir($file) ? $this->deleteDirectory($file) : unlink($file);
+            is_dir($file) ? deleteDirectory($file) : unlink($file);
         }
         rmdir($path);
     }
 
-    #[Test]
-    public function should_not_migrate_when_environment_variable_is_false() {
+    test('should not migrate when environment variable is false', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
         $migration = new TestMigration();
-        $this->assertFalse($migration->shouldRun());
-        $skipped = Migrator::run($migration);
-        $this->assertTrue($skipped, 'migrate() should be skipped when shouldRun() returns false');
-    }
+        expect($migration->shouldRun())->toBeFalse();
+        $skipped = run($migration);
+        expect($skipped)->toBeTrue('migrate() should be skipped when shouldRun() returns false');
+    });
 
-    #[Test]
-    public function should_migrate_when_environment_variable_is_true() {
+    test('should migrate when environment variable is true', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
         $migration = new TestMigration();
-        $this->assertTrue($migration->shouldRun());
-        $skipped = Migrator::run($migration);
-        $this->assertFalse($skipped, 'migrate() should be run when shouldRun() returns true');
-    }
+        expect($migration->shouldRun())->toBeTrue();
+        $skipped = run($migration);
+        expect($skipped)->toBeFalse('migrate() should be run when shouldRun() returns true');
+    });
 
-    #[Test]
-    /**
-     * This is somewhat controversial, as it's only called when the migration is registered
-     * but when the variable is set for rollback, it would still happen. This is due to the current
-     * implementation in Laravel 12.x where shouldRun() is not called on rollback at all.
-     *
-    */
-    public function should_rollback_when_environment_variable_is_false() {
+    test('should rollback when environment variable is false', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
         $migration = new TestMigration();
-        $this->assertFalse($migration->shouldRun());
-        $skipped = Migrator::rollback($migration);
-        $this->assertFalse($skipped, 'rollback() should be run when shouldRun() returns false');
-    }
+        expect($migration->shouldRun())->toBeFalse();
+        $skipped = rollback($migration);
+        expect($skipped)->toBeFalse('rollback() should be run when shouldRun() returns false');
+    });
 
-    #[Test]
-    public function should_rollback_when_environment_variable_is_true() {
+    test('should rollback when environment variable is true', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
         $migration = new TestMigration();
-        $this->assertTrue($migration->shouldRun());
-        $skipped = Migrator::rollback($migration);
-        $this->assertFalse($skipped, 'rollback() should not be skipped when shouldRun() returns true');
-    }
+        expect($migration->shouldRun())->toBeTrue();
+        $skipped = rollback($migration);
+        expect($skipped)->toBeFalse('rollback() should not be skipped when shouldRun() returns true');
+    });
 
-    #[Test]
-    public function moves_files_between_disks_successfully() {
+    test('moves files between disks successfully', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         // Create test migration instance
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup test files
         $source = Storage::disk('test_source');
         $target = Storage::disk('test_target');
@@ -159,57 +144,50 @@ class FilesystemMigrationTest extends TestCase {
         $source->put('test_dir/file2.txt', 'content2');
 
         // Execute migration
-        $migration->up();
+        up();
 
         // Assert files moved correctly
-        $this->assertFalse($source->exists('test_dir/file1.txt'));
-        $this->assertFalse($source->exists('test_dir/file2.txt'));
-        $this->assertFalse($source->exists('test_dir'));
+        expect($source->exists('test_dir/file1.txt'))->toBeFalse();
+        expect($source->exists('test_dir/file2.txt'))->toBeFalse();
+        expect($source->exists('test_dir'))->toBeFalse();
 
-        $this->assertTrue($target->exists('test_dir/file1.txt'));
-        $this->assertTrue($target->exists('test_dir/file2.txt'));
-        $this->assertEquals('content1', $target->get('test_dir/file1.txt'));
-        $this->assertEquals('content2', $target->get('test_dir/file2.txt'));
-    }
+        expect($target->exists('test_dir/file1.txt'))->toBeTrue();
+        expect($target->exists('test_dir/file2.txt'))->toBeTrue();
+        expect($target->get('test_dir/file1.txt'))->toEqual('content1');
+        expect($target->get('test_dir/file2.txt'))->toEqual('content2');
+    });
 
-    #[Test]
-    public function handles_non_existent_source_directory_gracefully() {
+    test('handles non existent source directory gracefully', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'non_existent_dir');
             }
         };
-
         // Should not throw exception
-        $migration->up();
+        up();
 
         $source = Storage::disk('test_source');
-        $this->assertFalse($source->exists('non_existent_dir'));
+        expect($source->exists('non_existent_dir'))->toBeFalse();
         $target = Storage::disk('test_target');
-        $this->assertFalse($target->exists('non_existent_dir'));
-    }
+        expect($target->exists('non_existent_dir'))->toBeFalse();
+    });
 
-    /**
-     * This test is not strictly necessary, but it ensures that
-     * if a file with the same content already exists in the target,
-     * the migration does not fail.
-    */
-    #[Test]
-    public function does_not_fail_when_files_have_same_content() {
+    test('does not fail when files have same content', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup files in both locations with same content
         $source = Storage::disk('test_source');
         $target = Storage::disk('test_target');
@@ -221,23 +199,22 @@ class FilesystemMigrationTest extends TestCase {
         $target->put('test_dir/same_file.txt', 'same content');
 
         // Should not throw exception
-        $migration->up();
+        up();
 
-        $this->assertEquals('same content', $target->get('test_dir/same_file.txt'));
-    }
+        expect($target->get('test_dir/same_file.txt'))->toEqual('same content');
+    });
 
-    #[Test]
-    public function fails_when_existing_file_has_different_content() {
+    test('fails when existing file has different content', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup files with different content
         $source = Storage::disk('test_source');
         $target = Storage::disk('test_target');
@@ -252,21 +229,20 @@ class FilesystemMigrationTest extends TestCase {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('File verification failed for: test_dir/conflict_file.txt');
 
-        $migration->up();
-    }
+        up();
+    });
 
-    #[Test]
-    public function creates_target_directory_if_not_exists() {
+    test('creates target directory if not exists', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup source only
         $source = Storage::disk('test_source');
         $target = Storage::disk('test_target');
@@ -274,24 +250,23 @@ class FilesystemMigrationTest extends TestCase {
         $source->makeDirectory('test_dir');
         $source->put('test_dir/file.txt', 'content');
 
-        $migration->up();
+        up();
 
-        $this->assertTrue($target->exists('test_dir'));
-        $this->assertTrue($target->exists('test_dir/file.txt'));
-    }
+        expect($target->exists('test_dir'))->toBeTrue();
+        expect($target->exists('test_dir/file.txt'))->toBeTrue();
+    });
 
-    #[Test]
-    public function fails_when_encountering_symlinks() {
+    test('fails when encountering symlinks', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup source with a symlink
         $source = Storage::disk('test_source');
         $source->makeDirectory('test_dir');
@@ -300,30 +275,30 @@ class FilesystemMigrationTest extends TestCase {
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Migration incomplete: completion could not be evaluated due to symlinked files in test_source/test_dir. Please verify manually if the migration was successful.');
+
         // Should not throw exception, as symlinks are caught and ignored
-        $migration->up();
+        up();
 
         // Verify the regular file was moved, but the symlink was ignored
-        $this->assertFalse($source->exists('test_dir/file.txt'));
-        $this->assertFalse($source->exists('test_dir/symlink.txt'));
+        expect($source->exists('test_dir/file.txt'))->toBeFalse();
+        expect($source->exists('test_dir/symlink.txt'))->toBeFalse();
 
         $target = Storage::disk('test_target');
-        $this->assertTrue($target->exists('test_dir/file.txt'));
-        $this->assertFalse($target->exists('test_dir/symlink.txt'));
-    }
+        expect($target->exists('test_dir/file.txt'))->toBeTrue();
+        expect($target->exists('test_dir/symlink.txt'))->toBeFalse();
+    });
 
-    #[Test]
-    public function does_not_delete_source_directory_if_not_empty() {
+    test('does not delete source directory if not empty', function () {
         putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
 
         $migration = new class extends Migration {
-            use FilesystemMigration;
-
-            public function up(): void {
+            uses(\App\Traits\FilesystemMigration::class);
+            
+            function up(): void
+            {
                 $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
             }
         };
-
         // Setup source with one file and one subdirectory
         $source = Storage::disk('test_source');
         $source->makeDirectory('test_dir');
@@ -335,11 +310,11 @@ class FilesystemMigrationTest extends TestCase {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Migration incomplete: some files could not be moved from test_source/test_dir to test_target/test_dir. Source directory was not empty and therefore not deleted!');
 
-        $migration->up();
+        up();
 
         // Verify source directory still exists with the subdirectory
-        $this->assertTrue($source->exists('test_dir'));
-        $this->assertTrue($source->exists('test_dir/subdir'));
-        $this->assertTrue($source->exists('test_dir/subdir/nested_file.txt'));
-    }
+        expect($source->exists('test_dir'))->toBeTrue();
+        expect($source->exists('test_dir/subdir'))->toBeTrue();
+        expect($source->exists('test_dir/subdir/nested_file.txt'))->toBeTrue();
+    });
 }

--- a/tests/Unit/Migration/FilesystemMigrationTest.php
+++ b/tests/Unit/Migration/FilesystemMigrationTest.php
@@ -1,40 +1,16 @@
 <?php
 
-uses(\Illuminate\Foundation\Testing\TestCase::class);
 use Illuminate\Support\Facades\Storage;
-use \Tests\Unit\Migration\TestMigration;
-use \Illuminate\Foundation\Testing\TestCase;
-use \Illuminate\Database\Migrations\Migration;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\Test;
+use Illuminate\Database\Migrations\Migration;
 
+require_once __DIR__ . '/MigrationTestHelpers.php';
 
-function run($migration)
-{
-    $shouldRunMigration = $migration instanceof Migration
-        ? $migration->shouldRun()
-        : true;
-
-    $skipped = true;
-    if($shouldRunMigration) {
-        $skipped = false;
-        up();
-    }
-
-    return $skipped;
-}
-
-// Currently Laravel does not call shouldRun() on rollback (12.x)
-function rollback($migration)
-{
-    down();
-    return false;
-}
+use function Tests\Unit\Migration\cleanupTestDirectories;
 
 // We just need empty migrations as the Migrator is handling the check
 // whether the migration was run or not.
 class TestMigration extends Migration {
-    uses(\App\Traits\FilesystemMigration::class);
+    use \App\Traits\FilesystemMigration;
     
     function up(): void
     {
@@ -45,276 +21,265 @@ class TestMigration extends Migration {
     }
 }
 
-class FilesystemMigrationTest extends TestCase {
-    beforeEach(function () {
-        // Create test storage disks for testing
-        config([
-            'filesystems.disks.test_source' => [
-                'driver' => 'local',
-                'root' => storage_path('testing/source'),
-            ],
-            'filesystems.disks.test_target' => [
-                'driver' => 'local',
-                'root' => storage_path('testing/target'),
-            ],
-        ]);
+function run($migration)
+{
+    $shouldRunMigration = $migration instanceof Migration
+        ? $migration->shouldRun()
+        : true;
 
-        // Clean up any previous test files
-        cleanupTestDirectories();
-    });
-
-    afterEach(function () {
-        cleanupTestDirectories();
-    });
-
-    function cleanupTestDirectories(): void
-    {
-        $sourcePath = storage_path('testing/source');
-        $targetPath = storage_path('testing/target');
-
-        if(is_dir($sourcePath)) {
-            deleteDirectory($sourcePath);
-        }
-        if(is_dir($targetPath)) {
-            deleteDirectory($targetPath);
-        }
+    $skipped = true;
+    if($shouldRunMigration) {
+        $skipped = false;
+        $migration->up();
     }
 
-    function deleteDirectory(string $path): void
-    {
-        if(!is_dir($path)) return;
-
-        $files = glob($path . '/*');
-        foreach($files as $file) {
-            is_dir($file) ? deleteDirectory($file) : unlink($file);
-        }
-        rmdir($path);
-    }
-
-    test('should not migrate when environment variable is false', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
-        $migration = new TestMigration();
-        expect($migration->shouldRun())->toBeFalse();
-        $skipped = run($migration);
-        expect($skipped)->toBeTrue('migrate() should be skipped when shouldRun() returns false');
-    });
-
-    test('should migrate when environment variable is true', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-        $migration = new TestMigration();
-        expect($migration->shouldRun())->toBeTrue();
-        $skipped = run($migration);
-        expect($skipped)->toBeFalse('migrate() should be run when shouldRun() returns true');
-    });
-
-    test('should rollback when environment variable is false', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
-        $migration = new TestMigration();
-        expect($migration->shouldRun())->toBeFalse();
-        $skipped = rollback($migration);
-        expect($skipped)->toBeFalse('rollback() should be run when shouldRun() returns false');
-    });
-
-    test('should rollback when environment variable is true', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-        $migration = new TestMigration();
-        expect($migration->shouldRun())->toBeTrue();
-        $skipped = rollback($migration);
-        expect($skipped)->toBeFalse('rollback() should not be skipped when shouldRun() returns true');
-    });
-
-    test('moves files between disks successfully', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        // Create test migration instance
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup test files
-        $source = Storage::disk('test_source');
-        $target = Storage::disk('test_target');
-
-        $source->makeDirectory('test_dir');
-        $source->put('test_dir/file1.txt', 'content1');
-        $source->put('test_dir/file2.txt', 'content2');
-
-        // Execute migration
-        up();
-
-        // Assert files moved correctly
-        expect($source->exists('test_dir/file1.txt'))->toBeFalse();
-        expect($source->exists('test_dir/file2.txt'))->toBeFalse();
-        expect($source->exists('test_dir'))->toBeFalse();
-
-        expect($target->exists('test_dir/file1.txt'))->toBeTrue();
-        expect($target->exists('test_dir/file2.txt'))->toBeTrue();
-        expect($target->get('test_dir/file1.txt'))->toEqual('content1');
-        expect($target->get('test_dir/file2.txt'))->toEqual('content2');
-    });
-
-    test('handles non existent source directory gracefully', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'non_existent_dir');
-            }
-        };
-        // Should not throw exception
-        up();
-
-        $source = Storage::disk('test_source');
-        expect($source->exists('non_existent_dir'))->toBeFalse();
-        $target = Storage::disk('test_target');
-        expect($target->exists('non_existent_dir'))->toBeFalse();
-    });
-
-    test('does not fail when files have same content', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup files in both locations with same content
-        $source = Storage::disk('test_source');
-        $target = Storage::disk('test_target');
-
-        $source->makeDirectory('test_dir');
-        $target->makeDirectory('test_dir');
-
-        $source->put('test_dir/same_file.txt', 'same content');
-        $target->put('test_dir/same_file.txt', 'same content');
-
-        // Should not throw exception
-        up();
-
-        expect($target->get('test_dir/same_file.txt'))->toEqual('same content');
-    });
-
-    test('fails when existing file has different content', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup files with different content
-        $source = Storage::disk('test_source');
-        $target = Storage::disk('test_target');
-
-        $source->makeDirectory('test_dir');
-        $target->makeDirectory('test_dir');
-
-        $source->put('test_dir/conflict_file.txt', 'source content');
-        $target->put('test_dir/conflict_file.txt', 'different target content');
-
-        // Should throw exception due to hash mismatch
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('File verification failed for: test_dir/conflict_file.txt');
-
-        up();
-    });
-
-    test('creates target directory if not exists', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup source only
-        $source = Storage::disk('test_source');
-        $target = Storage::disk('test_target');
-
-        $source->makeDirectory('test_dir');
-        $source->put('test_dir/file.txt', 'content');
-
-        up();
-
-        expect($target->exists('test_dir'))->toBeTrue();
-        expect($target->exists('test_dir/file.txt'))->toBeTrue();
-    });
-
-    test('fails when encountering symlinks', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup source with a symlink
-        $source = Storage::disk('test_source');
-        $source->makeDirectory('test_dir');
-        file_put_contents(storage_path('testing/source/test_dir/file.txt'), 'content');
-        symlink(storage_path('testing/source/test_dir/file.txt'), storage_path('testing/source/test_dir/symlink.txt'));
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Migration incomplete: completion could not be evaluated due to symlinked files in test_source/test_dir. Please verify manually if the migration was successful.');
-
-        // Should not throw exception, as symlinks are caught and ignored
-        up();
-
-        // Verify the regular file was moved, but the symlink was ignored
-        expect($source->exists('test_dir/file.txt'))->toBeFalse();
-        expect($source->exists('test_dir/symlink.txt'))->toBeFalse();
-
-        $target = Storage::disk('test_target');
-        expect($target->exists('test_dir/file.txt'))->toBeTrue();
-        expect($target->exists('test_dir/symlink.txt'))->toBeFalse();
-    });
-
-    test('does not delete source directory if not empty', function () {
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        $migration = new class extends Migration {
-            uses(\App\Traits\FilesystemMigration::class);
-            
-            function up(): void
-            {
-                $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
-            }
-        };
-        // Setup source with one file and one subdirectory
-        $source = Storage::disk('test_source');
-        $source->makeDirectory('test_dir');
-        $source->put('test_dir/file.txt', 'content');
-        $source->makeDirectory('test_dir/subdir');
-        $source->put('test_dir/subdir/nested_file.txt', 'nested content');
-
-        // Should throw exception because source directory won't be empty after moving files
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Migration incomplete: some files could not be moved from test_source/test_dir to test_target/test_dir. Source directory was not empty and therefore not deleted!');
-
-        up();
-
-        // Verify source directory still exists with the subdirectory
-        expect($source->exists('test_dir'))->toBeTrue();
-        expect($source->exists('test_dir/subdir'))->toBeTrue();
-        expect($source->exists('test_dir/subdir/nested_file.txt'))->toBeTrue();
-    });
+    return $skipped;
 }
+
+// Currently Laravel does not call shouldRun() on rollback (12.x)
+function rollback($migration)
+{
+    $migration->down();
+    return false;
+}
+
+beforeEach(function () {
+    // Create test storage disks for testing
+    config([
+        'filesystems.disks.test_source' => [
+            'driver' => 'local',
+            'root' => storage_path('testing/source'),
+        ],
+        'filesystems.disks.test_target' => [
+            'driver' => 'local',
+            'root' => storage_path('testing/target'),
+        ],
+    ]);
+
+    // Clean up any previous test files
+    cleanupTestDirectories();
+});
+
+afterEach(function () {
+    cleanupTestDirectories();
+});
+
+test('should not migrate when environment variable is false', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
+    $migration = new TestMigration();
+    expect($migration->shouldRun())->toBeFalse();
+    $skipped = run($migration);
+    expect($skipped)->toBeTrue('migrate() should be skipped when shouldRun() returns false');
+});
+
+test('should migrate when environment variable is true', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+    $migration = new TestMigration();
+    expect($migration->shouldRun())->toBeTrue();
+    $skipped = run($migration);
+    expect($skipped)->toBeFalse('migrate() should be run when shouldRun() returns true');
+});
+
+test('should rollback when environment variable is false', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
+    $migration = new TestMigration();
+    expect($migration->shouldRun())->toBeFalse();
+    $skipped = rollback($migration);
+    expect($skipped)->toBeFalse('rollback() should be run when shouldRun() returns false');
+});
+
+test('should rollback when environment variable is true', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+    $migration = new TestMigration();
+    expect($migration->shouldRun())->toBeTrue();
+    $skipped = rollback($migration);
+    expect($skipped)->toBeFalse('rollback() should not be skipped when shouldRun() returns true');
+});
+
+test('moves files between disks successfully', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    // Create test migration instance
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup test files
+    $source = Storage::disk('test_source');
+    $target = Storage::disk('test_target');
+
+    $source->makeDirectory('test_dir');
+    $source->put('test_dir/file1.txt', 'content1');
+    $source->put('test_dir/file2.txt', 'content2');
+
+    // Execute migration
+    $migration->up();
+
+    // Assert files moved correctly
+    expect($source->exists('test_dir/file1.txt'))->toBeFalse();
+    expect($source->exists('test_dir/file2.txt'))->toBeFalse();
+    expect($source->exists('test_dir'))->toBeFalse();
+
+    expect($target->exists('test_dir/file1.txt'))->toBeTrue();
+    expect($target->exists('test_dir/file2.txt'))->toBeTrue();
+    expect($target->get('test_dir/file1.txt'))->toEqual('content1');
+    expect($target->get('test_dir/file2.txt'))->toEqual('content2');
+});
+
+test('handles non existent source directory gracefully', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'non_existent_dir');
+        }
+    };
+    // Should not throw exception
+    $migration->up();
+
+    $source = Storage::disk('test_source');
+    expect($source->exists('non_existent_dir'))->toBeFalse();
+    $target = Storage::disk('test_target');
+    expect($target->exists('non_existent_dir'))->toBeFalse();
+});
+
+test('does not fail when files have same content', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup files in both locations with same content
+    $source = Storage::disk('test_source');
+    $target = Storage::disk('test_target');
+
+    $source->makeDirectory('test_dir');
+    $target->makeDirectory('test_dir');
+
+    $source->put('test_dir/same_file.txt', 'same content');
+    $target->put('test_dir/same_file.txt', 'same content');
+
+    // Should not throw exception
+    $migration->up();
+
+    expect($target->get('test_dir/same_file.txt'))->toEqual('same content');
+});
+
+test('fails when existing file has different content', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup files with different content
+    $source = Storage::disk('test_source');
+    $target = Storage::disk('test_target');
+
+    $source->makeDirectory('test_dir');
+    $target->makeDirectory('test_dir');
+
+    $source->put('test_dir/conflict_file.txt', 'source content');
+    $target->put('test_dir/conflict_file.txt', 'different target content');
+
+    // Should throw exception due to hash mismatch
+    expect(fn() => $migration->up())
+        ->toThrow(\Exception::class, 'File verification failed for: test_dir/conflict_file.txt');
+});
+
+test('creates target directory if not exists', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup source only
+    $source = Storage::disk('test_source');
+    $target = Storage::disk('test_target');
+
+    $source->makeDirectory('test_dir');
+    $source->put('test_dir/file.txt', 'content');
+
+    $migration->up();
+
+    expect($target->exists('test_dir'))->toBeTrue();
+    expect($target->exists('test_dir/file.txt'))->toBeTrue();
+});
+
+test('fails when encountering symlinks', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup source with a symlink
+    $source = Storage::disk('test_source');
+    $source->makeDirectory('test_dir');
+    file_put_contents(storage_path('testing/source/test_dir/file.txt'), 'content');
+    symlink(storage_path('testing/source/test_dir/file.txt'), storage_path('testing/source/test_dir/symlink.txt'));
+
+    expect(fn() => $migration->up())
+        ->toThrow(\Exception::class, 'Migration incomplete: completion could not be evaluated due to symlinked files in test_source/test_dir. Please verify manually if the migration was successful.');
+
+    // Verify the regular file was moved, but the symlink was ignored
+    expect($source->exists('test_dir/file.txt'))->toBeFalse();
+    expect($source->exists('test_dir/symlink.txt'))->toBeFalse();
+
+    $target = Storage::disk('test_target');
+    expect($target->exists('test_dir/file.txt'))->toBeTrue();
+    expect($target->exists('test_dir/symlink.txt'))->toBeFalse();
+})->skip(PHP_OS_FAMILY === 'Windows', 'Symlink creation requires administrator privileges on Windows');
+
+test('does not delete source directory if not empty', function () {
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    $migration = new class extends Migration {
+        use \App\Traits\FilesystemMigration;
+        
+        function up(): void
+        {
+            $this->safelyMoveDirectoryBetweenDisks('test_source', 'test_target', 'test_dir');
+        }
+    };
+    // Setup source with one file and one subdirectory
+    $source = Storage::disk('test_source');
+    $source->makeDirectory('test_dir');
+    $source->put('test_dir/file.txt', 'content');
+    $source->makeDirectory('test_dir/subdir');
+    $source->put('test_dir/subdir/nested_file.txt', 'nested content');
+
+    // Should throw exception because source directory won't be empty after moving files
+    expect(fn() => $migration->up())
+        ->toThrow(\Exception::class, 'Migration incomplete: some files could not be moved from test_source/test_dir to test_target/test_dir. Source directory was not empty and therefore not deleted!');
+
+    // Verify source directory still exists with the subdirectory
+    expect($source->exists('test_dir'))->toBeTrue();
+    expect($source->exists('test_dir/subdir'))->toBeTrue();
+    expect($source->exists('test_dir/subdir/nested_file.txt'))->toBeTrue();
+});

--- a/tests/Unit/Migration/FilesystemMigrationTest.php
+++ b/tests/Unit/Migration/FilesystemMigrationTest.php
@@ -241,6 +241,8 @@ test('fails when encountering symlinks', function () {
     // Setup source with a symlink
     $source = Storage::disk('test_source');
     $source->makeDirectory('test_dir');
+    
+    $target = Storage::disk('test_target');
     $target->makeDirectory('test_dir');
     
     file_put_contents(storage_path('testing/source/test_dir/file.txt'), 'content');
@@ -253,7 +255,6 @@ test('fails when encountering symlinks', function () {
     expect($source->exists('test_dir/file.txt'))->toBeFalse();
     expect($source->exists('test_dir/symlink.txt'))->toBeFalse();
 
-    $target = Storage::disk('test_target');
     expect($target->exists('test_dir/file.txt'))->toBeTrue();
     expect($target->exists('test_dir/symlink.txt'))->toBeFalse();
 })->skip(PHP_OS_FAMILY === 'Windows', 'Symlink creation requires administrator privileges on Windows');

--- a/tests/Unit/Migration/FilesystemMigrationTest.php
+++ b/tests/Unit/Migration/FilesystemMigrationTest.php
@@ -248,15 +248,19 @@ test('fails when encountering symlinks', function () {
     file_put_contents(storage_path('testing/source/test_dir/file.txt'), 'content');
     symlink(storage_path('testing/source/test_dir/file.txt'), storage_path('testing/source/test_dir/symlink.txt'));
 
+    expect($source->exists('test_dir/file.txt'))->toBeTrue();
+    expect($source->exists('test_dir/symlink.txt'))->toBeTrue();
+    
     expect(fn() => $migration->up())
         ->toThrow(\Exception::class, 'Migration incomplete: completion could not be evaluated due to symlinked files in test_source/test_dir. Please verify manually if the migration was successful.');
+    
+        $fileIsStillInSource = $source->exists('test_dir/file.txt');
+    $filwWasMoved = $target->exists('test_dir/file.txt');
+    
+    // Check that the original file was not removed:
+    expect($fileIsStillInSource || $filwWasMoved)->toBeTrue();
+    expect($source->exists('test_dir/symlink.txt'))->toBeTrue();
 
-    // Verify the regular file was moved, but the symlink was ignored
-    expect($source->exists('test_dir/file.txt'))->toBeFalse();
-    expect($source->exists('test_dir/symlink.txt'))->toBeFalse();
-
-    expect($target->exists('test_dir/file.txt'))->toBeTrue();
-    expect($target->exists('test_dir/symlink.txt'))->toBeFalse();
 })->skip(PHP_OS_FAMILY === 'Windows', 'Symlink creation requires administrator privileges on Windows');
 
 test('does not delete source directory if not empty', function () {

--- a/tests/Unit/Migration/MakeFilesPrivateMigrationTest.php
+++ b/tests/Unit/Migration/MakeFilesPrivateMigrationTest.php
@@ -1,200 +1,190 @@
 <?php
 
-namespace Tests\Unit\Migration;
-
-// We need to use the default TestCase to avoid the Database to be refreshed.
-use Illuminate\Foundation\Testing\TestCase;
+uses(\Illuminate\Foundation\Testing\TestCase::class);
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 
-class MakeFilesPrivateMigrationTest extends TestCase
+
+beforeEach(function () {
+    // Set up test environment
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
+
+    // Reconfigure the existing 'public' and 'local' disks to use test directories
+    config([
+        'filesystems.disks.public' => [
+            'driver' => 'local',
+            'root' => storage_path('testing/make_private_migration/public'),
+            'url' => './storage',
+            'visibility' => 'public',
+            'throw' => true,
+        ],
+        'filesystems.disks.local' => [
+            'driver' => 'local',
+            'root' => storage_path('testing/make_private_migration/local'),
+            'throw' => true,
+        ],
+    ]);
+
+    // Clean up any existing test files
+    cleanupTestFiles();
+});
+
+afterEach(function () {
+    cleanupTestFiles();
+    putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
+});
+
+function cleanupTestFiles(): void
 {
-    protected function setUp(): void {
-        parent::setUp();
+    $testPublicPath = storage_path('testing/make_private_migration/public');
+    $testLocalPath = storage_path('testing/make_private_migration/local');
 
-        // Set up test environment
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=true');
-
-        // Reconfigure the existing 'public' and 'local' disks to use test directories
-        config([
-            'filesystems.disks.public' => [
-                'driver' => 'local',
-                'root' => storage_path('testing/make_private_migration/public'),
-                'url' => './storage',
-                'visibility' => 'public',
-                'throw' => true,
-            ],
-            'filesystems.disks.local' => [
-                'driver' => 'local',
-                'root' => storage_path('testing/make_private_migration/local'),
-                'throw' => true,
-            ],
-        ]);
-
-        // Clean up any existing test files
-        $this->cleanupTestFiles();
+    if(is_dir($testPublicPath)) {
+        deleteDirectory($testPublicPath);
     }
-
-    protected function tearDown(): void {
-        $this->cleanupTestFiles();
-        putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
-        parent::tearDown();
-    }
-
-    private function cleanupTestFiles(): void {
-        $testPublicPath = storage_path('testing/make_private_migration/public');
-        $testLocalPath = storage_path('testing/make_private_migration/local');
-
-        if(is_dir($testPublicPath)) {
-            $this->deleteDirectory($testPublicPath);
-        }
-        if(is_dir($testLocalPath)) {
-            $this->deleteDirectory($testLocalPath);
-        }
-    }
-
-    private function deleteDirectory(string $path): void {
-        if(!is_dir($path)) {
-            return;
-        }
-
-        $files = array_diff(scandir($path), ['.', '..']);
-        foreach($files as $file) {
-            $fullPath = $path . DIRECTORY_SEPARATOR . $file;
-            if(is_dir($fullPath)) {
-                $this->deleteDirectory($fullPath);
-            } else {
-                unlink($fullPath);
-            }
-        }
-        rmdir($path);
-    }
-
-    #[Test]
-    public function moves_files_from_public_to_private_storage() {
-        // Get the actual migration
-        $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
-
-        // Setup test data in public storage
-        $public = Storage::disk('public');
-        $private = Storage::disk('local');
-
-        $public->makeDirectory('avatars');
-        $public->makeDirectory('bibliography');
-        $public->put('avatars/user1.jpg', 'fake avatar content');
-        $public->put('bibliography/paper1.pdf', 'fake pdf content');
-
-        // Run the migration
-        $migration->up();
-
-        // Assert files moved to private storage
-        $this->assertFalse($public->exists('avatars/user1.jpg'));
-        $this->assertFalse($public->exists('bibliography/paper1.pdf'));
-        $this->assertFalse($public->exists('avatars'));
-        $this->assertFalse($public->exists('bibliography'));
-
-        $this->assertTrue($private->exists('avatars/user1.jpg'));
-        $this->assertTrue($private->exists('bibliography/paper1.pdf'));
-        $this->assertEquals('fake avatar content', $private->get('avatars/user1.jpg'));
-        $this->assertEquals('fake pdf content', $private->get('bibliography/paper1.pdf'));
-    }
-
-    #[Test]
-    public function can_rollback_migration() {
-        // Get the actual migration
-        $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
-
-        // Setup files in private storage (simulating after migration)
-        $private = Storage::disk('local');
-        $public = Storage::disk('public');
-
-        $private->makeDirectory('avatars');
-        $private->put('avatars/user1.jpg', 'avatar content');
-
-        // Run rollback
-        $migration->down();
-
-        // Assert files moved back to public storage
-        $this->assertFalse($private->exists('avatars/user1.jpg'));
-        $this->assertFalse($private->exists('avatars'));
-
-        $this->assertTrue($public->exists('avatars/user1.jpg'));
-        $this->assertEquals('avatar content', $public->get('avatars/user1.jpg'));
-    }
-
-    #[Test]
-    public function skips_migration_when_no_directories_exist() {
-        // Get the actual migration
-        $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
-
-        // Ensure no directories exist
-        $public = Storage::disk('public');
-        $private = Storage::disk('local');
-
-        $this->assertFalse($public->exists('avatars'));
-        $this->assertFalse($public->exists('bibliography'));
-        $this->assertFalse($public->exists('plugins'));
-
-        // Should not throw any exceptions
-        $migration->up();
-
-        // Nothing should be created
-        $this->assertFalse($private->exists('avatars'));
-        $this->assertFalse($private->exists('bibliography'));
-        $this->assertFalse($private->exists('plugins'));
-    }
-
-    #[Test]
-    public function fail_when_directory_has_subdirectories() {
-        // Get the actual migration
-        $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
-
-        // Ensure no directories exist
-        $public = Storage::disk('public');
-        $private = Storage::disk('local');
-
-        $public->makeDirectory('avatars');
-        $public->makeDirectory('bibliography');
-        $public->makeDirectory('plugins');
-
-        $public->put('avatars/user1.jpg', 'fake avatar content');
-        $public->put('bibliography/paper1.pdf', 'fake pdf content');
-        $public->put('plugins/plugin1.php', 'fake plugin content');
-
-        $public->makeDirectory('avatars/subdir');
-        $public->makeDirectory('bibliography/subdir');
-        $public->makeDirectory('plugins/subdir');
-        $public->put('avatars/subdir/user1.jpg', 'fake avatar content');
-        $public->put('bibliography/subdir/paper1.pdf', 'fake pdf content');
-        $public->put('plugins/subdir/plugin1.php', 'fake plugin content');
-
-        // Run the migration and assert it throws an exception with the expected message
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessageMatches('/Migration incomplete: some files could not be moved from public\/avatars to local\/avatars\. Source directory was not empty and therefore not deleted!/');
-
-        $migration->up();
-
-        // Assert files moved to private storage
-        $this->assertFalse($public->exists('avatars/user1.jpg'));
-        $this->assertFalse($public->exists('bibliography/paper1.pdf'));
-        $this->assertFalse($public->exists('plugins/plugin1.php'));
-
-        $this->assertTrue($private->exists('avatars/user1.jpg'));
-        $this->assertTrue($private->exists('bibliography/paper1.pdf'));
-        $this->assertTrue($private->exists('plugins/plugin1.php'));
-
-        $this->assertFalse($public->exists('avatars/subdir/user1.jpg'));
-        $this->assertFalse($public->exists('bibliography/subdir/paper1.pdf'));
-        $this->assertFalse($public->exists('plugins/subdir/plugin1.php'));
-        $this->assertTrue($public->exists('avatars/subdir'));
-        $this->assertTrue($public->exists('bibliography/subdir'));
-        $this->assertTrue($public->exists('plugins/subdir'));
-
-        $this->assertTrue($private->exists('avatars/subdir/user1.jpg'));
-        $this->assertTrue($private->exists('bibliography/subdir/paper1.pdf'));
-        $this->assertTrue($private->exists('plugins/subdir/plugin1.php'));
-        $this->assertEquals('fake avatar content', $private->get('avatars/subdir/user1.jpg'));
-        $this->assertEquals('fake pdf content', $private->get('bibliography/subdir/paper1.pdf'));
-        $this->assertEquals('fake plugin content', $private->get('plugins/subdir/plugin1.php'));
+    if(is_dir($testLocalPath)) {
+        deleteDirectory($testLocalPath);
     }
 }
+
+function deleteDirectory(string $path): void
+{
+    if(!is_dir($path)) {
+        return;
+    }
+
+    $files = array_diff(scandir($path), ['.', '..']);
+    foreach($files as $file) {
+        $fullPath = $path . DIRECTORY_SEPARATOR . $file;
+        if(is_dir($fullPath)) {
+            deleteDirectory($fullPath);
+        } else {
+            unlink($fullPath);
+        }
+    }
+    rmdir($path);
+}
+
+test('moves files from public to private storage', function () {
+    // Get the actual migration
+    $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
+
+    // Setup test data in public storage
+    $public = Storage::disk('public');
+    $private = Storage::disk('local');
+
+    $public->makeDirectory('avatars');
+    $public->makeDirectory('bibliography');
+    $public->put('avatars/user1.jpg', 'fake avatar content');
+    $public->put('bibliography/paper1.pdf', 'fake pdf content');
+
+    // Run the migration
+    $migration->up();
+
+    // Assert files moved to private storage
+    expect($public->exists('avatars/user1.jpg'))->toBeFalse();
+    expect($public->exists('bibliography/paper1.pdf'))->toBeFalse();
+    expect($public->exists('avatars'))->toBeFalse();
+    expect($public->exists('bibliography'))->toBeFalse();
+
+    expect($private->exists('avatars/user1.jpg'))->toBeTrue();
+    expect($private->exists('bibliography/paper1.pdf'))->toBeTrue();
+    expect($private->get('avatars/user1.jpg'))->toEqual('fake avatar content');
+    expect($private->get('bibliography/paper1.pdf'))->toEqual('fake pdf content');
+});
+
+test('can rollback migration', function () {
+    // Get the actual migration
+    $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
+
+    // Setup files in private storage (simulating after migration)
+    $private = Storage::disk('local');
+    $public = Storage::disk('public');
+
+    $private->makeDirectory('avatars');
+    $private->put('avatars/user1.jpg', 'avatar content');
+
+    // Run rollback
+    $migration->down();
+
+    // Assert files moved back to public storage
+    expect($private->exists('avatars/user1.jpg'))->toBeFalse();
+    expect($private->exists('avatars'))->toBeFalse();
+
+    expect($public->exists('avatars/user1.jpg'))->toBeTrue();
+    expect($public->get('avatars/user1.jpg'))->toEqual('avatar content');
+});
+
+test('skips migration when no directories exist', function () {
+    // Get the actual migration
+    $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
+
+    // Ensure no directories exist
+    $public = Storage::disk('public');
+    $private = Storage::disk('local');
+
+    expect($public->exists('avatars'))->toBeFalse();
+    expect($public->exists('bibliography'))->toBeFalse();
+    expect($public->exists('plugins'))->toBeFalse();
+
+    // Should not throw any exceptions
+    $migration->up();
+
+    // Nothing should be created
+    expect($private->exists('avatars'))->toBeFalse();
+    expect($private->exists('bibliography'))->toBeFalse();
+    expect($private->exists('plugins'))->toBeFalse();
+});
+
+test('fail when directory has subdirectories', function () {
+    // Get the actual migration
+    $migration = require database_path('migrations/2024_12_04_073048_make_files_private.php');
+
+    // Ensure no directories exist
+    $public = Storage::disk('public');
+    $private = Storage::disk('local');
+
+    $public->makeDirectory('avatars');
+    $public->makeDirectory('bibliography');
+    $public->makeDirectory('plugins');
+
+    $public->put('avatars/user1.jpg', 'fake avatar content');
+    $public->put('bibliography/paper1.pdf', 'fake pdf content');
+    $public->put('plugins/plugin1.php', 'fake plugin content');
+
+    $public->makeDirectory('avatars/subdir');
+    $public->makeDirectory('bibliography/subdir');
+    $public->makeDirectory('plugins/subdir');
+    $public->put('avatars/subdir/user1.jpg', 'fake avatar content');
+    $public->put('bibliography/subdir/paper1.pdf', 'fake pdf content');
+    $public->put('plugins/subdir/plugin1.php', 'fake plugin content');
+
+    // Run the migration and assert it throws an exception with the expected message
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessageMatches('/Migration incomplete: some files could not be moved from public\/avatars to local\/avatars\. Source directory was not empty and therefore not deleted!/');
+
+    $migration->up();
+
+    // Assert files moved to private storage
+    expect($public->exists('avatars/user1.jpg'))->toBeFalse();
+    expect($public->exists('bibliography/paper1.pdf'))->toBeFalse();
+    expect($public->exists('plugins/plugin1.php'))->toBeFalse();
+
+    expect($private->exists('avatars/user1.jpg'))->toBeTrue();
+    expect($private->exists('bibliography/paper1.pdf'))->toBeTrue();
+    expect($private->exists('plugins/plugin1.php'))->toBeTrue();
+
+    expect($public->exists('avatars/subdir/user1.jpg'))->toBeFalse();
+    expect($public->exists('bibliography/subdir/paper1.pdf'))->toBeFalse();
+    expect($public->exists('plugins/subdir/plugin1.php'))->toBeFalse();
+    expect($public->exists('avatars/subdir'))->toBeTrue();
+    expect($public->exists('bibliography/subdir'))->toBeTrue();
+    expect($public->exists('plugins/subdir'))->toBeTrue();
+
+    expect($private->exists('avatars/subdir/user1.jpg'))->toBeTrue();
+    expect($private->exists('bibliography/subdir/paper1.pdf'))->toBeTrue();
+    expect($private->exists('plugins/subdir/plugin1.php'))->toBeTrue();
+    expect($private->get('avatars/subdir/user1.jpg'))->toEqual('fake avatar content');
+    expect($private->get('bibliography/subdir/paper1.pdf'))->toEqual('fake pdf content');
+    expect($private->get('plugins/subdir/plugin1.php'))->toEqual('fake plugin content');
+});

--- a/tests/Unit/Migration/MakeFilesPrivateMigrationTest.php
+++ b/tests/Unit/Migration/MakeFilesPrivateMigrationTest.php
@@ -1,9 +1,10 @@
 <?php
 
-uses(\Illuminate\Foundation\Testing\TestCase::class);
 use Illuminate\Support\Facades\Storage;
-use PHPUnit\Framework\Attributes\Test;
 
+require_once __DIR__ . '/MigrationTestHelpers.php';
+
+use function Tests\Unit\Migration\cleanuPrivateMigrationFiles;
 
 beforeEach(function () {
     // Set up test environment
@@ -26,44 +27,13 @@ beforeEach(function () {
     ]);
 
     // Clean up any existing test files
-    cleanupTestFiles();
+    cleanuPrivateMigrationFiles();
 });
 
 afterEach(function () {
-    cleanupTestFiles();
+    cleanuPrivateMigrationFiles();
     putenv('ALLOW_FILESYSTEM_MIGRATIONS=false');
 });
-
-function cleanupTestFiles(): void
-{
-    $testPublicPath = storage_path('testing/make_private_migration/public');
-    $testLocalPath = storage_path('testing/make_private_migration/local');
-
-    if(is_dir($testPublicPath)) {
-        deleteDirectory($testPublicPath);
-    }
-    if(is_dir($testLocalPath)) {
-        deleteDirectory($testLocalPath);
-    }
-}
-
-function deleteDirectory(string $path): void
-{
-    if(!is_dir($path)) {
-        return;
-    }
-
-    $files = array_diff(scandir($path), ['.', '..']);
-    foreach($files as $file) {
-        $fullPath = $path . DIRECTORY_SEPARATOR . $file;
-        if(is_dir($fullPath)) {
-            deleteDirectory($fullPath);
-        } else {
-            unlink($fullPath);
-        }
-    }
-    rmdir($path);
-}
 
 test('moves files from public to private storage', function () {
     // Get the actual migration

--- a/tests/Unit/Migration/MigrationTestHelpers.php
+++ b/tests/Unit/Migration/MigrationTestHelpers.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Migration;
+
+function cleanupTestDirectories(): void
+{
+    $sourcePath = storage_path('testing/source');
+    $targetPath = storage_path('testing/target');
+
+    if(is_dir($sourcePath)) {
+        deleteDirectory($sourcePath);
+    }
+    if(is_dir($targetPath)) {
+        deleteDirectory($targetPath);
+    }
+}
+
+function deleteDirectory(string $path): void
+{
+    if(!is_dir($path)) return;
+
+    $files = glob($path . '/*');
+    foreach($files as $file) {
+        is_dir($file) ? deleteDirectory($file) : unlink($file);
+    }
+    rmdir($path);
+}
+
+function cleanuPrivateMigrationFiles(): void
+{
+    $testPublicPath = storage_path('testing/make_private_migration/public');
+    $testLocalPath = storage_path('testing/make_private_migration/local');
+
+    if(is_dir($testPublicPath)) {
+        deleteDirectory($testPublicPath);
+    }
+    if(is_dir($testLocalPath)) {
+        deleteDirectory($testLocalPath);
+    }
+}

--- a/tests/Unit/PreferenceTest.php
+++ b/tests/Unit/PreferenceTest.php
@@ -1,97 +1,79 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
 use App\Preference;
 
-class PreferenceTest extends TestCase
-{
-    /**
-     * Test decodePreference() method
-     *
-     * @return void
-     */
-    public function testDecodePreference()
-    {
-        $preferences = [
-            [
-                'label' => 'prefs.not-existing',
-                'value' => 'input',
-                'testValue' => 'input'
-            ],
-        ];
 
-        foreach($preferences as $p) {
-            $value = Preference::decodePreference($p['label'], $p['value']);
-            $this->assertEquals($p['testValue'], $value);
-        }
+test('decode preference', function () {
+    $preferences = [
+        [
+            'label' => 'prefs.not-existing',
+            'value' => 'input',
+            'testValue' => 'input'
+        ],
+    ];
+
+    foreach($preferences as $p) {
+        $value = Preference::decodePreference($p['label'], $p['value']);
+        expect($value)->toEqual($p['testValue']);
     }
+});
 
-    /**
-     * Test encodePreference() method
-     *
-     * @return void
-     */
-    public function testEncodePreference()
-    {
-        $preferences = [
-            [
-                'label' => 'prefs.gui-language',
-                'value' => 'de',
-                'testValue' => '{"language_key":"de"}'
-            ],
-            [
-                'label' => 'prefs.columns',
-                'value' => '{"left":2, "right":5, "center":5}',
-                'testValue' => '"{\"left\":2, \"right\":5, \"center\":5}"'
-            ],
-            [
-                'label' => 'prefs.show-tooltips',
-                'value' => false,
-                'testValue' => '{"show":false}'
-            ],
-            [
-                'label' => 'prefs.tag-root',
-                'value' => 'http://example.com',
-                'testValue' => '{"uri":"http:\/\/example.com"}'
-            ],
-            [
-                'label' => 'prefs.load-extensions',
-                'value' => '{"map":true, "files":false}',
-                'testValue' => '{"map":true, "files":false}'
-            ],
-            [
-                'label' => 'prefs.link-to-thesaurex',
-                'value' => 'http://example.com',
-                'testValue' => '{"url":"http:\/\/example.com"}'
-            ],
-            [
-                'label' => 'prefs.project-name',
-                'value' => 'Unit Testing',
-                'testValue' => '{"name":"Unit Testing"}'
-            ],
-            [
-                'label' => 'prefs.project-maintainer',
-                'value' => '{"name":"PHPUnit", "email":"admin@admin.com", "public":true, "description": "None"}',
-                'testValue' => '{"name":"PHPUnit", "email":"admin@admin.com", "public":true, "description": "None"}'
-            ],
-            [
-                'label' => 'prefs.map-projection',
-                'value' => '{"epsg": "4326"}',
-                'testValue' => '{"epsg": "4326"}'
-            ],
-            [
-                'label' => 'prefs.enable-password-reset-link',
-                'value' => false,
-                'testValue' => '{"use":false}'
-            ],
-        ];
+test('encode preference', function () {
+    $preferences = [
+        [
+            'label' => 'prefs.gui-language',
+            'value' => 'de',
+            'testValue' => '{"language_key":"de"}'
+        ],
+        [
+            'label' => 'prefs.columns',
+            'value' => '{"left":2, "right":5, "center":5}',
+            'testValue' => '"{\"left\":2, \"right\":5, \"center\":5}"'
+        ],
+        [
+            'label' => 'prefs.show-tooltips',
+            'value' => false,
+            'testValue' => '{"show":false}'
+        ],
+        [
+            'label' => 'prefs.tag-root',
+            'value' => 'http://example.com',
+            'testValue' => '{"uri":"http:\/\/example.com"}'
+        ],
+        [
+            'label' => 'prefs.load-extensions',
+            'value' => '{"map":true, "files":false}',
+            'testValue' => '{"map":true, "files":false}'
+        ],
+        [
+            'label' => 'prefs.link-to-thesaurex',
+            'value' => 'http://example.com',
+            'testValue' => '{"url":"http:\/\/example.com"}'
+        ],
+        [
+            'label' => 'prefs.project-name',
+            'value' => 'Unit Testing',
+            'testValue' => '{"name":"Unit Testing"}'
+        ],
+        [
+            'label' => 'prefs.project-maintainer',
+            'value' => '{"name":"PHPUnit", "email":"admin@admin.com", "public":true, "description": "None"}',
+            'testValue' => '{"name":"PHPUnit", "email":"admin@admin.com", "public":true, "description": "None"}'
+        ],
+        [
+            'label' => 'prefs.map-projection',
+            'value' => '{"epsg": "4326"}',
+            'testValue' => '{"epsg": "4326"}'
+        ],
+        [
+            'label' => 'prefs.enable-password-reset-link',
+            'value' => false,
+            'testValue' => '{"use":false}'
+        ],
+    ];
 
-        foreach($preferences as $p) {
-            $value = Preference::encodePreference($p['label'], $p['value']);
-            $this->assertEquals($p['testValue'], $value);
-        }
+    foreach($preferences as $p) {
+        $value = Preference::encodePreference($p['label'], $p['value']);
+        expect($value)->toEqual($p['testValue']);
     }
-}
+});

--- a/tests/Unit/ReferenceTest.php
+++ b/tests/Unit/ReferenceTest.php
@@ -1,36 +1,17 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\Reference;
 
-class ReferenceTest extends TestCase
-{
-    /**
-     * Test relations of an reference (id=3)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $ref = Reference::with(['entity', 'attribute', 'bibliography'])->find(3);
 
-        $this->assertEquals(1, $ref->entity->id);
-        $this->assertEquals(13, $ref->attribute->id);
-        $this->assertEquals(1323, $ref->bibliography->id);
-    }
+test('relations', function () {
+    $ref = Reference::with(['entity', 'attribute', 'bibliography'])->find(3);
 
-    /**
-     * Test get last editor of first reference entry
-     *
-     * @return void
-     */
-    public function testGetReferenceEntryLasteditor()
-    {
-        $ref = Reference::first();
-        $this->assertEquals(1, $ref->user->id);
-    }
-}
+    expect($ref->entity->id)->toEqual(1);
+    expect($ref->attribute->id)->toEqual(13);
+    expect($ref->bibliography->id)->toEqual(1323);
+});
+
+test('get reference entry lasteditor', function () {
+    $ref = Reference::first();
+    expect($ref->user->id)->toEqual(1);
+});

--- a/tests/Unit/ThConceptTest.php
+++ b/tests/Unit/ThConceptTest.php
@@ -1,61 +1,38 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
 use App\ThConcept;
 use App\ThConceptLabel;
 use Illuminate\Support\Facades\App;
 
-class ThConceptTest extends TestCase
-{
-    /**
-     * Test locale label of a concept (id=1)
-     *
-     * @return void
-     */
-    public function testLocaleLabel() {
-        $concept = ThConcept::find(1);
-        $labelEn = $concept->getActiveLocaleLabel();
-        $this->assertEquals('Site', $labelEn);
 
-        App::setLocale('de');
-        $labelDe = $concept->getActiveLocaleLabel();
-        $this->assertEquals('Fundstelle', $labelDe);
+test('locale label', function () {
+    $concept = ThConcept::find(1);
+    $labelEn = $concept->getActiveLocaleLabel();
+    expect($labelEn)->toEqual('Site');
 
-        App::setLocale('en');
-        $this->assertEquals('Site', $labelEn);
-    }
+    App::setLocale('de');
+    $labelDe = $concept->getActiveLocaleLabel();
+    expect($labelDe)->toEqual('Fundstelle');
 
-    /**
-     * Test relations of a concept (id=20)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $concept = ThConcept::with(['labels', 'narrowers', 'broaders'])->find(20);
+    App::setLocale('en');
+    expect($labelEn)->toEqual('Site');
+});
 
-        $this->assertEquals(1, $concept->labels->count());
-        $this->assertEquals(26, $concept->labels[0]->id);
-        $this->assertEquals(1, $concept->labels[0]->language_id);
-        $this->assertEquals(20, $concept->labels[0]->concept_id);
-        $this->assertEquals(0, $concept->narrowers->count());
-        $this->assertEquals(1, $concept->broaders->count());
-        $this->assertEquals(17, $concept->broaders[0]->id);
-    }
+test('relations', function () {
+    $concept = ThConcept::with(['labels', 'narrowers', 'broaders'])->find(20);
 
-    /**
-     * Test get last editor of first thesaurus concept
-     *
-     * @return void
-     */
-    public function testGetThConceptLasteditor()
-    {
-        $concept = ThConcept::first();
-        $this->assertEquals(1, $concept->user->id);
-        $label = ThConceptLabel::first();
-        $this->assertEquals(1, $label->user->id);
-    }
-}
+    expect($concept->labels->count())->toEqual(1);
+    expect($concept->labels[0]->id)->toEqual(26);
+    expect($concept->labels[0]->language_id)->toEqual(1);
+    expect($concept->labels[0]->concept_id)->toEqual(20);
+    expect($concept->narrowers->count())->toEqual(0);
+    expect($concept->broaders->count())->toEqual(1);
+    expect($concept->broaders[0]->id)->toEqual(17);
+});
+
+test('get th concept lasteditor', function () {
+    $concept = ThConcept::first();
+    expect($concept->user->id)->toEqual(1);
+    $label = ThConceptLabel::first();
+    expect($label->user->id)->toEqual(1);
+});

--- a/tests/Unit/ThLanguageTest.php
+++ b/tests/Unit/ThLanguageTest.php
@@ -1,57 +1,38 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
 use App\ThLanguage;
 
-class ThLanguageTest extends TestCase
-{
-    /**
-     * Test relations of an language (id=2, EN)
-     *
-     * @return void
-     */
-    public function testRelations()
-    {
-        $l = ThLanguage::with(['labels'])->find(2);
 
-        $this->assertEquals(5, $l->labels->count());
-        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
-            [
-                'concept_id' => 1,
-                'label' => 'Site',
-            ],
-            [
-                'concept_id' => 2,
-                'label' => 'Feature',
-            ],
-            [
-                'concept_id' => 3,
-                'label' => 'Find',
-            ],
-            [
-                'concept_id' => 9,
-                'label' => 'Pottery',
-            ],
-            [
-                'concept_id' => 10,
-                'label' => 'Stone',
-            ],
-        ], $l->labels->toArray(),
-        ['concept_id', 'label']);
-    }
+test('relations', function () {
+    $l = ThLanguage::with(['labels'])->find(2);
 
-    /**
-     * Test get last editor of first language
-     *
-     * @return void
-     */
-    public function testGetLanguageLasteditor()
-    {
-        $lang = ThLanguage::first();
-        $this->assertEquals(1, $lang->user->id);
-    }
-}
+    expect($l->labels->count())->toEqual(5);
+    $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+        [
+            'concept_id' => 1,
+            'label' => 'Site',
+        ],
+        [
+            'concept_id' => 2,
+            'label' => 'Feature',
+        ],
+        [
+            'concept_id' => 3,
+            'label' => 'Find',
+        ],
+        [
+            'concept_id' => 9,
+            'label' => 'Pottery',
+        ],
+        [
+            'concept_id' => 10,
+            'label' => 'Stone',
+        ],
+    ], $l->labels->toArray(),
+    ['concept_id', 'label']);
+});
+
+test('get language lasteditor', function () {
+    $lang = ThLanguage::first();
+    expect($lang->user->id)->toEqual(1);
+});

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,19 +1,5 @@
 <?php
 
-namespace Tests\Unit;
-
-use Tests\TestCase;
-
-
-class UserTest extends TestCase
-{
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
-    public function testExample()
-    {
-        $this->assertTrue(true);
-    }
-}
+test('example', function () {
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
- Used auto-migration to move unit tests to the PEST framework and fixed errors not handled by auto-migration
- Added PEST v4 browser testing functionality
  - PHP version requirements changed to: 8.3 and 8.4,because PEST browser testing requires PHP 8.3 (8.2 should still work but is no longer covered by tests)
  - Added basic test case for site access
  - Added test case for login page
  