### PR TITLE
[0.12] feature auto columns preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Now entity metadata is only loaded when accessing the metadata tab
 - Migrations now have logging automatically disabled
 - Migrations that require filesystem changes can now be handled using the `App\Traits\FilesystemMigration` trait (call `$this->safelyMoveDirectoryBetweenDisks(...)` with `ALLOW_FILESYTEM_MIGRATIONS` set to `true`)
+- Column values in preferences are automatically recalculated to values that sum up to 12
 
 ## 0.11.1
 ### Added

--- a/resources/js/components/Preferences.vue
+++ b/resources/js/components/Preferences.vue
@@ -52,6 +52,7 @@
                 <button
                     type="button"
                     class="btn btn-outline-success btn-sm"
+                    :disabled="!state.hasDirtyData"
                     @click="savePreferences()"
                 >
                     <i class="fas fa-fw fa-save" />
@@ -130,6 +131,7 @@
     import ThesaurusLink from '@/components/preferences/ThesaurusLink.vue';
     import ProjectName from '@/components/preferences/ProjectName.vue';
     import ProjectMaintainer from '@/components/preferences/ProjectMaintainer.vue';
+    import { scalePropotionallyInteger } from '../helpers/math';
 
     export default {
         components: {
@@ -202,15 +204,25 @@
                     updatedLanguage = state.dirtyData.user['prefs.gui-language'].value;
                 }
                 const changes = [];
-                for(let k in state.dirtyData.user) {
-                    const curr = state.dirtyData.user[k];
-                    curr.user = true;
-                    changes.push(curr);
-                }
-                for(let k in state.dirtyData.system) {
-                    const curr = state.dirtyData.system[k];
-                    changes.push(curr);
-                }
+
+                ['user', 'system'].forEach(category => {
+                    for(let prefLabel in state.dirtyData[category]) {
+                        const curr = state.dirtyData[category][prefLabel];
+
+                        let preference = getPreferenceCategory(category);
+
+                        // Execute onSave hook if exists
+                        const config = findPreferenceConfig(category, prefLabel);
+                        if(config?.hooks?.onSave) {
+                            curr.value = config.hooks.onSave(curr.value);
+                        }
+                        preference[prefLabel] = curr.value;
+
+                        curr.user = category === 'user';
+                        changes.push(curr);
+                    }
+                });
+
                 const data = {
                     changes: changes,
                 };
@@ -228,6 +240,30 @@
                         simple: true,
                     });
                 });
