### PR TITLE
[0.12] Allow multi move using the multi select capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Plugin-System now supports PluginScopes
 - .env variable `ALLOW_FILESYSTEM_MIGRATIONS` to explcitly enable filesystem migrations
 - API endpoint for getting all entity details data in one request: GET::v1/entity/{id}/entity_detail
+- Multi move in entity tree: Select multi edit mode, select multiple entities in the tree and then right click 'move' to move all selected entities at once
 ### Fixed
 - Removed redundant calls to the entity endpoint
 - Metadata tab error on submit (unknown variable)

--- a/app/Entity.php
+++ b/app/Entity.php
@@ -322,7 +322,7 @@ class Entity extends Model implements Searchable {
         DB::commit();
     }
 
-    public static function getNextRank($parent_id = null){
+    public static function getNextRank($parent_id = null) {
         $rank=0;
         if(isset($parent_id)) {
             $rank = Entity::where('root_entity_id', $parent_id)->max('rank');

--- a/app/Entity.php
+++ b/app/Entity.php
@@ -322,6 +322,16 @@ class Entity extends Model implements Searchable {
         DB::commit();
     }
 
+    public static function getNextRank($parent_id = null){
+        $rank=0;
+        if(isset($parent_id)) {
+            $rank = Entity::where('root_entity_id', $parent_id)->max('rank');
+        } else {
+            $rank = Entity::whereNull('root_entity_id')->max('rank');
+        }
+        return $rank + 1;
+    }
+
     public function child_entities() {
         return $this->hasMany('App\Entity', 'root_entity_id')->orderBy('id');
     }

--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -1115,7 +1115,7 @@ class EntityController extends Controller {
         ]);
 
         $entity;
-        try{
+        try {
             $entity = Entity::findOrFail($id);
         } catch(ModelNotFoundException $e) {
             return response()->json([
@@ -1126,7 +1126,7 @@ class EntityController extends Controller {
         $rank = $request->get('rank') ?? null;
         $parent_id = $request->get('parent_id') ?? null;
 
-        try{
+        try {
             $entity->move($parent_id, $rank, $user);
         } catch(Exception $e) {
             return response()->json([
@@ -1152,8 +1152,8 @@ class EntityController extends Controller {
         $entityIds = $request->get('entity_ids');
         $parentId = $request->get('parent_id');
 
-        foreach($entityIds as $id){
-            if($id == $parentId){
+        foreach($entityIds as $id) {
+            if($id == $parentId) {
                 return response()->json([
                     'error' => __('An entity cannot be its own parent'),
                 ], 400);

--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -1137,6 +1137,66 @@ class EntityController extends Controller {
         return response()->json(null, 204);
     }
 
+    public function moveEntities(Request $request) {
+        $user = auth()->user();
+        if(!$user->can('entity_write')) {
+            return response()->json([
+                'error' => __('You do not have the permission to modify an entity'),
+            ], 403);
+        }
+        $this->validate($request, [
+            'entity_ids' => 'required|array',
+            'parent_id' => 'nullable|integer|exists:entities,id',
+        ]);
+
+        $entityIds = $request->get('entity_ids');
+        $parentId = $request->get('parent_id');
+
+        foreach($entityIds as $id){
+            if($id == $parentId){
+                return response()->json([
+                    'error' => __('An entity cannot be its own parent'),
+                ], 400);
+            }
+        }
+
+        $parent = null;
+        if(isset($parentId)) {
+            $parent = Entity::find($parentId);
+            if(!isset($parent)) {
+                return response()->json([
+                    'error' => __('The parent entity does not exist'),
+                ], 400);
+            }
+        }
+
+        $startRank = Entity::getNextRank($parentId);
+        $modified = [];
+        DB::beginTransaction();
+        try {
+            for($i = 0; $i < count($entityIds); $i++) {
+                $entity = Entity::findOrFail($entityIds[$i]);
+                $entity->move($parentId, $startRank, $user);
+                $startRank++;
+
+                $modified[] = array(
+                    "entity_id" => $entity->id,
+                    "parent_id" => $entity->root_entity_id,
+                    "rank" => $entity->rank,
+                );
+            }
+        } catch(Exception $e) {
+            DB::rollBack();
+            info("Error while moving Entities:\n$e");
+            return response()->json([
+                'error' => __('An error occurred while moving the entities'),
+            ], 500);
+        }
+
+        DB::commit();
+        return response()->json($modified, 200);
+    }
+
     // DELETE
 
     public function deleteEntity($id) {

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -66,7 +66,7 @@ export async function fetchEntityMetadata(id) {
 }
 
 export async function fetchUser() {
-    return await $httpQueue.add(() => http.get('/auth/user').then(response => response.data));
+    return await $httpQueue.add(() => http.get('/auth/user').then(response => { return response.data.data; }));
 }
 
 export async function fetchAttributes() {
@@ -594,6 +594,14 @@ export async function moveEntity(entityId, {
     return $httpQueue.add(
         () => http.patch(`/entity/${entityId}/rank`, data).then(response => response.data)
     );
+}
+
+export async function moveMultipleEntities(entityIds, parentId) {
+    const data = {
+        parent_id: parentId,
+        entity_ids: entityIds,
+    };
+    return $httpQueue.add(() => http.post(`/entity/moveMultiple`, data));
 }
 
 export async function patchEntityType(etid, updatedProps) {

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -601,7 +601,7 @@ export async function moveMultipleEntities(entityIds, parentId) {
         parent_id: parentId,
         entity_ids: entityIds,
     };
-    return $httpQueue.add(() => http.post(`/entity/moveMultiple`, data));
+    return $httpQueue.add(() => http.patch(`/entity/move`, data));
 }
 
 export async function patchEntityType(etid, updatedProps) {

--- a/resources/js/bootstrap/stores/entity.js
+++ b/resources/js/bootstrap/stores/entity.js
@@ -42,6 +42,7 @@ import {
     getEntityParentMetadata,
     handleModeration,
     moveEntity,
+    moveMultipleEntities,
     patchEntityType,
     patchAttribute as apiPatchAttribute,
     patchAttributes as apiPatchAttributes,
@@ -390,6 +391,12 @@ export const useEntityStore = defineStore('entity', {
                 to_end: to_end,
             });
             this.processEntityMove(entityId, parentId, rank, to_end);
+        },
+        async moveMultiple(entityIds, parentId) {
+            await moveMultipleEntities(entityIds, parentId);
+            for(const entityId of entityIds) {
+                this.processEntityMove(entityId, parentId, 0, true);
+            }
         },
         processEntityMove(entityId, parentId, rank, to_end) {
             const entity = this.getEntity(entityId);

--- a/resources/js/components/modals/entity/Move.vue
+++ b/resources/js/components/modals/entity/Move.vue
@@ -27,6 +27,20 @@
                     role="form"
                     @submit.prevent="move()"
                 >
+
+                    <div
+                        v-if="isMoveModeMulti"
+                        class="alert alert-warning"
+                    >
+                        {{ t('main.entity.tree.multiedit.warning') }}
+                    </div>
+
+                    <Alert
+                        v-if="invalidSelection"
+                        type="error"
+                        :message="t('main.entity.tree.move.invalid_selection')"
+                    />
+
                     <div
                         v-if="state.hasParent"
                         class="form-check form-switch"
@@ -101,12 +115,19 @@
     import {
         isAllowedSubEntityType,
     } from '@/helpers/helpers.js';
-    
+
     import {
         isPaginated,
     } from '@/helpers/pagination.js';
 
+    import useEntityStore from '../../../bootstrap/stores/entity';
+
+    import Alert from '@/components/Alert.vue';
+
     export default {
+        components: {
+            Alert,
+        },
         props: {
             entity: {
                 required: true,
@@ -120,6 +141,8 @@
                 entity,
             } = toRefs(props);
 
+            const entityStore = useEntityStore();
+
             // FUNCTIONS
             const entitySelected = entity => {
                 state.parent = entity;
@@ -128,22 +151,70 @@
                 if(isPaginated(results)) {
                     results = results.data;
                 }
-                return results.filter(r => {
-                    const onSame = r.id == entity.value.root_entity_id ||
-                        r.id == entity.value.id;
-                    if(onSame) return false;
-                    return isAllowedSubEntityType(r.entity_type_id, entity.value.entity_type_id);
-                });
+
+                if(isMoveModeMulti.value) {
+                    return filterForMultiMove(results);
+                } else {
+                    return results.filter(r => {
+                        const onSame = r.id == entity.value.root_entity_id ||
+                            r.id == entity.value.id;
+                        if(onSame) return false;
+                        return isAllowedSubEntityType(r.entity_type_id, entity.value.entity_type_id);
+                    });
+                }
             };
+
+            const filterForMultiMove = (results) => {
+                if(invalidSelection.value) {
+                    return [];
+                } else {
+                    // As we reqire the same entity type, we can just take the first one
+                    const entity = Object.values(entityStore.treeSelection)[0];
+                    const entities = Object.keys(entityStore.treeSelection).map(id => parseInt(id));
+                    const entityTypeId = entity.entity_type_id;
+
+                    return results.filter(result => {
+                        const onSameEntity = entities.includes(parseInt(result.id));
+                        if(onSameEntity) return false;
+                        return isAllowedSubEntityType(result.entity_type_id, entityTypeId);
+                    });
+                }
+            }
+
             const move = _ => {
                 if(state.dataMissing) {
                     return;
                 }
-                context.emit('confirm', state.moveToRoot ? null : state.parent.id);
+
+                let targets = isMoveModeMulti.value ? Object.keys(entityStore.treeSelection).map(id => parseInt(id)) : [];
+                context.emit('confirm', state.moveToRoot ? null : state.parent.id, targets);
             };
             const closeModal = _ => {
                 context.emit('cancel', false);
             };
+
+            const isMoveModeMulti = computed(() => {
+                return Object.keys(entityStore.treeSelection).length > 1;
+            });
+
+            // We only allow moving entities of the same type
+            const invalidSelection = computed(() => {
+                if(isMoveModeMulti.value) {
+                    let type = null;
+                    const selection = entityStore.treeSelection;
+                    for(let index in selection) {
+                        const item = selection[index];
+                        const entityTypeId = item?.entity_type_id;
+                        if(type == null) {
+                            type = entityTypeId;
+                        } else if(type !== entityTypeId) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                } else return false;
+            });
 
             // DATA
             const state = reactive({
@@ -161,6 +232,8 @@
                 // HELPERS
                 searchEntity,
                 // LOCAL
+                invalidSelection,
+                isMoveModeMulti,
                 entitySelected,
                 filterEntityResults,
                 move,

--- a/resources/js/components/modals/entity/Move.vue
+++ b/resources/js/components/modals/entity/Move.vue
@@ -8,7 +8,7 @@
             <div class="modal-header">
                 <h5 class="modal-title">
                     {{ t('main.entity.modals.move.title') }}
-                    <small>
+                    <small v-if="!isMoveModeMulti">
                         {{ entity.name }}
                     </small>
                 </h5>
@@ -27,7 +27,6 @@
                     role="form"
                     @submit.prevent="move()"
                 >
-
                     <div
                         v-if="isMoveModeMulti"
                         class="alert alert-warning"
@@ -108,6 +107,8 @@
     } from 'vue';
     import { useI18n } from 'vue-i18n';
 
+    import useEntityStore from '@/bootstrap/stores/entity.js';
+
     import {
         searchEntity,
     } from '@/api.js';
@@ -119,8 +120,6 @@
     import {
         isPaginated,
     } from '@/helpers/pagination.js';
-
-    import useEntityStore from '../../../bootstrap/stores/entity';
 
     import Alert from '@/components/Alert.vue';
 
@@ -164,11 +163,11 @@
                 }
             };
 
-            const filterForMultiMove = (results) => {
+            const filterForMultiMove = results => {
                 if(invalidSelection.value) {
                     return [];
                 } else {
-                    // As we reqire the same entity type, we can just take the first one
+                    // As we require the same entity type, we can just take the first one
                     const entity = Object.values(entityStore.treeSelection)[0];
                     const entities = Object.keys(entityStore.treeSelection).map(id => parseInt(id));
                     const entityTypeId = entity.entity_type_id;
@@ -179,7 +178,7 @@
                         return isAllowedSubEntityType(result.entity_type_id, entityTypeId);
                     });
                 }
-            }
+            };
 
             const move = _ => {
                 if(state.dataMissing) {
@@ -189,6 +188,7 @@
                 let targets = isMoveModeMulti.value ? Object.keys(entityStore.treeSelection).map(id => parseInt(id)) : [];
                 context.emit('confirm', state.moveToRoot ? null : state.parent.id, targets);
             };
+
             const closeModal = _ => {
                 context.emit('cancel', false);
             };
@@ -213,7 +213,9 @@
                     }
 
                     return false;
-                } else return false;
+                } else {
+                    return false;
+                }
             });
 
             // DATA

--- a/resources/js/components/tree/Node.vue
+++ b/resources/js/components/tree/Node.vue
@@ -5,7 +5,10 @@
         @dragleave="onDragLeave"
         @click="e => addToMSList(e)"
     >
-        <div class="d-flex">
+        <div
+            class="d-flex"
+            :class="{ 'opacity-50': state.isSelectionDisabled }"
+        >
             <span
                 v-if="state.isSelectionMode"
                 class="mx-1"
@@ -16,13 +19,8 @@
                 >
                     <i class="fas fa-fw fa-circle-check" />
                 </span>
-                <span
-                    v-show="!state.multieditSelected"
-                    :class="{'opacity-50': state.isSelectionDisabled}"
-                >
-                    <i
-                        class="far fa-fw fa-circle"
-                    />
+                <span v-show="!state.multieditSelected">
+                    <i class="far fa-fw fa-circle" />
                 </span>
             </span>
             <a
@@ -167,15 +165,11 @@
                 disabledMenuEntries: computed(_ => {
                     const options = {};
                     const entityIds = Object.keys(entityStore.treeSelection).map(id => parseInt(id));
-                    // Disable move option if:
-                    // 1. currently clicked node is not is selection
-                    // OR
-                    // 2. more than one entity type is selected
-                    if(
-                        (entityIds.length > 0 && !entityIds.includes(data.value.id))
-                        ||
-                        entityStore.treeSelectionTypeIds.length > 1
-                    ) {
+
+                    const clickedNodeNotInSelection = (entityIds.length > 0 && !entityIds.includes(data.value.id))
+                    const multipleEntityTypesSelected = entityStore.treeSelectionTypeIds.length > 1;
+
+                    if(clickedNodeNotInSelection || multipleEntityTypesSelected) {
                         options.move = true;
                     }
                     return options;

--- a/resources/js/components/tree/Node.vue
+++ b/resources/js/components/tree/Node.vue
@@ -16,8 +16,13 @@
                 >
                     <i class="fas fa-fw fa-circle-check" />
                 </span>
-                <span v-show="!state.multieditSelected">
-                    <i class="far fa-fw fa-circle" />
+                <span
+                    v-show="!state.multieditSelected"
+                    :class="{'opacity-50': state.isSelectionDisabled}"
+                >
+                    <i
+                        class="far fa-fw fa-circle"
+                    />
                 </span>
             </span>
             <a
@@ -57,6 +62,7 @@
         <TreeMenu
             v-if="state.ddVisible"
             :data="data"
+            :disabled-options="state.disabledMenuEntries"
             @close="hidePopup()"
         />
     </div>
@@ -128,6 +134,9 @@
 
                 event.stopPropagation();
                 event.preventDefault();
+
+                if(state.isSelectionDisabled) return;
+
                 state.multieditSelected = !state.multieditSelected;
                 if(state.multieditSelected) {
                     entityStore.addToTreeSelection({
@@ -154,6 +163,22 @@
                         return false;
                     }
                     return !entityStore.hasIntersectionWithEntityAttributes(data.value.entity_type_id, entityStore.treeSelectionTypeIds);
+                }),
+                disabledMenuEntries: computed(_ => {
+                    const options = {};
+                    const entityIds = Object.keys(entityStore.treeSelection).map(id => parseInt(id));
+                    // Disable move option if:
+                    // 1. currently clicked node is not is selection
+                    // OR
+                    // 2. more than one entity type is selected
+                    if(
+                        (entityIds.length > 0 && !entityIds.includes(data.value.id))
+                        ||
+                        entityStore.treeSelectionTypeIds.length > 1
+                    ) {
+                        options.move = true;
+                    }
+                    return options;
                 }),
             });
 

--- a/resources/js/components/tree/TreeMenu.vue
+++ b/resources/js/components/tree/TreeMenu.vue
@@ -12,6 +12,7 @@
         <li>
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.add}"
                 href="#"
                 @click.stop.prevent="addEntity"
                 @dblclick.stop.prevent=""
@@ -25,6 +26,7 @@
         <li>
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.add}"
                 href="#"
                 @click.stop.prevent="addEntity('above')"
                 @dblclick.stop.prevent=""
@@ -38,6 +40,7 @@
         <li>
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.add}"
                 href="#"
                 @click.stop.prevent="addEntity('below')"
                 @dblclick.stop.prevent=""
@@ -51,6 +54,7 @@
         <li>
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.duplicate}"
                 href="#"
                 @click.stop.prevent="duplicateEntity"
                 @dblclick.stop.prevent=""
@@ -64,6 +68,7 @@
         <li>
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.move}"
                 href="#"
                 @click.stop.prevent="moveEntity"
                 @dblclick.stop.prevent=""
@@ -77,6 +82,7 @@
         <li v-if="can('entity_share')">
             <a
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.export}"
                 href="#"
                 @click.stop.prevent="exportWithChildren"
                 @dblclick.stop.prevent=""
@@ -91,6 +97,7 @@
             <a
                 v-if="can('entity_delete')"
                 class="dropdown-item"
+                :class="{'disabled': disabledOptions?.delete}"
                 href="#"
                 @click.stop.prevent="deleteEntity"
                 @dblclick.stop.prevent=""
@@ -137,6 +144,10 @@
             data: {
                 type: Object,
                 required: true
+            },
+            disabledOptions: {
+                type: Object,
+                required: false,
             }
         },
         emits: [
@@ -151,6 +162,7 @@
             });
 
             const addEntity = where => {
+                if(props.disabledOptions?.add) return;
                 if(where == 'above') {
                     const parent = entityStore.getEntity(props.data.root_entity_id);
                     showAddEntity(parent, null, props.data.rank);
@@ -162,24 +174,28 @@
                 }
             };
             const duplicateEntity = _ => {
+                if(props.disabledOptions?.duplicate) return;
                 duplicateEntityApi(props.data).then(data => {
                     entityStore.add(data);
                     context.emit('close');
                 });
             };
             const moveEntity = _ => {
+                if(props.disabledOptions?.move) return;
                 ShowMoveEntity(props.data);
                 context.emit('close');
             };
 
             const deleteEntity = _ => {
                 if(!can('entity_delete')) return;
+                if(props.disabledOptions?.delete) return;
                 showDeleteEntity(props.data.id);
                 context.emit('close');
             };
 
             const exportWithChildren = async _ => {
                 if(!can('entity_share')) return;
+                if(props.disabledOptions?.export) return;
                 try{
                     const exported = await exportEntityTreeApi(props.data.id);
                     console.log(exported);

--- a/resources/js/helpers/modal.js
+++ b/resources/js/helpers/modal.js
@@ -571,13 +571,25 @@ export function ShowMoveEntity(entity, onMoved) {
             onCancel(e) {
                 modal.destroy();
             },
-            onConfirm(parentId) {
-                useEntityStore().move(entity.id, parentId).then(data => {
-                    if(!!onMoved) {
-                        onMoved(entity.id, parentId, data);
-                    }
-                    modal.destroy();
-                });
+            onConfirm(parentId, entity_ids) {
+                if(entity_ids && entity_ids.length > 0) {
+                    useEntityStore().moveMultiple(entity_ids, parentId).then(data => {
+                        if(!!onMoved) {
+                            entity_ids.forEach(entity_id => {
+                                onMoved(entity_id, parentId, data);
+                            });
+                        }
+                        useEntityStore().setTreeSelectionMode(false);
+                        modal.destroy();
+                    });
+                } else {
+                    useEntityStore().move(entity.id, parentId).then(data => {
+                        if(!!onMoved) {
+                            onMoved(entity.id, parentId, data);
+                        }
+                        modal.destroy();
+                    });
+                }
             },
         },
     });

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -532,6 +532,7 @@
                 "multiedit": {
                     "title": "Mehrfachauswahl umschalten",
                     "open": "Mehrfach-Bearbeitungs-Werkzeug öffnen",
+                    "warning": "Diese Aktion wird alle ausgewählten Entitäten betreffen.", 
                     "toast": {
                         "saved": {
                             "title": "Mehrfach-Bearbeitung erfolgreich",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -532,6 +532,7 @@
                 "multiedit": {
                     "title": "Toggle Multiedit",
                     "open": "Open Multiedit Tool",
+                    "warning": "This operation will edit all selected entities at once!",
                     "toast": {
                         "saved": {
                             "title": "Multiedit successful",

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,7 +78,7 @@ Route::middleware('auth:sanctum')->prefix('v1/entity')->group(function() {
     Route::patch('/{id}/name', 'EntityController@patchName')->where('id', '[0-9]+');
     Route::patch('/{id}/metadata', 'EntityController@patchMetadata')->where('id', '[0-9]+');
     Route::patch('/{id}/rank', 'EntityController@moveEntity')->where('id', '[0-9]+');
-    Route::post('/moveMultiple', 'EntityController@moveEntities');
+    Route::patch('/move', 'EntityController@moveEntities');
     Route::patch('/reference/{id}', 'ReferenceController@patchReference')->where('id', '[0-9]+');
 
     Route::delete('/{id}', 'EntityController@deleteEntity')->where('id', '[0-9]+');

--- a/routes/api.php
+++ b/routes/api.php
@@ -78,6 +78,7 @@ Route::middleware('auth:sanctum')->prefix('v1/entity')->group(function() {
     Route::patch('/{id}/name', 'EntityController@patchName')->where('id', '[0-9]+');
     Route::patch('/{id}/metadata', 'EntityController@patchMetadata')->where('id', '[0-9]+');
     Route::patch('/{id}/rank', 'EntityController@moveEntity')->where('id', '[0-9]+');
+    Route::post('/moveMultiple', 'EntityController@moveEntities');
     Route::patch('/reference/{id}', 'ReferenceController@patchReference')->where('id', '[0-9]+');
 
     Route::delete('/{id}', 'EntityController@deleteEntity')->where('id', '[0-9]+');


### PR DESCRIPTION
updated version #506

Allows to move multiple entities with the 'Right-click -> Move' functionality when in the existing 'Multi-edit-selection' mode. 
I consider this very useful and would not want to scrap it. 