+            };
+
+            const getPreferenceCategory = (category) => {
+                if(category == 'system') {
+                    return state.systemPreferences;
+                } else {
+                    return state.userPreferences;
+                }
+            };
+
+            const findPreferenceConfig = (category, label) => {
+                const categoryConfig = preferencesConfig[category];
+                const configMap = {};
+                for(let subcatKey in categoryConfig) {
+                    const subcat = categoryConfig[subcatKey];
+                    subcat.preferences.forEach(pref => {
+                        configMap[pref.label] = pref;
+                    });
+                }
+                if(configMap[label]) {
+                    return configMap[label];
+                }
+
+                return null;
             };
 
             const setProgramPreferences = (categories, name) => {
@@ -283,6 +319,14 @@
                                 title: 'main.preference.key.columns.title',
                                 label: 'prefs.columns',
                                 component: 'columns-preference',
+                                data: 'v-model',
+                                hooks: {
+                                    onSave(value) {                                        
+                                        const values = ['left', 'center', 'right'].map(key => value[key]);
+                                        const twelveBased = scalePropotionallyInteger(values, 12);
+                                        return { left: twelveBased[0], center: twelveBased[1], right: twelveBased[2] };
+                                    }
+                                }
                             },
                             {
                                 title: 'main.preference.key.tooltips',

--- a/resources/js/components/preferences/Columns.vue
+++ b/resources/js/components/preferences/Columns.vue
@@ -1,89 +1,37 @@
 <template>
-    <div class="row mb-3">
-        <label
-            for="left-column"
-            class="col-md-2 col-form-label text-end"
-        >{{ t('main.preference.key.columns.left') }}:</label>
-        <div class="col-md">
+    <div class="column-preferences input-group flex-no-wrap">
+        <template
+            v-for="{ id, label } in sections"
+            :key="id"
+        >
+            <span
+                id="addon-wrapping"
+                class="input-group-text"
+            >{{ t(label) }}</span>
             <input
-                id="left-column"
-                v-model.number="data.left"
+                :id="id"
+                :value="modelValue[id]"
                 class="form-control"
                 type="number"
                 :disabled="readonly"
                 min="0"
-                :max="state.maxLeft"
+                style="min-width:3rem;"
                 :readonly="readonly"
-                @input="onChange"
+                @input="(event) => onChange(event, id)"
             >
-        </div>
-    </div>
-    <div class="row mb-3">
-        <label
-            for="center-column"
-            class="col-md-2 col-form-label text-end"
-        >{{ t('main.preference.key.columns.center') }}:</label>
-        <div class="col-md">
-            <input
-                id="center-column"
-                v-model.number="data.center"
-                class="form-control"
-                type="number"
-                :disabled="readonly"
-                min="0"
-                :max="state.maxCenter"
-                :readonly="readonly"
-                @input="onChange"
-            >
-        </div>
-    </div>
-    <div class="row mb-3">
-        <label
-            for="right-column"
-            class="col-md-2 col-form-label text-end"
-        >{{ t('main.preference.key.columns.right') }}:</label>
-        <div class="col-md">
-            <input
-                id="right-column"
-                v-model.number="data.right"
-                class="form-control"
-                type="number"
-                :disabled="readonly"
-                min="0"
-                :max="state.maxRight"
-                :readonly="readonly"
-                @input="onChange"
-            >
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-10 offset-md-2">
-            <div
-                class="alert bg-info mb-0 w-50"
-                role="alert"
-            >
-                {{ t('main.preference.info.columns') }}
-            </div>
-        </div>
+        </template>
     </div>
 </template>
 
 <script>
-    import {
-        computed,
-        reactive,
-        toRefs,
-    } from 'vue';
-
     import { useI18n } from 'vue-i18n';
 
-    import {
-        _debounce
-    } from '@/helpers/helpers.js';
-    
     export default {
         props: {
-            data: {
+            /**
+            * The column data object with keys 'left', 'center' and 'right'
+            */
+            modelValue: {
                 required: true,
                 type: Object,
             },
@@ -93,30 +41,24 @@
                 default: false,
             },
         },
-        emits: ['changed'],
+        emits: ['changed', 'update:modelValue'],
         setup(props, context) {
             const { t } = useI18n();
-            const {
-                data,
-                readonly,
-            } = toRefs(props);
+
+            const sections = [
+                { id: 'left', label: t('main.preference.key.columns.left') },
+                { id: 'center', label: t('main.preference.key.columns.center') },
+                { id: 'right', label: t('main.preference.key.columns.right') },
+            ];
 
             // FUNCTIONS
-            const onChange = _debounce(e => {
-                if(readonly.value) return;
-                context.emit('changed', {
-                    left: data.value['left'],
-                    center: data.value['center'],
-                    right: data.value['right'],
-                });
-            }, 250);
-
-            // DATA
-            const state = reactive({
-                maxLeft: computed(_ => 12 - data.value['center'] - data.value['right']),
-                maxCenter: computed(_ => 12 - data.value['left'] - data.value['right']),
-                maxRight: computed(_ => 12 - data.value['left'] - data.value['center']),
-            });
+            const onChange = (event, column) => {
+                if(props.readonly) return;
+                let value = { ...props.modelValue }
+                value[column] = parseInt(event.target.value) || 0;
+                context.emit('update:modelValue', value);
+                context.emit('changed', value);
+            }
 
             // RETURN
             return {
@@ -124,8 +66,8 @@
                 // LOCAL
                 onChange,
                 // STATE
-                state,
+                sections,
             };
         }
-    }
+    };
 </script>

--- a/resources/js/components/preferences/Columns.vue
+++ b/resources/js/components/preferences/Columns.vue
@@ -46,9 +46,9 @@
             const { t } = useI18n();
 
             const sections = [
-                { id: 'left', label: t('main.preference.key.columns.left') },
-                { id: 'center', label: t('main.preference.key.columns.center') },
-                { id: 'right', label: t('main.preference.key.columns.right') },
+                { id: 'left', label: t('global.positions.left') },
+                { id: 'center', label: t('global.positions.center') },
+                { id: 'right', label: t('global.positions.right') },
             ];
 
             // FUNCTIONS

--- a/resources/js/helpers/math.js
+++ b/resources/js/helpers/math.js
@@ -6,3 +6,42 @@ export function mod(a, b, allowNegative = false) {
         return ((a % b) + b) % b;
     }
 }
+
+
+/**
+ * Takes an array of positive numbers and a target number, and adjusts the numbers in the array to integer values
+ * so that their sum matches the target number, while staying close to their relative proportions.
+ * 
+ * @param {array} numbers 
+ * @param {number} target 
+ * @returns 
+ */
+export function scalePropotionallyInteger(array, target) {
+    if(array.length === 0) {
+        return array;
+    }
+
+    // We clone the array to avoid mutating the original one
+    const output = array.slice();
+    const total = array.reduce((acc, val) => acc + val, 0);
+
+    // If only 0 values are set, set all to 1
+    // to avoid division by 0.
+    if(total === 0) {
+        output.map(() => 1);
+    }
+
+    let last = null;
+    let remainder = target;
+    for(let [index, number] of output.entries()) {
+        output[index] = Math.round(number / total * target);
+        remainder -= output[index];
+        last = index;
+    }
+
+    if(last) {
+        output[output.length-1] += remainder;
+    }
+
+    return output;
+}

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -29,6 +29,11 @@
         "file": "Datei",
         "remove_file": "Datei entfernen",
         "no_file": "Keine Datei vorhanden",
+        "positions": {
+            "center": "Mitte",
+            "left": "Links",
+            "right": "Rechts"
+        },
         "list": {
             "and_more": "und weitere | und {cnt} weitere",
             "nr_of_entries": "Keine Einträge | 1 Eintrag | {cnt} Einträge",
@@ -831,10 +836,7 @@
                     }
                 },
                 "columns": {
-                    "title": "Spalten Hauptansicht",
-                    "left": "Linke Spalte",
-                    "center": "Mittlere Spalte",
-                    "right": "Rechte Spalte"
+                    "title": "Spalten Hauptansicht"
                 },
                 "tooltips": "Infos anzeigen",
                 "tag_root": "Thesaurus-URI für Schlagworte",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -14,7 +14,7 @@
         "edit": "Edit",
         "edited": "edited",
         "duplicate": "Duplicate",
-        "export":"Export",
+        "export": "Export",
         "sort": "Sort",
         "resort": "Re-sort",
         "update": "Update",
@@ -29,6 +29,11 @@
         "file": "File",
         "remove_file": "Remove file",
         "no_file": "No file",
+        "positions": {
+            "center": "Center",
+            "left": "Left",
+            "right": "Right"
+        },
         "list": {
             "and_more": "and more | and {cnt} more",
             "nr_of_entries": "No Entries | 1 Entry | {cnt} Entries",
@@ -831,10 +836,7 @@
                     }
                 },
                 "columns": {
-                    "title": "Columns in Main View",
-                    "left": "Left Column",
-                    "center": "Center Column",
-                    "right": "Right Column"
+                    "title": "Columns in Main View"
                 },
                 "tooltips": "Show Tooltips",
                 "tag_root": "Thesaurus-URI for Tags",


### PR DESCRIPTION
Currently the user must sum columns manually in the preferences and calculate the number to 12 always in their head, requiring a big explanation text, why he has to do so. 

I implemented this feature in an old branch and think it's worth implementing (until columns can be resized freely).
![auto-calculate-columns](https://github.com/user-attachments/assets/4ab2626e-c232-4356-a638-f31bdf5f7cf2)
